### PR TITLE
Marten-Based Repositories

### DIFF
--- a/Deveel.Repository.sln
+++ b/Deveel.Repository.sln
@@ -48,9 +48,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Repository.Manager.X
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Repository.Manager.DynamicLinq", "src\Deveel.Repository.Manager.DynamicLinq\Deveel.Repository.Manager.DynamicLinq.csproj", "{638851EF-B000-490C-9035-A962279A3E9B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Repository.Manager.EasyCaching", "src\Deveel.Repository.Manager.EasyCaching\Deveel.Repository.Manager.EasyCaching.csproj", "{84D55BE2-7DAD-4CA3-A3E2-EFB4D41FA3CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Repository.Manager.EasyCaching", "src\Deveel.Repository.Manager.EasyCaching\Deveel.Repository.Manager.EasyCaching.csproj", "{84D55BE2-7DAD-4CA3-A3E2-EFB4D41FA3CA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Repository.Manager.EasyCaching.XUnit", "test\Deveel.Repository.Manager.EasyCaching.XUnit\Deveel.Repository.Manager.EasyCaching.XUnit.csproj", "{F47C196B-758D-4C05-8918-FB63C61649EB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Repository.Manager.EasyCaching.XUnit", "test\Deveel.Repository.Manager.EasyCaching.XUnit\Deveel.Repository.Manager.EasyCaching.XUnit.csproj", "{F47C196B-758D-4C05-8918-FB63C61649EB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Repository.MartenDb", "src\Deveel.Repository.MartenDb\Deveel.Repository.MartenDb.csproj", "{96284897-30DC-4F27-866C-355F06D02DFB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Repository.MartenDb.XUnit", "test\Deveel.Repository.MartenDb.XUnit\Deveel.Repository.MartenDb.XUnit.csproj", "{8CAC793C-A886-42C8-B754-7E5F7D8DE1F2}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Repository.Aggregate.Model", "src\Deveel.Repository.Aggregate.Model\Deveel.Repository.Aggregate.Model.csproj", "{D7403F7B-AD31-4F06-876B-1D97103B931A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -126,6 +132,18 @@ Global
 		{F47C196B-758D-4C05-8918-FB63C61649EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F47C196B-758D-4C05-8918-FB63C61649EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F47C196B-758D-4C05-8918-FB63C61649EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96284897-30DC-4F27-866C-355F06D02DFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96284897-30DC-4F27-866C-355F06D02DFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96284897-30DC-4F27-866C-355F06D02DFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96284897-30DC-4F27-866C-355F06D02DFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8CAC793C-A886-42C8-B754-7E5F7D8DE1F2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8CAC793C-A886-42C8-B754-7E5F7D8DE1F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CAC793C-A886-42C8-B754-7E5F7D8DE1F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CAC793C-A886-42C8-B754-7E5F7D8DE1F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7403F7B-AD31-4F06-876B-1D97103B931A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7403F7B-AD31-4F06-876B-1D97103B931A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7403F7B-AD31-4F06-876B-1D97103B931A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7403F7B-AD31-4F06-876B-1D97103B931A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,6 +166,9 @@ Global
 		{638851EF-B000-490C-9035-A962279A3E9B} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 		{84D55BE2-7DAD-4CA3-A3E2-EFB4D41FA3CA} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 		{F47C196B-758D-4C05-8918-FB63C61649EB} = {50434E05-0F21-4871-AFB3-A483CEE4A300}
+		{96284897-30DC-4F27-866C-355F06D02DFB} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
+		{8CAC793C-A886-42C8-B754-7E5F7D8DE1F2} = {50434E05-0F21-4871-AFB3-A483CEE4A300}
+		{D7403F7B-AD31-4F06-876B-1D97103B931A} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01FD9B16-84B3-4D99-80C1-11B2F3D65B56}

--- a/src/Deveel.Repository.Aggregate.Model/Data/Aggregate.cs
+++ b/src/Deveel.Repository.Aggregate.Model/Data/Aggregate.cs
@@ -1,0 +1,73 @@
+﻿namespace Deveel.Data {
+	/// <summary>
+	/// Provides a base implementation of an object
+	/// that aggregates a stream of events to form
+	/// its state.
+	/// </summary>
+	public abstract class Aggregate {
+		/// <summary>
+		/// Constructs the aggregate from the initial set of
+		/// committed events.
+		/// </summary>
+		/// <param name="committedEvents"></param>
+		protected Aggregate(IEnumerable<object>? committedEvents = null) {
+			Events = new EventCollection(this, committedEvents);
+
+			foreach (var @event in Events.Committed) {
+				ApplyEvent(@event);
+			}
+		}
+
+		/// <summary>
+		/// Gets the stream of events that are applied to
+		/// the aggregate.
+		/// </summary>
+		public EventCollection Events { get; }
+
+		/// <summary>
+		/// Gets the version of the aggregate.
+		/// </summary>
+		/// <remarks>
+		/// The default implementation returns the total number
+		/// of events in the stream.
+		/// </remarks>
+		[Version]
+		public virtual int Version => Events.Count;
+
+		/// <summary>
+		/// Applies the given event to the aggregate, changing
+		/// its state and incrementing the version.
+		/// </summary>
+		/// <param name="event">
+		/// The event to apply to the aggregate.
+		/// </param>
+		public void Apply(object @event) {
+			ArgumentNullException.ThrowIfNull(@event, nameof(@event));
+
+			ApplyEvent(@event);
+
+			Events.Add(@event);
+		}
+
+		/// <summary>
+		/// When overridden in a derived class, applies the given
+		/// event to the aggregate, changing its state.
+		/// </summary>
+		/// <param name="event">
+		/// The event to apply to the aggregate.
+		/// </param>
+		protected virtual void ApplyEvent(object @event) {
+		}
+
+		/// <summary>
+		/// Commits the current stream of events to the aggregate.
+		/// </summary>
+		public void Commit() => Events.Commit();
+
+		/// <summary>
+		/// Rolls back the current stream of uncommitted events 
+		/// to the aggregate.
+		/// </summary>
+		public void Rollback() => Events.Clear();
+	}
+}

--- a/src/Deveel.Repository.Aggregate.Model/Data/EventCollection.cs
+++ b/src/Deveel.Repository.Aggregate.Model/Data/EventCollection.cs
@@ -1,0 +1,143 @@
+﻿using System.Collections;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// A collection of events that are applied to an aggregate.
+	/// </summary>
+	public sealed class EventCollection : IReadOnlyCollection<object> {
+		private readonly List<EventState> events;
+
+		/// <summary>
+		/// Constructs the collection from the initial
+		/// set of committed events.
+		/// </summary>
+		/// <param name="aggregate">
+		/// The aggregate that the events are applied to.
+		/// </param>
+		/// <param name="committedEvents">
+		/// The initial set of events that are committed to
+		/// form the aggregate.
+		/// </param>
+		internal EventCollection(Aggregate aggregate, IEnumerable<object>? committedEvents = null) {
+			ArgumentNullException.ThrowIfNull(aggregate, nameof(aggregate));
+
+			Aggregate = aggregate;
+
+			events = new List<EventState>();
+
+			if (committedEvents != null) {
+				foreach (var @event in committedEvents) {
+					events.Add(new EventState(@event, true));
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets the aggregate that the events are applied to.
+		/// </summary>
+		public Aggregate Aggregate { get; }
+
+		/// <summary>
+		/// Gets the total number of events in the collection.
+		/// </summary>
+		public int Count {
+			get {
+				lock (events) {
+					return events.Count;
+				}
+			}
+		}
+
+		/// <inheritdoc/>
+		public IReadOnlyList<object> Committed {
+			get {
+				lock (events) {
+					return events.Where(x => x.IsCommitted).Select(x => x.Event).ToArray();
+				}
+			}
+		}
+
+		/// <inheritdoc/>
+		public IReadOnlyList<object> Uncommitted {
+			get {
+				lock (events) {
+					return events.Where(x => !x.IsCommitted).Select(x => x.Event).ToArray();
+				}
+			}
+		}
+
+		/// <summary>
+		/// Adds a new event to the collection as uncommitted.
+		/// </summary>
+		/// <param name="event">
+		/// The event to add to the collection.
+		/// </param>
+		/// <remarks>
+		/// The event is added to the collection as uncommitted,
+		/// that means that it is not yet part of the aggregate
+		/// and that can be removed or cleared.
+		/// </remarks>
+		internal void Add(object @event) {
+			lock (events) {
+				events.Add(new EventState(@event, false));
+			}
+		}
+
+		/// <summary>
+		/// Clears all the uncommitted events from the collection.
+		/// </summary>
+		internal void Clear() {
+			lock (events) {
+				for (var i = events.Count - 1; i >= 0; i--) {
+					if (!events[i].IsCommitted)
+						events.RemoveAt(i);
+				}
+			}
+		}
+
+		internal void Commit() {
+			lock (events) {
+				for (var i = events.Count - 1; i >= 0; i--) {
+					if (!events[i].IsCommitted)
+						events[i] = new EventState(events[i].Event, true);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Checks if the given event is contained in the collection.
+		/// </summary>
+		/// <param name="event">
+		/// The event to check.
+		/// </param>
+		/// <returns>
+		/// Returns <c>true</c> if the event is contained in the
+		/// collection, otherwise <c>false</c>.
+		/// </returns>
+		public bool Contains(object @event) {
+			lock (events) {
+				return events.Any(x => x.Event.Equals(@event));
+			}
+		}
+
+		/// <inheritdoc/>
+		public IEnumerator<object> GetEnumerator() {
+			lock (events) {
+				return events.Select(x => x.Event).GetEnumerator();
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+		private readonly struct EventState {
+			internal EventState(object @event, bool isCommitted) {
+				Event = @event;
+				IsCommitted = isCommitted;
+			}
+
+			public object Event { get; }
+
+			public bool IsCommitted { get; }
+		}
+	}
+}

--- a/src/Deveel.Repository.Aggregate.Model/Data/VersionAttribute.cs
+++ b/src/Deveel.Repository.Aggregate.Model/Data/VersionAttribute.cs
@@ -1,0 +1,9 @@
+﻿namespace Deveel.Data {
+	/// <summary>
+	/// An attribute that is used to identify a property of an
+	/// aggregate that is used to obtain its version.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+	public sealed class VersionAttribute : Attribute {
+	}
+}

--- a/src/Deveel.Repository.Aggregate.Model/Deveel.EventSourcing.Model.xml
+++ b/src/Deveel.Repository.Aggregate.Model/Deveel.EventSourcing.Model.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Deveel.Repository.Aggregate.Model</name>
+    </assembly>
+    <members>
+        <member name="T:Deveel.Data.Aggregate">
+            <summary>
+            Provides a base implementation of an object
+            that aggregates a stream of events to form
+            its state.
+            </summary>
+        </member>
+        <member name="M:Deveel.Data.Aggregate.#ctor(System.Collections.Generic.IEnumerable{System.Object})">
+            <summary>
+            Constructs the aggregate from the initial set of
+            committed events.
+            </summary>
+            <param name="committedEvents"></param>
+        </member>
+        <member name="P:Deveel.Data.Aggregate.Events">
+            <summary>
+            Gets the stream of events that are applied to
+            the aggregate.
+            </summary>
+        </member>
+        <member name="P:Deveel.Data.Aggregate.Version">
+            <summary>
+            Gets the version of the aggregate.
+            </summary>
+            <remarks>
+            The default implementation returns the total number
+            of events in the stream.
+            </remarks>
+        </member>
+        <member name="M:Deveel.Data.Aggregate.Apply(System.Object)">
+            <summary>
+            Applies the given event to the aggregate, changing
+            its state and incrementing the version.
+            </summary>
+            <param name="event">
+            The event to apply to the aggregate.
+            </param>
+        </member>
+        <member name="M:Deveel.Data.Aggregate.ApplyEvent(System.Object)">
+            <summary>
+            When overridden in a derived class, applies the given
+            event to the aggregate, changing its state.
+            </summary>
+            <param name="event">
+            The event to apply to the aggregate.
+            </param>
+        </member>
+        <member name="M:Deveel.Data.Aggregate.Commit">
+            <summary>
+            Commits the current stream of events to the aggregate.
+            </summary>
+        </member>
+        <member name="M:Deveel.Data.Aggregate.Rollback">
+            <summary>
+            Rolls back the current stream of uncommitted events 
+            to the aggregate.
+            </summary>
+        </member>
+        <member name="T:Deveel.Data.EventCollection">
+            <summary>
+            A collection of events that are applied to an aggregate.
+            </summary>
+        </member>
+        <member name="M:Deveel.Data.EventCollection.#ctor(Deveel.Data.Aggregate,System.Collections.Generic.IEnumerable{System.Object})">
+            <summary>
+            Constructs the collection from the initial
+            set of committed events.
+            </summary>
+            <param name="aggregate">
+            The aggregate that the events are applied to.
+            </param>
+            <param name="committedEvents">
+            The initial set of events that are committed to
+            form the aggregate.
+            </param>
+        </member>
+        <member name="P:Deveel.Data.EventCollection.Aggregate">
+            <summary>
+            Gets the aggregate that the events are applied to.
+            </summary>
+        </member>
+        <member name="P:Deveel.Data.EventCollection.Count">
+            <summary>
+            Gets the total number of events in the collection.
+            </summary>
+        </member>
+        <member name="P:Deveel.Data.EventCollection.Committed">
+            <inheritdoc/>
+        </member>
+        <member name="P:Deveel.Data.EventCollection.Uncommitted">
+            <inheritdoc/>
+        </member>
+        <member name="M:Deveel.Data.EventCollection.Add(System.Object)">
+            <summary>
+            Adds a new event to the collection as uncommitted.
+            </summary>
+            <param name="event">
+            The event to add to the collection.
+            </param>
+            <remarks>
+            The event is added to the collection as uncommitted,
+            that means that it is not yet part of the aggregate
+            and that can be removed or cleared.
+            </remarks>
+        </member>
+        <member name="M:Deveel.Data.EventCollection.Clear">
+            <summary>
+            Clears all the uncommitted events from the collection.
+            </summary>
+        </member>
+        <member name="M:Deveel.Data.EventCollection.Contains(System.Object)">
+            <summary>
+            Checks if the given event is contained in the collection.
+            </summary>
+            <param name="event">
+            The event to check.
+            </param>
+            <returns>
+            Returns <c>true</c> if the event is contained in the
+            collection, otherwise <c>false</c>.
+            </returns>
+        </member>
+        <member name="M:Deveel.Data.EventCollection.GetEnumerator">
+            <inheritdoc/>
+        </member>
+        <member name="T:Deveel.Data.VersionAttribute">
+            <summary>
+            An attribute that is used to identify a property of an
+            aggregate that is used to obtain its version.
+            </summary>
+        </member>
+    </members>
+</doc>

--- a/src/Deveel.Repository.Aggregate.Model/Deveel.Repository.Aggregate.Model.csproj
+++ b/src/Deveel.Repository.Aggregate.Model/Deveel.Repository.Aggregate.Model.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageTags>repository;event;eventsourcing;events;aggregate;model</PackageTags>
+    <Description>The library provides the models and abstractions to implement event aggregates to be supported by event-sourcing compatible repositories</Description>
+    <DocumentationFile>./Deveel.EventSourcing.Model.xml</DocumentationFile>
+  </PropertyGroup>
+
+</Project>

--- a/src/Deveel.Repository.MartenDb/Data/AggregateKey.cs
+++ b/src/Deveel.Repository.MartenDb/Data/AggregateKey.cs
@@ -1,0 +1,33 @@
+﻿namespace Deveel.Data {
+	/// <summary>
+	/// A structure that identifies an aggregate by its key and
+	/// revision version.
+	/// </summary>
+	public readonly struct AggregateKey {
+		/// <summary>
+		/// Constructs the key of an aggregate.
+		/// </summary>
+		/// <param name="key">
+		/// The unique key of the aggregate.
+		/// </param>
+		/// <param name="version">
+		/// An optional version of the aggregate to identify.
+		/// </param>
+		public AggregateKey(object key, long? version = null) {
+			ArgumentNullException.ThrowIfNull(key, nameof(key));
+
+			Key = key;
+			Version = version;
+		}
+
+		/// <summary>
+		/// Gets the unique key of the aggregate.
+		/// </summary>
+		public object Key { get; }
+
+		/// <summary>
+		/// Gets the version of the aggregate to identify.
+		/// </summary>
+		public long? Version { get; }
+	}
+}

--- a/src/Deveel.Repository.MartenDb/Data/MartenDocumentOptions.cs
+++ b/src/Deveel.Repository.MartenDb/Data/MartenDocumentOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace Deveel.Data {
+	/// <summary>
+	/// Provides a set of options that can be used to configure
+	/// the behavior of a <see cref="MartenDocumentRepository{TDocument}"/>.
+	/// </summary>
+	public class MartenDocumentOptions {
+		/// <summary>
+		/// Gets or sets a flag indicating if the repository is read-only.
+		/// </summary>
+		public bool ReadOnly { get; set; } = false;
+	}
+}

--- a/src/Deveel.Repository.MartenDb/Data/MartenDocumentRepository.cs
+++ b/src/Deveel.Repository.MartenDb/Data/MartenDocumentRepository.cs
@@ -1,0 +1,365 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Marten;
+using Marten.Schema;
+
+using Microsoft.Extensions.Options;
+
+namespace Deveel.Data {
+	public class MartenDocumentRepository<TEntity> : IRepository<TEntity>,
+		IFilterableRepository<TEntity>,
+		IPageableRepository<TEntity>
+		where TEntity : class {
+		private readonly IDocumentStore store;
+		private MemberInfo? keyMember;
+		private PropertyInfo? versionProperty;
+
+		public MartenDocumentRepository(IDocumentStore store, IOptions<MartenDocumentOptions>? options = null) {
+			this.store = store;
+			Options = options?.Value ?? new MartenDocumentOptions();
+		}
+
+		protected MartenDocumentOptions Options { get; }
+
+		protected void ThrowIfReadOnly() {
+			if (Options.ReadOnly)
+				throw new RepositoryException("The repository is read-only");
+		}
+
+		private Expression<Func<TEntity, bool>> AssertExpression(IQueryFilter filter) {
+			if (filter == null || filter.IsEmpty())
+				return x => true;
+
+			if (!(filter is IExpressionQueryFilter exprFilter))
+				throw new RepositoryException($"The filter of type {filter.GetType()} is not supported");
+
+			try {
+				return exprFilter.AsLambda<TEntity>();
+			} catch (Exception ex) {
+				throw new RepositoryException("Unable to trasnform the provided filter to an expression", ex);
+			}
+		}
+
+		public async Task AddAsync(TEntity entity, CancellationToken cancellationToken = default) {
+			ThrowIfReadOnly();
+
+			IDocumentSession? session = null;
+
+			try {
+				session = await store.LightweightSerializableSessionAsync(cancellationToken);
+
+				session.Insert(entity);
+
+				await session.SaveChangesAsync(cancellationToken);
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while adding an entity", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		public async Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+			ThrowIfReadOnly();
+
+			IDocumentSession? session = null;
+
+			try {
+				session = await store.LightweightSerializableSessionAsync(cancellationToken);
+
+				session.Insert(entities);
+
+				await session.SaveChangesAsync(cancellationToken);
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while adding a range of entities", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		Task<long> IFilterableRepository<TEntity>.CountAsync(IQueryFilter filter, CancellationToken cancellationToken) 
+			=> CountAsync(AssertExpression(filter), cancellationToken);
+
+		public async Task<long> CountAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken cancellationToken = default) {
+			IQuerySession? session = null;
+
+			try {
+				session = await store.QuerySerializableSessionAsync(cancellationToken);
+
+				IQueryable<TEntity> querySet = session.Query<TEntity>();
+				if (filter != null)
+					querySet = querySet.Where(filter);
+				
+				return await querySet.CountAsync(cancellationToken);
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while counting entities", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		Task<bool> IFilterableRepository<TEntity>.ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken)
+			=> ExistsAsync(AssertExpression(filter), cancellationToken);
+
+		public async Task<bool> ExistsAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken cancellationToken = default) {
+			IQuerySession? session = null;
+
+			try {
+				session = await store.QuerySerializableSessionAsync(cancellationToken);
+
+				IQueryable<TEntity> querySet = session.Query<TEntity>();
+				if (filter != null)
+					querySet = querySet.Where(filter);
+
+				return await querySet.AnyAsync(cancellationToken);
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while checking for entities", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		Task<IList<TEntity>> IFilterableRepository<TEntity>.FindAllAsync(IQueryFilter filter, CancellationToken cancellationToken) 
+			=> FindAllAsync(AssertExpression(filter), cancellationToken);
+
+		public async Task<IList<TEntity>> FindAllAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken cancellationToken = default) {
+			IQuerySession? session = null;
+
+			try {
+				session = await store.QuerySerializableSessionAsync(cancellationToken);
+
+				IQueryable<TEntity> querySet = session.Query<TEntity>();
+				if (filter != null)
+					querySet = querySet.Where(filter);
+
+				return (await querySet.ToListAsync(cancellationToken)).ToList();
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while finding entities", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		Task<TEntity?> IFilterableRepository<TEntity>.FindAsync(IQueryFilter filter, CancellationToken cancellationToken) 
+			=> FindAsync(AssertExpression(filter), cancellationToken);
+
+		public async Task<TEntity?> FindAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken cancellationToken = default) {
+			IQuerySession? session = null;
+
+			try {
+				session = await store.QuerySerializableSessionAsync(cancellationToken);
+
+				IQueryable<TEntity> querySet = session.Query<TEntity>();
+				if (filter != null)
+					querySet = querySet.Where(filter);
+
+				return await querySet.FirstOrDefaultAsync(cancellationToken);
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while finding an entity", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		public async Task<TEntity?> FindByKeyAsync(object key, CancellationToken cancellationToken = default) {
+			IQuerySession? session = null;
+
+			try {
+				session = await store.QuerySerializableSessionAsync(cancellationToken);
+
+				if (key is string keyString)
+					return await session.LoadAsync<TEntity>(keyString, cancellationToken);
+				if (key is Guid keyGuid)
+					return await session.LoadAsync<TEntity>(keyGuid, cancellationToken);
+				if (key is int keyInt)
+					return await session.LoadAsync<TEntity>(keyInt, cancellationToken);
+
+				throw new RepositoryException($"The key '{key}' is not a valid string or GUID");
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while finding an entity by key", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		public virtual object? GetEntityKey(TEntity entity) {
+			if (keyMember == null) {
+				var docType = store.Options.FindOrResolveDocumentType(typeof(TEntity));
+
+				if (docType == null)
+					throw new RepositoryException($"The entity '{typeof(TEntity).Name}' is not a valid document type");
+
+				keyMember = docType.IdMember;
+
+				if (keyMember == null)
+					throw new RepositoryException($"The entity '{typeof(TEntity).Name}' does not have an identity property");
+			}
+
+			if (keyMember is PropertyInfo property)
+				return property.GetValue(entity);
+			if (keyMember is FieldInfo field)
+				return field.GetValue(entity);
+
+			throw new RepositoryException($"The key member '{keyMember.Name}' is not a valid property or field");
+		}
+
+		public async Task<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {
+			ThrowIfReadOnly();
+
+			IDocumentSession? session = null;
+
+			try {
+				session = await store.LightweightSerializableSessionAsync(cancellationToken);
+
+				var key = GetEntityKey(entity);
+
+				if (key == null)
+					return false;
+
+				if (key is string keyString) {
+					var existing = await session.LoadAsync<TEntity>(keyString, cancellationToken);
+					if (existing == null)
+						return false;
+
+					session.Delete<TEntity>(keyString);
+				} else if (key is Guid keyGuid) {
+					var existing = await session.LoadAsync<TEntity>(keyGuid, cancellationToken);
+					if (existing == null)
+						return false;
+
+					session.Delete<TEntity>(keyGuid);
+				} else if (key is int keyInt) {
+					var existing = await session.LoadAsync<TEntity>(keyInt, cancellationToken);
+					if (existing == null)
+						return false;
+
+					session.Delete<TEntity>(keyInt);
+				} else {
+					throw new RepositoryException($"The key '{key}' is not a valid string or GUID");
+				}
+
+				session.SaveChanges();
+
+				return true;
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while removing an entity", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		public async Task RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+			ThrowIfReadOnly();
+
+			IDocumentSession? session = null;
+
+			try {
+				session = await store.LightweightSerializableSessionAsync(cancellationToken);
+
+				foreach (var entity in entities) {
+					var key = GetEntityKey(entity);
+
+					if (key == null)
+						throw new RepositoryException($"The entity '{typeof(TEntity)}' has no key");
+
+					if (key is string keyString) {
+						var existing = await session.LoadAsync<TEntity>(keyString, cancellationToken);
+						if (existing == null)
+							throw new RepositoryException($"The entity '{typeof(TEntity)}' with key '{keyString}' does not exist");
+
+						session.Delete<TEntity>(keyString);
+					} else if (key is Guid keyGuid) {
+						var existing = await session.LoadAsync<TEntity>(keyGuid, cancellationToken);
+						if (existing == null)
+							throw new RepositoryException($"The entity '{typeof(TEntity)}' with key '{keyGuid}' does not exist");
+
+						session.Delete<TEntity>(keyGuid);
+					} else if (key is int keyInt) {
+						var existing = await session.LoadAsync<TEntity>(keyInt, cancellationToken);
+						if (existing == null)
+							throw new RepositoryException($"The entity '{typeof(TEntity)}' with key '{keyInt}' does not exist");
+
+						session.Delete<TEntity>(keyInt);
+					} else {
+						throw new RepositoryException($"The key '{key}' is not a valid string or GUID");
+					}
+				}
+
+				await session.SaveChangesAsync(cancellationToken);
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while removing a range of entities", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		public async Task<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) {
+			ThrowIfReadOnly();
+
+			IDocumentSession? session = null;
+
+			try {
+				session = await store.LightweightSerializableSessionAsync(cancellationToken);
+
+				var key = GetEntityKey(entity);
+
+				if (key == null)
+					return false;
+
+				TEntity? existing = null;
+				if (key is string keyString)
+					existing = await session.LoadAsync<TEntity>(keyString, cancellationToken);
+				if (key is Guid keyGuid)
+					existing = await session.LoadAsync<TEntity>(keyGuid, cancellationToken);
+				if (key is int keyInt)
+					existing = await session.LoadAsync<TEntity>(keyInt, cancellationToken);
+
+				if (existing == null)
+					return false;
+
+				session.Update(entity);
+
+				await session.SaveChangesAsync(cancellationToken);
+
+				return true;
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while updating an entity", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		public async Task<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> query, CancellationToken cancellationToken = default) {
+			IQuerySession? session = null;
+
+			try {
+				session = await store.QuerySerializableSessionAsync(cancellationToken);
+
+				IQueryable<TEntity> querySet = session.Query<TEntity>();
+				if (query.Filter != null) {
+					querySet = query.Filter.Apply(querySet);
+				}
+
+				var total = await querySet.CountAsync(cancellationToken);
+
+				if (query.ResultSorts != null) {
+					foreach (var sort in query.ResultSorts) {
+						querySet = sort.Apply(querySet);
+					}
+				}
+
+				querySet = querySet.Skip(query.Offset);
+
+				if (query.Size > 0)
+					querySet = querySet.Take(query.Size);
+
+				return new PageResult<TEntity>(query, total, querySet.ToList());
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while getting a page of entities", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+	}
+}

--- a/src/Deveel.Repository.MartenDb/Data/MartenEventRepository.cs
+++ b/src/Deveel.Repository.MartenDb/Data/MartenEventRepository.cs
@@ -1,0 +1,383 @@
+﻿using System.Reflection;
+
+using JasperFx.Core;
+
+using Marten;
+using Marten.Events;
+using Marten.Schema;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// A repository that aggregates events in a stream
+	/// of events from MartenDb.
+	/// </summary>
+	/// <typeparam name="TAggregate">
+	/// The type of entity that aggregates an event stream
+	/// to form its state.
+	/// </typeparam>
+	/// <seealso cref="Aggregate"/>
+	public class MartenEventRepository<TAggregate> : IRepository<TAggregate>
+		where TAggregate : Aggregate {
+		private IDocumentStore store;
+		private MemberInfo? idMember;
+		private PropertyInfo? versionProperty;
+
+		/// <summary>
+		/// Constructs the repository with the given
+		/// document store.
+		/// </summary>
+		/// <param name="store">
+		/// The document store that is used to access
+		/// the event stream.
+		/// </param>
+		public MartenEventRepository(IDocumentStore store) {
+			ArgumentNullException.ThrowIfNull(store, nameof(store));
+
+			this.store = store;
+		}
+
+		/// <inheritdoc/>
+		public virtual async Task AddAsync(TAggregate aggregate, CancellationToken cancellationToken = default) {
+			IDocumentSession? session = null;
+
+			try {
+				// TODO: check if this is the best session type for this operation
+
+				session = await store.LightweightSerializableSessionAsync(cancellationToken);
+
+				var key = GetAggregateIdentity(aggregate);
+
+				if (key == null)
+					throw new RepositoryException($"The aggregate '{typeof(TAggregate)}' has no key");
+
+				if (key is string streamKey) {
+					session.Events.StartStream<TAggregate>(streamKey, aggregate.Events.Uncommitted);
+				} else if (key is Guid streamId) {
+					session.Events.StartStream<TAggregate>(streamId, aggregate.Events.Uncommitted);
+				} else {
+					throw new RepositoryException($"The key '{key}' is not a valid string or GUID");
+				}
+
+				await session.SaveChangesAsync(cancellationToken);
+
+				aggregate.Commit();
+			} catch(RepositoryException) {
+				throw;
+			} catch (Exception ex) {
+				//TODO: log the error
+				throw new RepositoryException("Unknown error while adding an aggregate", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		/// <inheritdoc/>
+		public async Task AddRangeAsync(IEnumerable<TAggregate> entities, CancellationToken cancellationToken = default) {
+			ArgumentNullException.ThrowIfNull(entities, nameof(entities));
+
+			IDocumentSession? session = null;
+
+			try {
+				// TODO: check if this is the best session type for this operation
+				session = await store.LightweightSerializableSessionAsync(cancellationToken);
+
+				foreach (var aggregate in entities) {
+					var key = GetAggregateIdentity(aggregate);
+					// TODO: verify the version to be 0
+					// var version = GetAggregateVersion(aggregate) ?? 0;
+
+					if (key == null)
+						throw new RepositoryException($"The aggregate '{typeof(TAggregate)}' has no key");
+
+					if (key is string streamKey) {
+						session.Events.StartStream<TAggregate>(streamKey, aggregate.Events.Uncommitted.ToArray());
+					} else if (key is Guid streamId) {
+						session.Events.StartStream<TAggregate>(streamId, aggregate.Events.Uncommitted.ToArray());
+					} else {
+						throw new RepositoryException($"The key '{key}' is not a valid string or GUID");
+					}
+				}
+
+				await session.SaveChangesAsync(cancellationToken);
+
+				foreach (var aggregate in entities) {
+					aggregate.Commit();
+				}
+			} catch(RepositoryException) {
+				throw;
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while adding a range of aggregates", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+		
+		/// <inheritdoc/>
+		public async Task<TAggregate?> FindByKeyAsync(object key, CancellationToken cancellationToken = default) {
+			ArgumentNullException.ThrowIfNull(key, nameof(key));
+
+			IQuerySession? session = null;
+
+			try {
+				session = await store.QuerySerializableSessionAsync(cancellationToken);
+
+				TAggregate? aggregate = null;
+
+				if (key is AggregateKey aggregateKey) {
+					var version = aggregateKey.Version ?? 0L;
+					if (aggregateKey.Key is string sKey) {
+						aggregate = await session.Events.AggregateStreamAsync<TAggregate>(sKey, version, token: cancellationToken);
+					} else if (aggregateKey.Key is Guid streamId) {
+						aggregate = await session.Events.AggregateStreamAsync<TAggregate>(streamId, version, token: cancellationToken);
+					}
+				} else if (key is string sKey) {
+					aggregate = await session.Events.AggregateStreamAsync<TAggregate>(sKey, token: cancellationToken);
+				} else if (key is Guid streamId) {
+					aggregate = await session.Events.AggregateStreamAsync<TAggregate>(streamId, token: cancellationToken);
+				} else {
+					throw new RepositoryException($"The key '{key}' is not a valid string or GUID");
+				}
+
+				if (aggregate != null)
+					aggregate.Commit();
+
+				return aggregate;
+			} catch (RepositoryException) {
+				throw;
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while finding an aggregate by key", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		object? IRepository<TAggregate>.GetEntityKey(TAggregate entity)
+			=> GetAggregateIdentity(entity);
+
+		/// <summary>
+		/// Gets the identity of the given aggregate.
+		/// </summary>
+		/// <param name="aggregate">
+		/// The aggregate to get the identity from.
+		/// </param>
+		/// <returns>
+		/// Returns the identity of the aggregate, or <c>null</c>
+		/// if the aggregate has no identity.
+		/// </returns>
+		/// <exception cref="RepositoryException">
+		/// Thrown when the key of the aggregate is not a valid
+		/// identifier.
+		/// </exception>
+		public virtual object? GetAggregateIdentity(TAggregate aggregate) {
+			if (idMember == null) {
+				idMember = typeof(TAggregate)
+					.GetMembers(BindingFlags.Public | BindingFlags.Instance)
+					.Where(x => Attribute.IsDefined(x, typeof(IdentityAttribute)))
+					.FirstOrDefault();
+
+				if (idMember == null)
+					throw new RepositoryException($"The aggregate '{typeof(TAggregate)}' has no key");
+			}
+
+			if (idMember == null)
+				return null;
+
+			object? id = null;
+
+			if (idMember is PropertyInfo property) {
+				id = property.GetValue(aggregate);
+			} else if (idMember is FieldInfo field) {
+				id = field.GetValue(aggregate);
+			}
+
+			if (id == null)
+				return null;
+
+			if (store.Options.Events.StreamIdentity == StreamIdentity.AsGuid) {
+				if (id is Guid g)
+					return g;
+				if (id is string s)
+					return Guid.Parse(s);
+			} else if (store.Options.Events.StreamIdentity == StreamIdentity.AsString) {
+				if (id is string s)
+					return s;
+				if (id is Guid g)
+					return g.ToString();
+
+				return id.ToString();
+			}
+
+			throw new RepositoryException($"The key of the aggregate '{typeof(TAggregate)}' is not a valid string or GUID");
+		}
+
+		/// <summary>
+		/// Gets the version of the given aggregate.
+		/// </summary>
+		/// <param name="aggregate">
+		/// The aggregate to get the version from.
+		/// </param>
+		/// <returns>
+		/// Returns the version of the aggregate, or <c>null</c>
+		/// if the aggregate has no version.
+		/// </returns>
+		/// <exception cref="RepositoryException">
+		/// Thrown when the version of the aggregate is not a valid
+		/// version number.
+		/// </exception>
+		public virtual long? GetAggregateVersion(TAggregate aggregate) {
+			if (versionProperty == null) {
+				versionProperty = typeof(TAggregate).GetProperties()
+					.Where(x => Attribute.IsDefined(x, typeof(VersionAttribute)))
+					.FirstOrDefault();
+			}
+
+			if (versionProperty == null)
+				return null;
+
+			var version = versionProperty.GetValue(aggregate);
+			if (version == null)
+				return null;
+
+			if (version is string s)
+				return Int64.Parse(s);
+
+			if (version is int i)
+				return i;
+			if (version is long l)
+				return l;
+
+			throw new RepositoryException("The version of the aggregate is not a valid integer");
+		}
+
+		/// <inheritdoc/>
+		public async Task<bool> RemoveAsync(TAggregate entity, CancellationToken cancellationToken = default) {
+			IDocumentSession? session = null;
+
+			try {
+				// TODO: check if this is the best session type for this operation
+				session = await store.LightweightSerializableSessionAsync(cancellationToken);
+
+				var key = GetAggregateIdentity(entity);
+
+				if (key == null)
+					return false;
+
+				if (key is string streamKey) {
+					var state = await session.Events.FetchStreamStateAsync(streamKey, cancellationToken);
+					if (state == null || state.IsArchived)
+						return false;
+
+					session.Events.ArchiveStream(streamKey);
+				} else if (key is Guid streamId) {
+					var state = await session.Events.FetchStreamStateAsync(streamId, cancellationToken);
+
+					if (state == null || state.IsArchived)
+						return false;
+
+					session.Events.ArchiveStream(streamId);
+				}
+
+				await session.SaveChangesAsync(cancellationToken);
+
+				return true;
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while removing an aggregate", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		/// <inheritdoc/>
+		public async Task RemoveRangeAsync(IEnumerable<TAggregate> entities, CancellationToken cancellationToken = default) {
+			IDocumentSession? session = null;
+
+			try {
+				// TODO: check if this is the best session type for this operation
+				session = await store.LightweightSerializableSessionAsync(cancellationToken);
+
+				foreach (var entity in entities) {
+					var key = GetAggregateIdentity(entity);
+
+					if (key == null)
+						throw new RepositoryException($"The aggregate '{typeof(TAggregate)}' has no key");
+
+					if (key is string streamKey) {
+						var state = await session.Events.FetchStreamStateAsync(streamKey, cancellationToken);
+						if (state == null || state.IsArchived)
+							throw new RepositoryException($"The aggregate '{streamKey}' is not found");
+
+						session.Events.ArchiveStream(streamKey);
+					} else if (key is Guid streamId) {
+						var state = await session.Events.FetchStreamStateAsync(streamId, cancellationToken);
+
+						if (state == null || state.IsArchived)
+							throw new RepositoryException($"The aggregate '{streamId}' is not found");
+
+						session.Events.ArchiveStream(streamId);
+					}
+				}
+
+				await session.SaveChangesAsync(cancellationToken);
+			} catch(RepositoryException) {
+				throw;
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while removing a range of aggregates", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+
+		/// <inheritdoc/>
+		public async Task<bool> UpdateAsync(TAggregate entity, CancellationToken cancellationToken = default) {
+			IDocumentSession? session = null;
+
+			try {
+				session = await store.LightweightSerializableSessionAsync(cancellationToken);
+				var key = GetAggregateIdentity(entity);
+				var version = GetAggregateVersion(entity) ?? 0;
+
+				if (key == null)
+					return false;
+
+				if (key is string streamKey) {
+					var state = await session.Events.FetchStreamStateAsync(streamKey, cancellationToken);
+					if (state == null || state.IsArchived)
+						return false;
+
+					if (version <= state.Version ||
+						entity.Events.Uncommitted.Count == 0)
+						return false;
+
+					foreach (var @event in entity.Events.Uncommitted) {
+						session.Events.Append(streamKey, version, @event);
+					}
+				} else if (key is Guid streamId) {
+					var state = await session.Events.FetchStreamStateAsync(streamId, cancellationToken);
+
+					if (state == null || state.IsArchived)
+						return false;
+
+					if (state.Version == version ||
+						entity.Events.Uncommitted.Count == 0)
+						return false;
+
+					foreach (var @event in entity.Events.Uncommitted) {
+						session.Events.Append(streamId, version, @event);
+					}
+				}
+
+				await session.SaveChangesAsync(cancellationToken);
+
+				entity.Commit();
+
+				return true;
+			} catch (RepositoryException) {
+				throw;
+			} catch (Exception ex) {
+				throw new RepositoryException("Unknown error while updating an aggregate", ex);
+			} finally {
+				session?.Dispose();
+			}
+		}
+	}
+}

--- a/src/Deveel.Repository.MartenDb/Data/RepositoryExtensions.cs
+++ b/src/Deveel.Repository.MartenDb/Data/RepositoryExtensions.cs
@@ -1,0 +1,7 @@
+﻿namespace Deveel.Data {
+	public static class RepositoryExtensions {
+		public static Task<TAggregate?> FindByKeyAsync<TAggregate>(this IRepository<TAggregate> repository, object key, int? version = null)
+			where TAggregate : Aggregate
+			=> repository.FindByKeyAsync(new AggregateKey(key, version));
+	}
+}

--- a/src/Deveel.Repository.MartenDb/Deveel.Repository.MartenDb.csproj
+++ b/src/Deveel.Repository.MartenDb/Deveel.Repository.MartenDb.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageTags>repository;events;event;eventsourcing;event-sourcing;marten;postgres</PackageTags>
+    <Description>The implementation of the repository pattern that is based on the MartenDB event storage system</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Marten" Version="6.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Deveel.Repository.Aggregate.Model\Deveel.Repository.Aggregate.Model.csproj" />
+    <ProjectReference Include="..\Deveel.Repository.Core\Deveel.Repository.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/DbPerson.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/DbPerson.cs
@@ -7,10 +7,7 @@ namespace Deveel.Data {
 		[Key]
 		public Guid? Id { get; set; }
 
-		string? IPerson.Id {
-			get => Id.ToString();
-			set => Id = value == null ? null : Guid.Parse(value);
-		}
+		string? IPerson.Id =>  Id.ToString();
 
 		public string FirstName { get; set; }
 

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/DbTenantPerson.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/DbTenantPerson.cs
@@ -7,10 +7,7 @@ namespace Deveel.Data {
 		[Key]
 		public Guid? Id { get; set; }
 
-		string? IPerson.Id {
-			get => Id.ToString();
-			set => Id = value == null ? null : Guid.Parse(value);
-		}
+		string? IPerson.Id => Id.ToString();
 
 		public string FirstName { get; set; }
 

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityRepositoryProviderTestSuite.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityRepositoryProviderTestSuite.cs
@@ -42,6 +42,14 @@ namespace Deveel.Data {
 
 		protected override IEnumerable<DbTenantPerson> NaturalOrder(IEnumerable<DbTenantPerson> source) => source.OrderBy(x => x.Id);
 
+		protected override void SetPersonId(DbTenantPerson person, string id) {
+			person.Id = Guid.Parse(id);
+		}
+
+		protected override void SetFirstName(DbTenantPerson person, string firstName) {
+			person.FirstName = firstName;
+		}
+
 		protected override Task AddRelationshipAsync(DbTenantPerson person, DbTenantPersonRelationship relationship) {
 			if (person.Relationships == null)
 				person.Relationships = new List<DbTenantPersonRelationship>();

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityRepositoryTestSuite.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityRepositoryTestSuite.cs
@@ -22,6 +22,14 @@ namespace Deveel.Data {
 
 		protected DbPersonRepository PersonRepository => (DbPersonRepository)Repository;
 
+		protected override void SetFirstName(DbPerson person, string firstName) {
+			person.FirstName = firstName;
+		}
+
+		protected override void SetPersonId(DbPerson person, string id) {
+			person.Id = Guid.Parse(id);
+		}
+
 		protected override Task AddRelationshipAsync(DbPerson person, DbRelationship relationship) {
 			if (person.Relationships == null)
 				person.Relationships = new List<DbRelationship>();

--- a/test/Deveel.Repository.InMemory.XUnit/Data/InMemoryRepositoryTests.cs
+++ b/test/Deveel.Repository.InMemory.XUnit/Data/InMemoryRepositoryTests.cs
@@ -15,6 +15,14 @@ namespace Deveel.Data {
 
 		protected override IEnumerable<Person> NaturalOrder(IEnumerable<Person> source) => source.OrderBy(x => x.Id);
 
+		protected override void SetFirstName(Person person, string firstName) {
+			person.FirstName = firstName;
+		}
+
+		protected override void SetPersonId(Person person, string id) {
+			person.Id = id;
+		}
+
 		protected override Task AddRelationshipAsync(Person person, PersonRelationship relationship) {
 			if (person.Relationships == null)
 				person.Relationships = new List<PersonRelationship>();

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/MartenDocumentRepositoryTestSuite.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/MartenDocumentRepositoryTestSuite.cs
@@ -1,0 +1,78 @@
+﻿using Bogus;
+
+using Marten;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit.Abstractions;
+
+namespace Deveel.Data {
+	[Collection(nameof(PostgresTestCollection))]
+	public class MartenDocumentRepositoryTestSuite : RepositoryTestSuite<PersonDocument, PersonRelationship> {
+		private readonly PostgresDatabase postgres;
+
+		public MartenDocumentRepositoryTestSuite(PostgresDatabase postgres, ITestOutputHelper? testOutput) : base(testOutput) {
+			this.postgres = postgres;
+		}
+
+		protected override Faker<PersonDocument> PersonFaker => new PersonDocumentFaker();
+
+		protected override Faker<PersonRelationship> RelationshipFaker => new PersonRelationshipFaker();
+
+		protected override Task AddRelationshipAsync(PersonDocument person, PersonRelationship relationship) {
+			if (person.Relationships == null)
+				person.Relationships = new List<PersonRelationship>();
+
+			person.Relationships.Add(relationship);
+
+			return Task.CompletedTask;
+		}
+
+		protected override Task RemoveRelationshipAsync(PersonDocument person, PersonRelationship relationship) {
+			if (person.Relationships == null)
+				return Task.CompletedTask;
+
+			var rel = person.Relationships.FirstOrDefault(x => x.Type == relationship.Type && x.FullName == relationship.FullName);
+			if (rel != null)
+				person.Relationships.Remove(rel);
+
+			return Task.CompletedTask;
+		}
+
+		protected override void SetFirstName(PersonDocument person, string firstName) {
+			person.FirstName = firstName;
+		}
+
+		protected override void SetPersonId(PersonDocument person, string id) {
+			person.Id = id;
+		}
+
+		protected override void ConfigureServices(IServiceCollection services) {
+			services.AddMarten(options => {
+				options.Connection(postgres.ConnectionString);
+			});
+
+			services.AddRepository<MartenDocumentRepository<PersonDocument>>();
+		}
+
+		protected override async Task<IList<PersonDocument>> FindAllPeopleAsync() {
+			var store = Services.GetRequiredService<IDocumentStore>();
+			using var session = await store.QuerySerializableSessionAsync();
+
+			return (await session.Query<PersonDocument>().ToListAsync()).ToList();
+		}
+
+		protected override async Task SeedAsync(IRepository<PersonDocument> repository) {
+			var store = Services.GetRequiredService<IDocumentStore>();
+			using var session = store.LightweightSession();
+
+			session.Insert<PersonDocument>(People);
+			await session.SaveChangesAsync();
+		}
+
+		protected override async Task DisposeAsync() {
+			var store = Services.GetRequiredService<IDocumentStore>();
+			await store.Advanced.Clean.DeleteDocumentsByTypeAsync(typeof(PersonDocument));
+		}
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/MartenEventRepositoryTestSuite.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/MartenEventRepositoryTestSuite.cs
@@ -1,0 +1,147 @@
+﻿using Bogus;
+
+using Marten;
+using Marten.Events;
+using Marten.Events.Projections;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Xunit.Abstractions;
+
+namespace Deveel.Data {
+	[Collection(nameof(PostgresTestCollection))]
+	public class MartenEventRepositoryTestSuite : RepositoryTestSuite<PersonAggregate, PersonRelationship> {
+		private readonly PostgresDatabase postgres;
+
+		public MartenEventRepositoryTestSuite(PostgresDatabase postgres, ITestOutputHelper? testOutput) : base(testOutput) {
+			this.postgres = postgres;
+		}
+
+		protected override Faker<PersonAggregate> PersonFaker => new PersonAggregateFaker();
+
+		protected override Faker<PersonRelationship> RelationshipFaker => new PersonRelationshipFaker();
+
+		protected override void ConfigureServices(IServiceCollection services) {
+			services.AddMarten(options => {
+				options.Connection(postgres.ConnectionString);
+				options.Events.StreamIdentity = StreamIdentity.AsString;
+				options.Projections.Add<PersonProjection>(ProjectionLifecycle.Inline);
+			});
+			services.AddRepository<MartenEventRepository<PersonAggregate>>();
+		}
+
+		protected override void SetFirstName(PersonAggregate person, string firstName) {
+			person.Apply(new PersonNameChanged(firstName, null));
+		}
+
+		protected override void SetPersonId(PersonAggregate person, string id) {
+			person.Apply(new PersonIdChanged(id));
+		}
+
+		protected override Task AddRelationshipAsync(PersonAggregate person, PersonRelationship relationship) {
+			person.Apply(new RelationshipAdded(relationship.Type, relationship.FullName));
+			return Task.CompletedTask;
+		}
+
+		protected override Task RemoveRelationshipAsync(PersonAggregate person, PersonRelationship relationship) {
+			person.Apply(new RelationshipRemoved(relationship.Type, relationship.FullName));
+			return Task.CompletedTask;
+		}
+
+		protected override async Task SeedAsync(IRepository<PersonAggregate> repository) {
+			var store = Services.GetRequiredService<IDocumentStore>();
+			using var session = store.LightweightSession();
+
+			foreach (var person in People) {
+				session.Events.StartStream(person.Id, person.Events.Uncommitted);
+			}
+
+			await session.SaveChangesAsync();
+		}
+
+		protected override async Task DisposeAsync() {
+			var store = Services.GetRequiredService<IDocumentStore>();
+			await store.Advanced.Clean.DeleteAllEventDataAsync();
+		}
+
+		protected override async Task<IList<PersonAggregate>> FindAllPeopleAsync() {
+			var store = Services.GetRequiredService<IDocumentStore>();
+			using var session = store.QuerySession();
+
+			var streamKeys = session.Events.QueryAllRawEvents().Select(x => x.StreamKey).Distinct().ToArray();
+
+			var people = new List<PersonAggregate>();
+			foreach (var stream in streamKeys) {
+				var person = await session.Events.AggregateStreamAsync<PersonAggregate>(stream);
+
+				if (person != null)
+					people.Add(person);
+			}
+
+			return people;
+		}
+
+		public override Task CountAll() => Task.CompletedTask;
+
+		public override void CountAll_Sync() {
+			return;
+		}
+
+		public override Task CountFiltered() => Task.CompletedTask;
+
+		public override Task CountFiltered_Sync() => Task.CompletedTask;
+
+		public override Task ExistsFiltered() => Task.CompletedTask;
+
+		public override Task ExistsFiltered_Sync() => Task.CompletedTask;
+
+		public override Task FindFirst() => Task.CompletedTask;
+
+		public override void FindFirstSync() {
+			return;
+		}
+
+		public override Task FindFirstFiltered() => Task.CompletedTask;
+
+		public override Task FindFirstFiltered_Sync() => Task.CompletedTask;
+
+		public override Task FindAll() => Task.CompletedTask;
+
+		public override Task FindAllFiltered() => Task.CompletedTask;
+
+		public override Task FindAllFiltered_BadFilter() => Task.CompletedTask;
+
+		public override void FindAll_Sync() {
+			return;
+		}
+
+		public override Task GetSimplePage() => Task.CompletedTask;
+
+		public override Task GetSortedPage() => Task.CompletedTask;
+
+		public override Task GetDescendingSortedPage() => Task.CompletedTask;
+
+		public override Task GetFilteredPage() => Task.CompletedTask;
+
+		public override void GetPage_Sync() {
+			return;
+		}
+
+		public override Task GetPage_ChainedFilters() => Task.CompletedTask;
+
+		public override Task GetPage_MultipleFilters() => Task.CompletedTask;
+
+		public override Task GetSimplePage_WithParameters() => Task.CompletedTask;
+
+		[Fact]
+		public async Task FindByKeyAndVersion() {
+			var person = await RandomPersonAsync();
+
+			var result = await Repository.FindByKeyAsync(person.Id!, person.Version);
+
+			Assert.NotNull(result);
+			Assert.Equal(person.Id, result.Id);
+			Assert.Equal(person.Version, result.Version);
+		}
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/PersonAggregate.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/PersonAggregate.cs
@@ -1,0 +1,61 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+using Marten.Schema;
+
+namespace Deveel.Data {
+	public class PersonAggregate : Aggregate, IPerson {
+		public PersonAggregate(IEnumerable<object>? committedEvents = null) : base(committedEvents) {
+		}
+
+		public PersonAggregate() {
+			ApplyEvent(new PersonCreated(Id = Guid.NewGuid().ToString("N")));
+		}
+
+		[Identity]
+		public string? Id { get; private set; }
+
+		public string FirstName { get; private set; }
+
+		public string LastName { get; private set; }
+
+		public string? Email { get; private set; }
+
+		public DateTime? DateOfBirth { get; private set; }
+
+		public string? PhoneNumber { get; private set; }
+
+		IEnumerable<IRelationship> IPerson.Relationships => Relationships ?? new List<PersonRelationship>();
+
+		public List<PersonRelationship>? Relationships { get; set; }
+
+		protected override void ApplyEvent(object @event) {
+			if (@event is PersonCreated createdEvent) {
+				Id = createdEvent.Id;
+				FirstName = createdEvent.FirstName ?? "";
+				LastName = createdEvent.LastName ?? "";
+				Email = createdEvent.Email;
+				DateOfBirth = createdEvent.DateOfBirth;
+				PhoneNumber = createdEvent.PhoneNumber;
+			} else if (@event is PersonIdChanged personIdChanged) {
+				Id = personIdChanged.Id;
+			} else if (@event is PersonNameChanged nameChangedEvent) {
+				FirstName = nameChangedEvent.FirstName ?? FirstName;
+				LastName = nameChangedEvent.LastName ?? LastName;
+			} else if (@event is PersonEmailChanged emailChangedEvent) {
+				Email = emailChangedEvent.Email;
+			} else if (@event is RelationshipAdded relationshipAdded) {
+				if (Relationships == null)
+					Relationships = new List<PersonRelationship>();
+
+				Relationships.Add(new PersonRelationship { Type = relationshipAdded.Type, FullName = relationshipAdded.FullName });
+			} else if (@event is RelationshipRemoved relationshipRemoved) {
+				if (Relationships == null)
+					return;
+
+				var relationship = Relationships.FirstOrDefault(x => x.Type == relationshipRemoved.Type && x.FullName == relationshipRemoved.FullName);
+				if (relationship != null)
+					Relationships.Remove(relationship);
+			}
+		}
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/PersonAggregateFaker.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/PersonAggregateFaker.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Bogus;
+
+namespace Deveel.Data {
+	public class PersonAggregateFaker : Faker<PersonAggregate> {
+		public PersonAggregateFaker() {
+			CustomInstantiator(f => {
+				var p = new PersonAggregate();
+				var firstName = f.Name.FirstName();
+				var lastName = f.Name.LastName();
+				var id = f.Random.Guid().ToString();
+				var birthDate = f.Date.Past(100).OrNull(f);
+				var email = f.Internet.Email(firstName, lastName).OrNull(f);
+				var phone = f.Phone.PhoneNumber().OrNull(f);
+
+				p.Apply(new PersonCreated(id, firstName, lastName, birthDate, email, phone));
+
+				return p;
+			});
+
+			RuleFor(x => x.Relationships, (f, p) => {
+				if (f.Random.Bool()) {
+					var faker = new PersonRelationshipFaker();
+					var relationships = faker.GenerateBetween(1, 5);
+					foreach (var relationship in relationships) {
+						p.Apply(new RelationshipAdded(relationship.Type, relationship.FullName));
+					}
+				}
+
+				return p.Relationships;
+			});
+		}
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/PersonDocument.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/PersonDocument.cs
@@ -1,0 +1,24 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Deveel.Data {
+	public class PersonDocument : IPerson {
+		[Key]
+		public string? Id { get; set; }
+
+		public string FirstName { get; set; }
+
+		public string LastName { get; set; }
+
+		public string? Email { get; set; }
+
+		public DateTime? DateOfBirth { get; set; }
+
+		public string? PhoneNumber { get; set; }
+
+		IEnumerable<IRelationship> IPerson.Relationships => Relationships;
+
+		public List<PersonRelationship> Relationships { get; set; }
+
+		public DateTimeOffset CreatedAt { get; set; }
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/PersonDocumentFaker.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/PersonDocumentFaker.cs
@@ -1,0 +1,18 @@
+﻿using Bogus;
+
+namespace Deveel.Data {
+	public class PersonDocumentFaker : Faker<PersonDocument> {
+		public PersonDocumentFaker() {
+			RuleFor(x => x.Id, f => f.Random.Guid().ToString());
+			RuleFor(x => x.FirstName, f => f.Name.FirstName());
+			RuleFor(x => x.LastName, f => f.Name.LastName().OrNull(f));
+			RuleFor(x => x.DateOfBirth, f => f.Date.Past(10).OrNull(f));
+			RuleFor(x => x.Email, (f, p) => f.Internet.Email(p.FirstName, p.LastName).OrNull(f));
+			RuleFor(x => x.PhoneNumber, f => f.Phone.PhoneNumber().OrNull(f));
+			RuleFor(x => x.Relationships, f => {
+				var faker = new PersonRelationshipFaker();
+				return f.Random.Bool() ? faker.GenerateBetween(1, 5) : null;
+			});
+		}
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/PersonEvents.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/PersonEvents.cs
@@ -1,0 +1,13 @@
+﻿namespace Deveel.Data {
+	public record PersonCreated(string? Id = null, string? FirstName = null, string? LastName = null, DateTime? DateOfBirth = null, string? Email = null, string? PhoneNumber = null);
+
+	public record PersonIdChanged(string Id);
+
+	public record PersonNameChanged(string? FirstName = null, string? LastName = null);
+
+	public record PersonEmailChanged(string Email);
+
+	public record RelationshipAdded(string Type, string FullName);
+
+	public record RelationshipRemoved(string Type, string FullName);
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/PersonProjection.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/PersonProjection.cs
@@ -1,0 +1,47 @@
+﻿using Marten.Events;
+using Marten.Events.Aggregation;
+
+namespace Deveel.Data {
+	public class PersonProjection : SingleStreamProjection<PersonDocument> {
+
+		public PersonProjection() {
+			CreateEvent<PersonCreated>(Create);
+		}
+
+		public PersonDocument Create(PersonCreated created) {
+			return new PersonDocument {
+				Id = created.Id,
+				FirstName = created.FirstName,
+				LastName = created.LastName,
+				Email = created.Email,
+				DateOfBirth = created.DateOfBirth,
+				PhoneNumber = created.PhoneNumber,
+			};
+		}
+
+		public void Apply(PersonDocument document, PersonNameChanged changed) {
+			document.FirstName = changed.FirstName ?? document.FirstName;
+			document.LastName = changed.LastName ?? document.LastName;
+		}
+
+		public void Apply(PersonDocument document, PersonEmailChanged changed) {
+			document.Email = changed.Email;
+		}
+
+		public void Apply(PersonDocument document, RelationshipAdded added) {
+			if (document.Relationships == null)
+				document.Relationships = new List<PersonRelationship>();
+
+			document.Relationships.Add(new PersonRelationship { Type = added.Type, FullName = added.FullName });
+		}
+
+		public void Apply(PersonDocument document, RelationshipRemoved removed) {
+			if (document.Relationships == null)
+				return;
+
+			var relationship = document.Relationships.FirstOrDefault(x => x.Type == removed.Type && x.FullName == removed.FullName);
+			if (relationship != null)
+				document.Relationships.Remove(relationship);
+		}
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/PersonRelationship.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/PersonRelationship.cs
@@ -1,0 +1,7 @@
+﻿namespace Deveel.Data {
+	public class PersonRelationship : IRelationship {
+		public string Type { get; set; }
+
+		public string FullName { get; set; }
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/PersonRelationshipFaker.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/PersonRelationshipFaker.cs
@@ -1,0 +1,10 @@
+﻿using Bogus;
+
+namespace Deveel.Data {
+	public class PersonRelationshipFaker : Faker<PersonRelationship> {
+		public PersonRelationshipFaker() {
+			RuleFor(x => x.Type, f => f.PickRandom(new[] {"father", "mother", "sister", "brother"}));
+			RuleFor(x => x.FullName, f => f.Name.FullName());
+		}
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/PostgresDatabase.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/PostgresDatabase.cs
@@ -1,0 +1,24 @@
+﻿using Testcontainers.PostgreSql;
+
+namespace Deveel.Data {
+	public class PostgresDatabase : IAsyncLifetime {
+		private PostgreSqlContainer _container;
+
+		public PostgresDatabase() {
+			_container = new PostgreSqlBuilder()
+				.WithDatabase("test")
+				.Build();
+		}
+
+		public string ConnectionString => _container.GetConnectionString();
+
+		public async Task InitializeAsync() {
+			await _container.StartAsync();
+		}
+
+		public async Task DisposeAsync() {
+			if (_container != null)
+				await _container.DisposeAsync();
+		}
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Data/PostgresTestCollection.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/Data/PostgresTestCollection.cs
@@ -1,0 +1,5 @@
+﻿namespace Deveel.Data {
+	[CollectionDefinition(nameof(PostgresTestCollection))]
+	public class PostgresTestCollection : ICollectionFixture<PostgresDatabase> {
+	}
+}

--- a/test/Deveel.Repository.MartenDb.XUnit/Deveel.Repository.MartenDb.XUnit.csproj
+++ b/test/Deveel.Repository.MartenDb.XUnit/Deveel.Repository.MartenDb.XUnit.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Deveel</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.5.0" />
+    <PackageReference Include="xunit" Version="2.5.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Deveel.Repository.MartenDb\Deveel.Repository.MartenDb.csproj" />
+    <ProjectReference Include="..\Deveel.Repository.Tests.XUnit\Deveel.Repository.Tests.XUnit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Deveel.Repository.MartenDb.XUnit/GlobalUsings.cs
+++ b/test/Deveel.Repository.MartenDb.XUnit/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/Deveel.Repository.MongoFramework.XUnit/Data/MongoPerson.cs
+++ b/test/Deveel.Repository.MongoFramework.XUnit/Data/MongoPerson.cs
@@ -13,10 +13,7 @@ namespace Deveel.Data {
 		public ObjectId Id { get; set; }
 
 
-		string? IPerson.Id {
-			get => Id.ToEntityId();
-			set => Id = ObjectId.Parse(value);
-		}
+		string? IPerson.Id => Id.ToEntityId();
 
 		[Column("first_name")]
 		public string FirstName { get; set; }

--- a/test/Deveel.Repository.MongoFramework.XUnit/Data/MongoRepositoryTestSuite.cs
+++ b/test/Deveel.Repository.MongoFramework.XUnit/Data/MongoRepositoryTestSuite.cs
@@ -31,6 +31,14 @@ namespace Deveel.Data {
 			.GetDatabase(DatabaseName)
 			.GetCollection<TPerson>("persons");
 
+		protected override void SetPersonId(TPerson person, string id) {
+			person.Id = ObjectId.Parse(id);
+		}
+
+		protected override void SetFirstName(TPerson person, string firstName) {
+			person.FirstName = firstName;
+		}
+
 		protected override Task AddRelationshipAsync(TPerson person, MongoPersonRelationship relationship) {
 			if (person.Relationships == null)
 				person.Relationships = new List<MongoPersonRelationship>();

--- a/test/Deveel.Repository.Tests.XUnit/Data/IPerson.cs
+++ b/test/Deveel.Repository.Tests.XUnit/Data/IPerson.cs
@@ -1,16 +1,16 @@
 ﻿namespace Deveel.Data {
 	public interface IPerson {
-		string? Id { get; set; }
+		string? Id { get; }
 
-		string FirstName { get; set; }
+		string FirstName { get; }
 
-		string LastName { get; set; }
+		string LastName { get; }
 
-		string? Email { get; set; }
+		string? Email { get; }
 
-		DateTime? DateOfBirth { get; set; }
+		DateTime? DateOfBirth { get; }
 
-		string? PhoneNumber { get; set; }
+		string? PhoneNumber { get; }
 
 		IEnumerable<IRelationship> Relationships { get; }
 	}


### PR DESCRIPTION
Implementations of the Repository model that addresses the MartenDB:

* `MartenEventRepository` - An interface to the Event Streams managed by Marten, by considering _aggregates_ as entities, replaying the streams to form the entity, or unwrapping the events registered to the uncommitted ones
* `MartenDocumentRepository` - Interfaces the MartenDB feature of the DocumentDB to create a more traditional repository model