### PR TITLE
Entity Object Key 

### DIFF
--- a/src/Deveel.Repository.Core/Data/IRepository_T.cs
+++ b/src/Deveel.Repository.Core/Data/IRepository_T.cs
@@ -28,11 +28,11 @@ namespace Deveel.Data {
 		/// The instance of the entity to get the identifier of
 		/// </param>
 		/// <returns>
-		/// Returns a string that is the unique identifier of the entity
+		/// Returns an object that is the unique identifier of the entity
 		/// within the repository, or <c>null</c> if the entity is not
 		/// identified.
 		/// </returns>
-		string? GetEntityId(TEntity entity);
+		object? GetEntityKey(TEntity entity);
 
         /// <summary>
         /// Adds a new entity into the repository
@@ -40,7 +40,7 @@ namespace Deveel.Data {
         /// <param name="entity">The entity to be added</param>
         /// <param name="cancellationToken"></param>
         /// <returns>
-        /// Returns the unique identifier of the entity added.
+		/// Returns a task that will complete when the operation is completed
         /// </returns>
         /// <exception cref="RepositoryException">
         /// Thrown if it an error occurred while adding the entity
@@ -48,7 +48,7 @@ namespace Deveel.Data {
         /// <exception cref="ArgumentNullException">
         /// Thrown if the provided <paramref name="entity"/> is <c>null</c>
         /// </exception>
-        Task<string> AddAsync(TEntity entity, CancellationToken cancellationToken = default);
+        Task AddAsync(TEntity entity, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Adds a list of entities in the repository in one single operation
@@ -64,7 +64,7 @@ namespace Deveel.Data {
 		/// </para>
 		/// </remarks>
 		/// <returns>
-		/// Returns an ordered list of the unique identifiers of the entiies created
+		/// Returns a task that will complete when the operation is completed
 		/// </returns>
 		/// <exception cref="RepositoryException">
 		/// Thrown if it an error occurred while adding one or more entities
@@ -72,7 +72,7 @@ namespace Deveel.Data {
 		/// <exception cref="ArgumentNullException">
 		/// Thrown if the provided list of <paramref name="entities"/> is <c>null</c>
 		/// </exception>
-		Task<IList<string>> AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
+		Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
 
 
         /// <summary>
@@ -131,12 +131,15 @@ namespace Deveel.Data {
         /// Attempts to find in the repository an entity with the 
         /// given unique identifier
         /// </summary>
-        /// <param name="id">The unique identifier of the entity to find</param>
+        /// <param name="key">The unique identifier of the entity to find</param>
         /// <param name="cancellationToken"></param>
         /// <returns>
-        /// Returns the instance of the entity associated to the given <paramref name="id"/>,
+        /// Returns the instance of the entity associated to the given <paramref name="key"/>,
         /// or <c>null</c> if none entity was found.
         /// </returns>
-        Task<TEntity?> FindByIdAsync(string id, CancellationToken cancellationToken = default);
+		/// <exception cref="ArgumentNullException">
+		/// Thrown if the provided <paramref name="key"/> is <c>null</c>
+		/// </exception>
+        Task<TEntity?> FindByKeyAsync(object key, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Deveel.Repository.Core/Data/RepositoryExtensions.cs
+++ b/src/Deveel.Repository.Core/Data/RepositoryExtensions.cs
@@ -105,7 +105,7 @@ namespace Deveel.Data {
 		/// Returns a string that uniquely identifies the created entity
 		/// within the underlying storage.
 		/// </returns>
-		public static string Add<TEntity>(this IRepository<TEntity> repository, TEntity entity)
+		public static void Add<TEntity>(this IRepository<TEntity> repository, TEntity entity)
             where TEntity : class
             => repository.AddAsync(entity).ConfigureAwait(false).GetAwaiter().GetResult();
 
@@ -144,8 +144,8 @@ namespace Deveel.Data {
 		/// <param name="repository">
 		/// The instance of the repository from which the entity is removed
 		/// </param>
-		/// <param name="id">
-		/// The string that uniquely identifies the entity to remove
+		/// <param name="key">
+		/// The key that uniquely identifies the entity to remove
 		/// </param>
 		/// <param name="cancellationToken">
 		/// A token used to cancel the operation.
@@ -154,9 +154,9 @@ namespace Deveel.Data {
 		/// Returns <c>true</c> if the entity was removed successfully,
 		/// otherwise it returns <c>false</c>.
 		/// </returns>
-        public static async Task<bool> RemoveByIdAsync<TEntity>(this IRepository<TEntity> repository, string id, CancellationToken cancellationToken = default)
+        public static async Task<bool> RemoveByKeyAsync<TEntity>(this IRepository<TEntity> repository, object key, CancellationToken cancellationToken = default)
             where TEntity : class {
-            var entity = await repository.FindByIdAsync(id, cancellationToken);
+            var entity = await repository.FindByKeyAsync(key, cancellationToken);
             if (entity == null)
                 return false;
 
@@ -173,17 +173,17 @@ namespace Deveel.Data {
 		/// <param name="repository">
 		/// The instance of the repository from which the entity is removed.
 		/// </param>
-		/// <param name="id">
-		/// The string that uniquely identifies the entity to remove.
+		/// <param name="key">
+		/// The key that uniquely identifies the entity to remove.
 		/// </param>
 		/// <returns>
 		/// Returns <c>true</c> if the entity was removed successfully,
 		/// otherwise it returns <c>false</c>.
 		/// </returns>
 		/// <seealso cref="IRepository{TEntity}.RemoveAsync(TEntity, CancellationToken)"/>
-        public static bool RemoveById<TEntity>(this IRepository<TEntity> repository, string id)
+        public static bool RemoveByKey<TEntity>(this IRepository<TEntity> repository, string key)
             where TEntity : class
-            => repository.RemoveByIdAsync(id).ConfigureAwait(false).GetAwaiter().GetResult();
+            => repository.RemoveByKeyAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();
 
         #endregion
 
@@ -476,7 +476,7 @@ namespace Deveel.Data {
 
         public static TEntity? FindById<TEntity>(this IRepository<TEntity> store, string id)
             where TEntity : class
-            => store.FindByIdAsync(id).ConfigureAwait(false).GetAwaiter().GetResult();
+            => store.FindByKeyAsync(id).ConfigureAwait(false).GetAwaiter().GetResult();
 
         #endregion
 

--- a/src/Deveel.Repository.Core/Deveel.Repository.Core.xml
+++ b/src/Deveel.Repository.Core/Deveel.Repository.Core.xml
@@ -597,7 +597,7 @@
             </summary>
             <typeparam name="TEntity">The type of entity handled by the repository</typeparam>
         </member>
-        <member name="M:Deveel.Data.IRepository`1.GetEntityId(`0)">
+        <member name="M:Deveel.Data.IRepository`1.GetEntityKey(`0)">
             <summary>
             Gets the unique identifier of the entity given
             </summary>
@@ -605,7 +605,7 @@
             The instance of the entity to get the identifier of
             </param>
             <returns>
-            Returns a string that is the unique identifier of the entity
+            Returns an object that is the unique identifier of the entity
             within the repository, or <c>null</c> if the entity is not
             identified.
             </returns>
@@ -617,7 +617,7 @@
             <param name="entity">The entity to be added</param>
             <param name="cancellationToken"></param>
             <returns>
-            Returns the unique identifier of the entity added.
+            Returns a task that will complete when the operation is completed
             </returns>
             <exception cref="T:Deveel.Data.RepositoryException">
             Thrown if it an error occurred while adding the entity
@@ -641,7 +641,7 @@
             </para>
             </remarks>
             <returns>
-            Returns an ordered list of the unique identifiers of the entiies created
+            Returns a task that will complete when the operation is completed
             </returns>
             <exception cref="T:Deveel.Data.RepositoryException">
             Thrown if it an error occurred while adding one or more entities
@@ -702,17 +702,20 @@
             Thrown if it an error occurred while removing one or more entities
             </exception>
         </member>
-        <member name="M:Deveel.Data.IRepository`1.FindByIdAsync(System.String,System.Threading.CancellationToken)">
+        <member name="M:Deveel.Data.IRepository`1.FindByKeyAsync(System.Object,System.Threading.CancellationToken)">
             <summary>
             Attempts to find in the repository an entity with the 
             given unique identifier
             </summary>
-            <param name="id">The unique identifier of the entity to find</param>
+            <param name="key">The unique identifier of the entity to find</param>
             <param name="cancellationToken"></param>
             <returns>
-            Returns the instance of the entity associated to the given <paramref name="id"/>,
+            Returns the instance of the entity associated to the given <paramref name="key"/>,
             or <c>null</c> if none entity was found.
             </returns>
+            <exception cref="T:System.ArgumentNullException">
+            Thrown if the provided <paramref name="key"/> is <c>null</c>
+            </exception>
         </member>
         <member name="T:Deveel.Data.IResultSort">
             <summary>
@@ -1297,7 +1300,7 @@
             </returns>
             <seealso cref="M:Deveel.Data.IRepository`1.RemoveAsync(`0,System.Threading.CancellationToken)"/>
         </member>
-        <member name="M:Deveel.Data.RepositoryExtensions.RemoveByIdAsync``1(Deveel.Data.IRepository{``0},System.String,System.Threading.CancellationToken)">
+        <member name="M:Deveel.Data.RepositoryExtensions.RemoveByKeyAsync``1(Deveel.Data.IRepository{``0},System.Object,System.Threading.CancellationToken)">
             <summary>
             Removes an entity, identified by the given key,
             from the repository
@@ -1308,8 +1311,8 @@
             <param name="repository">
             The instance of the repository from which the entity is removed
             </param>
-            <param name="id">
-            The string that uniquely identifies the entity to remove
+            <param name="key">
+            The key that uniquely identifies the entity to remove
             </param>
             <param name="cancellationToken">
             A token used to cancel the operation.
@@ -1319,7 +1322,7 @@
             otherwise it returns <c>false</c>.
             </returns>
         </member>
-        <member name="M:Deveel.Data.RepositoryExtensions.RemoveById``1(Deveel.Data.IRepository{``0},System.String)">
+        <member name="M:Deveel.Data.RepositoryExtensions.RemoveByKey``1(Deveel.Data.IRepository{``0},System.String)">
             <summary>
             Synchronously removes an entity, identified by the given key,
             from the repository
@@ -1330,8 +1333,8 @@
             <param name="repository">
             The instance of the repository from which the entity is removed.
             </param>
-            <param name="id">
-            The string that uniquely identifies the entity to remove.
+            <param name="key">
+            The key that uniquely identifies the entity to remove.
             </param>
             <returns>
             Returns <c>true</c> if the entity was removed successfully,

--- a/src/Deveel.Repository.EntityFramework/Data/LoggerExtensions.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/LoggerExtensions.cs
@@ -18,56 +18,56 @@ using Microsoft.Extensions.Logging;
 
 namespace Deveel.Data {
     static partial class LoggerExtensions {
-        [LoggerMessage(EventId = LogEventIds.UnknownError, Level = LogLevel.Error, 
-            Message = "An unknwon error has occurred while operating on the entity '{EntityType}'")]
+        [LoggerMessage(LogEventIds.UnknownError, LogLevel.Error,
+			"An unknwon error has occurred while operating on the entity '{EntityType}'")]
         public static partial void LogUnknownError(this ILogger logger, Exception error, Type entityType);
 
-        [LoggerMessage(EventId = LogEventIds.CreatingEntity, Level = LogLevel.Trace, 
-                       Message = "Creating a new entity of type '{EntityType}' for tenant '{TenantId}'")]
+        [LoggerMessage(LogEventIds.CreatingEntity, LogLevel.Trace, 
+			"Creating a new entity of type '{EntityType}' for tenant '{TenantId}'")]
         public static partial void TraceCreatingEntity(this ILogger logger, Type entityType, string? tenantId);
 
-        [LoggerMessage(EventId = LogEventIds.UpdatingEntity, Level = LogLevel.Trace, 
-                                  Message = "Updating an entity of type '{EntityType}' (ID={EntityId}) owned by tenant '{TenantId}'")]
-        public static partial void TraceUpdatingEntity(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        [LoggerMessage(LogEventIds.UpdatingEntity, LogLevel.Trace, 
+			"Updating an entity of type '{EntityType}' (ID={EntityId}) owned by tenant '{TenantId}'")]
+        public static partial void TraceUpdatingEntity(this ILogger logger, Type entityType, object entityId, string? tenantId);
 
-        [LoggerMessage(EventId = LogEventIds.DeletingEntity, Level = LogLevel.Trace, 
-                                             Message = "Deleting an entity of type '{EntityType}' (ID={EntityId}) owned by tenant '{TenantId}'")]
-        public static partial void TraceDeletingEntity(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        [LoggerMessage(LogEventIds.DeletingEntity, LogLevel.Trace, 
+			"Deleting an entity of type '{EntityType}' (ID={EntityId}) owned by tenant '{TenantId}'")]
+        public static partial void TraceDeletingEntity(this ILogger logger, Type entityType, object entityId, string? tenantId);
 
-        [LoggerMessage(EventId = LogEventIds.FindingById, Level = LogLevel.Trace, 
-                       Message = "Finding an entity of type '{EntityType}' with ID '{EntityId}' owned by tenant '{TenantId}'")]
-        public static partial void TraceFindingById(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        [LoggerMessage(LogEventIds.FindingById, LogLevel.Trace, 
+			"Finding an entity of type '{EntityType}' with ID '{EntityId}' owned by tenant '{TenantId}'")]
+        public static partial void TraceFindingById(this ILogger logger, Type entityType, object entityId, string? tenantId);
 
         [LoggerMessage(EventId = LogEventIds.EntityCreated, Level = LogLevel.Information, 
                                   Message = "Entity of type '{EntityType}' with ID '{EntityId}' was created for tenant '{TenantId}'")]
-        public static partial void LogEntityCreated(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        public static partial void LogEntityCreated(this ILogger logger, Type entityType, object entityId, string? tenantId);
 
         [LoggerMessage(EventId = LogEventIds.EntityUpdated, Level = LogLevel.Information, 
                                              Message = "Entity of type '{EntityType}' (ID={EntityId}) updated for tenant '{TenantId}'")]
-        public static partial void LogEntityUpdated(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        public static partial void LogEntityUpdated(this ILogger logger, Type entityType, object entityId, string? tenantId);
 
         [LoggerMessage(EventId = LogEventIds.EntityDeleted, Level = LogLevel.Information, 
                                                         Message = "Entity of type '{EntityType}' (ID={EntityId}) deleted for tenant '{TenantId}'")]
-        public static partial void LogEntityDeleted(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        public static partial void LogEntityDeleted(this ILogger logger, Type entityType, object entityId, string? tenantId);
 
         [LoggerMessage(EventId = LogEventIds.EntityFoundById, Level = LogLevel.Trace, 
                                   Message = "Entity of type '{EntityType}' found with ID '{EntityId}' for tenant '{TenantId}'")]
-        public static partial void TraceEntityFoundById(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        public static partial void TraceEntityFoundById(this ILogger logger, Type entityType, object entityId, string? tenantId);
 
         [LoggerMessage(EventId = LogEventIds.EntityNotFoundById, Level = LogLevel.Trace, 
                                                         Message = "Entity of type '{EntityType}' not found with ID '{EntityId}' for tenant '{TenantId}'")]
-        public static partial void TraceEntityNotFoundById(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        public static partial void TraceEntityNotFoundById(this ILogger logger, Type entityType, object entityId, string? tenantId);
 
         [LoggerMessage(EventId = LogEventIds.EntityNotFound, Level = LogLevel.Warning, 
             Message = "Entity of type '{EntityType}' with ID '{EntityId}' not found for tenant '{TenantId}'")]
-        public static partial void WarnEntityNotFound(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        public static partial void WarnEntityNotFound(this ILogger logger, Type entityType, object entityId, string? tenantId);
 
         [LoggerMessage(EventId = LogEventIds.EntityNotDeleted, Level = LogLevel.Warning, 
                        Message = "Entity of type '{EntityType}' with ID '{EntityId}' not deleted for tenant '{TenantId}'")]
-        public static partial void WarnEntityNotDeleted(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        public static partial void WarnEntityNotDeleted(this ILogger logger, Type entityType, object entityId, string? tenantId);
 
         [LoggerMessage(EventId = LogEventIds.EntityNotUpdated, Level = LogLevel.Warning, 
                                              Message = "Entity of type '{EntityType}' with ID '{EntityId}' not updated for tenant '{TenantId}'")]
-        public static partial void WarnEntityNotUpdated(this ILogger logger, Type entityType, string entityId, string? tenantId);
+        public static partial void WarnEntityNotUpdated(this ILogger logger, Type entityType, object entityId, string? tenantId);
     }
 }

--- a/src/Deveel.Repository.EntityFramework/Deveel.Repository.EntityFramework.xml
+++ b/src/Deveel.Repository.EntityFramework/Deveel.Repository.EntityFramework.xml
@@ -81,13 +81,13 @@
             Thrown when the repository has been disposed.
             </exception>
         </member>
-        <member name="M:Deveel.Data.EntityRepository`1.ConvertEntityKey(System.String)">
+        <member name="M:Deveel.Data.EntityRepository`1.ConvertEntityKey(System.Object)">
             <summary>
-            Converts the given string identifier to the type of the 
+            Converts the given value to the type of the 
             primary key of the entity.
             </summary>
-            <param name="id">
-            The string representation of the identifier.
+            <param name="key">
+            The key that represents the identifier of the entity.
             </param>
             <returns>
             Returns the identifier converted to the type of the primary key
@@ -97,7 +97,7 @@
             Thrown when the given string is not a valid identifier for the entity.
             </exception>
         </member>
-        <member name="M:Deveel.Data.EntityRepository`1.GetEntityId(`0)">
+        <member name="M:Deveel.Data.EntityRepository`1.GetEntityKey(`0)">
             <inheritdoc/>
         </member>
         <member name="M:Deveel.Data.EntityRepository`1.AddAsync(`0,System.Threading.CancellationToken)">
@@ -112,7 +112,7 @@
         <member name="M:Deveel.Data.EntityRepository`1.RemoveRangeAsync(System.Collections.Generic.IEnumerable{`0},System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
-        <member name="M:Deveel.Data.EntityRepository`1.FindByIdAsync(System.String,System.Threading.CancellationToken)">
+        <member name="M:Deveel.Data.EntityRepository`1.FindByKeyAsync(System.Object,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
         <member name="M:Deveel.Data.EntityRepository`1.UpdateAsync(`0,System.Threading.CancellationToken)">

--- a/src/Deveel.Repsotiory.MongoFramework/Data/LoggerExtensions.cs
+++ b/src/Deveel.Repsotiory.MongoFramework/Data/LoggerExtensions.cs
@@ -28,35 +28,35 @@ namespace Deveel.Data {
 
 		[LoggerMessage(EventId = -100201, Level = LogLevel.Error,
 						Message = "Unknown error while operating on the repository for entity {EntityId}")]
-		public static partial void LogUnknownEntityError(this ILogger logger, Exception ex, string entityId);
+		public static partial void LogUnknownEntityError(this ILogger logger, Exception ex, object entityId);
 
 		[LoggerMessage(EventId = 1000231, Level = LogLevel.Debug, 
 			Message = "Trying to find entity with ID {EntityId}")]
-		public static partial void TraceFindingById(this ILogger logger, string entityId);
+		public static partial void TraceFindingById(this ILogger logger, object entityId);
 
 		[LoggerMessage(EventId = 1000232, Level = LogLevel.Debug, 
 			Message = "Trying to find entity with ID {EntityId} for tenant {TenantId}")]
-		public static partial void TraceFindingByIdForTenant(this ILogger logger, string tenantId, string entityId);
+		public static partial void TraceFindingByIdForTenant(this ILogger logger, string tenantId, object entityId);
 
 		[LoggerMessage(EventId = 1000233, Level = LogLevel.Debug, 
 			Message = "An entity with ID {EntityId} found")]
-		public static partial void TraceFoundById(this ILogger logger, string entityId);
+		public static partial void TraceFoundById(this ILogger logger, object entityId);
 
 		[LoggerMessage(EventId = 1000234, Level = LogLevel.Debug, 
 			Message = "An entity with ID {EntityId} found for tenant {TenantId}")]
-		public static partial void TraceFoundByIdForTenant(this ILogger logger, string tenantId, string entityId);
+		public static partial void TraceFoundByIdForTenant(this ILogger logger, string tenantId, object entityId);
 
 		[LoggerMessage(EventId = 100024, Level = LogLevel.Debug, Message = "Deleting entity {EntityId}")]
-		public static partial void TraceDeleting(this ILogger logger, string entityId);
+		public static partial void TraceDeleting(this ILogger logger, object entityId);
 
 		[LoggerMessage(EventId = 1000241, Level = LogLevel.Debug, Message = "Deleting entity {EntityId} for tenant {TenantId}")]
-		public static partial void TraceDeletingForTenant(this ILogger logger, string tenantId, string entityId);
+		public static partial void TraceDeletingForTenant(this ILogger logger, string tenantId, object entityId);
 
 		[LoggerMessage(EventId = 100025, Level = LogLevel.Debug, Message = "Entity {EntityId} deleted")]
-		public static partial void TraceDeleted(this ILogger logger, string entityId);
+		public static partial void TraceDeleted(this ILogger logger, object entityId);
 
 		[LoggerMessage(EventId = 1000251, Level = LogLevel.Debug, Message = "Entity {EntityId} deleted for tenant {TenantId}")]
-		public static partial void TraceDeletedForTenant(this ILogger logger, string tenantId, string entityId);
+		public static partial void TraceDeletedForTenant(this ILogger logger, string tenantId, object entityId);
 
 
 		[LoggerMessage(EventId = 100023, Level = LogLevel.Debug, Message = "Creating new entity")]
@@ -66,21 +66,21 @@ namespace Deveel.Data {
 		public static partial void TraceCreatingForTenant(this ILogger logger, string tenantId);
 
 		[LoggerMessage(EventId = 100022, Level = LogLevel.Debug, Message = "Entity {EntityId} created")]
-		public static partial void TraceCreated(this ILogger logger, string entityId);
+		public static partial void TraceCreated(this ILogger logger, object entityId);
 
 		[LoggerMessage(EventId = 1000221, Level = LogLevel.Debug, Message = "Entity {EntityId} created for tenant {TenantId}")]
-		public static partial void TraceCreatedForTenant(this ILogger logger, string tenantId, string entityId);
+		public static partial void TraceCreatedForTenant(this ILogger logger, string tenantId, object entityId);
 
 		[LoggerMessage(EventId = 100021, Level = LogLevel.Debug, Message = "Updating entity {EntityId}")]
 		public static partial void TraceUpdating(this ILogger logger, string entityId);
 
 		[LoggerMessage(EventId = 1000211, Level = LogLevel.Debug, Message = "Updating entity {EntityId} for tenant {TenantId}")]
-		public static partial void TraceUpdatingForTenant(this ILogger logger, string tenantId, string entityId);
+		public static partial void TraceUpdatingForTenant(this ILogger logger, string tenantId, object entityId);
 
 		[LoggerMessage(EventId = 100020, Level = LogLevel.Debug, Message = "Entity {EntityId} updated")]
-		public static partial void TraceUpdated(this ILogger logger, string entityId);
+		public static partial void TraceUpdated(this ILogger logger, object entityId);
 
 		[LoggerMessage(EventId = 1000201, Level = LogLevel.Debug, Message = "Entity {EntityId} updated for tenant {TenantId}")]
-		public static partial void TraceUpdatedForTenant(this ILogger logger, string tenantId, string entityId);
+		public static partial void TraceUpdatedForTenant(this ILogger logger, string tenantId, object entityId);
 	}
 }

--- a/src/Deveel.Repsotiory.MongoFramework/Deveel.Repository.MongoFramework.xml
+++ b/src/Deveel.Repsotiory.MongoFramework/Deveel.Repository.MongoFramework.xml
@@ -112,7 +112,7 @@
             <returns></returns>
             <exception cref="T:Deveel.Data.RepositoryException"></exception>
         </member>
-        <member name="M:Deveel.Data.MongoRepository`1.GetEntityId(`0)">
+        <member name="M:Deveel.Data.MongoRepository`1.GetEntityKey(`0)">
             <summary>
             Gets the value of the ID property of the given entity.
             </summary>
@@ -123,18 +123,18 @@
             Returns the value of the ID property of the given entity.
             </returns>
         </member>
-        <member name="M:Deveel.Data.MongoRepository`1.ConvertIdValue(System.String)">
+        <member name="M:Deveel.Data.MongoRepository`1.ConvertKeyValue(System.Object)">
             <summary>
-            Converts the given string value to the type of the ID property of the
+            Converts the given value to the type of the ID property of the
             entity managed by this repository.
             </summary>
-            <param name="id">
-            The string representation of the ID value.
+            <param name="key">
+            The value representing the key of the entity.
             </param>
             <returns>
             Returns the value converted accordingly to the type of the ID property
             of the entity managed by this repository, or <c>null</c> if the given
-            string is <c>null</c> or empty.
+            key is <c>null</c> or empty.
             </returns>
             <exception cref="T:Deveel.Data.RepositoryException">
             Thrown if the entity managed by this repository has no ID property

--- a/test/Deveel.Repository.Core.XUnit/Data/ListAsRepositoryTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Data/ListAsRepositoryTests.cs
@@ -57,10 +57,9 @@
 				.Generate(10)
 				.ToList();
 
-			var result = await repository.AddRangeAsync(newPersons);
+			await repository.AddRangeAsync(newPersons);
 
 			Assert.Equal(listCount + 10, repository.CountAll());
-			Assert.Equal(10, result.Count);
 
 			foreach (var person in newPersons) {
 				Assert.NotNull(person.Id);
@@ -96,7 +95,7 @@
 
 			var person = RandomPerson();
 
-			var result = await repository.RemoveByIdAsync(person.Id!);
+			var result = await repository.RemoveByKeyAsync(person.Id!);
 			Assert.True(result);
 
 			Assert.Equal(listCount - 1, repository.AsFilterable().CountAll());
@@ -106,7 +105,7 @@
 		public async Task Mutable_RemoveById_NotFound() {
 			var listCount = persons.Count;
 
-			var result = await repository.RemoveByIdAsync(Guid.NewGuid().ToString());
+			var result = await repository.RemoveByKeyAsync(Guid.NewGuid().ToString());
 			Assert.False(result);
 
 			Assert.Equal(listCount, repository.AsFilterable().CountAll());

--- a/test/Deveel.Repository.MongoFramework.XUnit/Data/MongoRepositoryTestSuite.cs
+++ b/test/Deveel.Repository.MongoFramework.XUnit/Data/MongoRepositoryTestSuite.cs
@@ -39,5 +39,24 @@ namespace Deveel.Data {
 
 			await base.DisposeAsync();
 		}
+
+		[Fact]
+		public async Task FindByObjectId() {
+			var person = await RandomPersonAsync();
+
+			var found = await Repository.FindByKeyAsync(person.Id);
+
+			Assert.NotNull(found);
+			Assert.Equal(person.Id, found.Id);
+		}
+
+		[Fact]
+		public async Task FindByObjectId_NotExisting() {
+			var personId = ObjectId.GenerateNewId();
+
+			var found = await Repository.FindByKeyAsync(personId.ToString());
+
+			Assert.Null(found);
+		}
 	}
 }

--- a/test/Deveel.Repository.MongoFramework.XUnit/Data/StateTests.cs
+++ b/test/Deveel.Repository.MongoFramework.XUnit/Data/StateTests.cs
@@ -80,7 +80,7 @@ namespace Deveel.Data {
             await StateRepository.AddStateAsync(person, state);
             await StateRepository.UpdateAsync(person);
 
-            var updated = await StateRepository.FindByIdAsync(person.Id.ToString());
+            var updated = await StateRepository.FindByKeyAsync(person.Id.ToString());
 
             Assert.NotNull(updated);
             Assert.Equal(PersonStatus.Alive, updated.Status);
@@ -113,7 +113,7 @@ namespace Deveel.Data {
 
 			await StateRepository.RemoveStateAsync(person, state);
 
-            var updated = await StateRepository.FindByIdAsync(person.Id.ToString());
+            var updated = await StateRepository.FindByKeyAsync(person.Id.ToString());
             Assert.NotNull(updated);
             Assert.Null(updated.Status);
             Assert.Null(updated.LastActorId);


### PR DESCRIPTION
Repositories don't force the specification of an ID for the entity that is of string type, but allow the specification of native types (eg. ObjectId, Guid, etc.).
If the key is a string and the registered type of the entity ID is not a string, implementations of the Repository will attempt to convert the string to the destination type.