### PR TITLE
IRepositoryProvider Design Review

### DIFF
--- a/docs/custom-repository.md
+++ b/docs/custom-repository.md
@@ -1,0 +1,57 @@
+# Customize the Repository
+
+In most of the circumstances, the default functions provided by the repository are enough, implementing the CRUD operations, but sometimes you need to add some custom functions to the repository. 
+
+For example, you may want to add a function to get all the users that have a specific role, or you may want to add a function to get all the users that have a specific role and are active: in this case, you can use the query functions provided by implementations of the `IQueryableRepository` or the `IFilterableRepository` interface, when a driver supports them.
+
+## Your Custom Repository
+
+Depending on your desining style, you might want to extend the `IRepository<TEntity>` interface contract, or you might want to extend the specific drivers implementations, for example the `MongoRepository<TEntity>`.
+
+If your intention is to being agnostic from the driver, you should extend the `IRepository<TEntity>` interface, for example:
+
+```csharp
+public interface IUserRepository : IRepository<User> {
+    Task<IEnumerable<User>> GetUsersByRoleAsync(string role);
+}
+```
+
+or even more generic:
+
+```csharp
+public interface IUserRepository<TUser> : IRepository<TUser> where TUser : class, IUser {
+    Task<IEnumerable<User>> GetUsersByRoleAsync(string role);
+}
+```
+
+## Registering the Custom Repository
+
+Once you have defined your custom repository, you need to register it in the `Startup` class, in the `ConfigureServices` method:
+
+```csharp
+public void ConfigureServices(IServiceCollection services) {
+    // ...
+    services.AddRepository<UserRepository>();
+    // ...
+}
+```
+
+The provided `AddRepository` extension method will register the repository as a scoped service by default, but you can still specify the lifetime you prefer.
+
+The method is smart enough to scan the type specified for its base classes and interfaces that implement the `IRepository<TEntity>` interface, and register them as well.
+
+In fact, once you have invoked the above method, you will have the following services registered:
+
+| Service Type | Description |
+| --- | --- |
+| `UserRepository` | The concrete implementation of the custom repository you have defined |
+| `IUserRepository` | The custom repository contract you have defined |
+| `IRepository<User>` | The default repository for the `User` entity |
+
+
+If your custom `IRepository<TEntity>` implements the `IQueryableRepository<TEntity>` or the `IFilterableRepository<TEntity>` interface, the `AddRepository` method will register the following services as well:
+
+| Service Type | Description |
+| --- | --- |
+| `IQueryableRepository<User>` | A queryable repository for the `User` entity |
+| `IFilterableRepository<User>` | A filterable repository for the `User` entity |

--- a/docs/ef-core.md
+++ b/docs/ef-core.md
@@ -50,10 +50,14 @@ services.AddDbContextForTenant<MyDbContext, TenantInfo>((tenant, options) => opt
 
 The `EntityRepository<TEntity>` implements both the `IQueryableRepository<TEntity>` and the `IFilterableRepository<TEntity>` interfaces, and allows to query the data only through the `ExpressionFilter<TEntity>` class or through lambda expressions of type `Expression<Func<TEntity, bool>>`.
 
-## Repository Providers
+For example, to retrieve all the entities of type `MyEntity` that have a property `Name` equal to `"John"`:
 
-Some scenarios of multi-tenant applications require to have a different repository for each tenant, and to be able to switch between the repositories according to the tenant that is currently active.
+```csharp
+var entities = await repository.FindAllAsync(new ExpressionFilter<MyEntity>(x => x.Name == "John"));
+```
 
-The preferred approach of the library is to use the [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant) framework to implement multi-tenant applications, and to use the `ITenantInfo` interface to retrieve the current tenant information: this is obtained by scanning the current HTTP request, and retrieving the tenant information from the request.
+or event simpler, using the lambda expression:
 
-In some cases, like in background services, where the identity of the tenant is not available through the user (eg. _machine-to-machine_ communication), it is possible to obtain the repository for a specific tenant by using the `IRepositoryProvider<TEntity>` interface: these are still drivers-specific, and produce instances of the repository for a specific tenant and specific driver.
+```csharp
+var entities = await repository.FindAllAsync(x => x.Name == "John");
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,30 +100,3 @@ In fact, after that exmaple call above, you will have the following services ava
 | `IPageableRepository<MyEntity>` | The repository to access the data using pagination (if the repository implements it). |
 | `IFilterableRepository<MyEntity>` | The repository to access the data using filters (if the repository implements it). |
 
-## Multi-Tenancy
-
-Some scenarios require information and data to be isolated between different _tenants_ of the application.
-
-By default, the _kernel_ library doesn't provides any set of abstractions and implementations to support multi-tenancy in your application, but the single drivers can provide it, accordingly to their specific capabilities.
-
-| Driver | Multi-Tenancy |
-| ------ | ------------- |
-| _In-Memory_ | :x: |
-| _MongoDB_ | :white_check_mark: |
-| _Entity Framework Core_ | :white_check_mark: |
-
-### The Tenant Context
-
-On a general basis, the tenant context is resolved through the identity of a user of the application, using mechanisms like _claims_ or _roles_ (see at [Finbuckle Multi-Tenant](https://github.com/Finbuckle/Finbuckle.MultiTenant) how this is implemented in ASP.NET Core).
-
-Some scenarios anyway require the access to those segregated information from a _service_ or a _background task_, where the user identity is not available: for this reason the framework provides an abstraction named `IRepositoryProvider<TEntity>` that will be used to resolve the repository to access the data, for the tenant identifier.
-
-To learn more about the usage of the `IRepositoryProvider<TEntity>` interface, you can read the documentation [here](multi-tenancy.md).
-
-#### The `IRepositoryProvider<TEntity>` interface
-
-The `IRepositoryProvider<TEntity>` exposes a single method that allows to obtain an instance of `IRepository<TEntity>` for a specific tenant.
-
-```csharp
-Task<IRepository<TEntity>> GetRepositoryAsync(string tenantId, CancellationToken cancellationToken = default);
-```

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -1,0 +1,36 @@
+# Multi-Tenancy of Data Sources
+
+Software-as-a-Service (SaaS) applications and Enterprise-level applications often need to segregate data between different _tenants_ of the application, that could be different customers or different departments of the same company.
+
+By default, the _kernel_ library doesn't provides any set of abstractions and implementations to support multi-tenancy in your application, but the single drivers can provide it, accordingly to their specific capabilities.
+
+| Driver | Multi-Tenancy |
+| ------ | ------------- |
+| _In-Memory_ | :x: |
+| _MongoDB_ | :white_check_mark: |
+| _Entity Framework Core_ | :white_check_mark: |
+
+### The Tenant Context
+
+On a general basis, the tenant context is resolved through the identity of a user of the application, using mechanisms like _claims_ or _roles_ (see at [Finbuckle Multi-Tenant](https://github.com/Finbuckle/Finbuckle.MultiTenant) how this is implemented in ASP.NET Core).
+
+Some scenarios anyway require the access to those segregated information from a _service_ or a _background task_, where the user identity is not available: for this reason the framework provides an abstraction named `IRepositoryProvider<TEntity>` that will be used to resolve the repository to access the data, for the tenant identifier.
+
+To learn more about the usage of the `IRepositoryProvider<TEntity>` interface, you can read the documentation [here](multi-tenancy.md).
+
+## Repository Providers
+
+The preferred approach of the library is to use the [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant) framework to implement multi-tenant applications, and to use the `ITenantInfo` interface to retrieve the current tenant information: this is obtained by scanning the current HTTP request, and retrieving the tenant information from the request.
+
+In some cases, like in background services, where the identity of the tenant is not available through the user (eg. _machine-to-machine_ communication), it is possible to obtain the repository for a specific tenant by using the `IRepositoryProvider<TEntity>` interface: these are still drivers-specific, and produce instances of the repository for a specific tenant and specific driver.
+
+
+#### The `IRepositoryProvider<TEntity>` interface
+
+The `IRepositoryProvider<TEntity>` exposes a single method that allows to obtain an instance of `IRepository<TEntity>` for a specific tenant.
+
+```csharp
+Task<IRepository<TEntity>> GetRepositoryAsync(string tenantId, CancellationToken cancellationToken = default);
+```
+
+Every driver that supports multi-tenancy will implement this interface, and the `IRepository<TEntity>` instance returned will be specific for the tenant identifier passed as parameter.

--- a/src/Deveel.Repository.EntityFramework/Data/IDbContextOptionsFactory.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/IDbContextOptionsFactory.cs
@@ -1,0 +1,9 @@
+﻿using Finbuckle.MultiTenant;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Deveel.Data {
+	public interface IDbContextOptionsFactory<TContext> where TContext : DbContext {
+		DbContextOptions<TContext> Create(ITenantInfo tenantInfo);
+	}
+}

--- a/src/Deveel.Repository.EntityFramework/Deveel.Repository.EntityFramework.xml
+++ b/src/Deveel.Repository.EntityFramework/Deveel.Repository.EntityFramework.xml
@@ -195,12 +195,13 @@
             The type of <see cref="T:Microsoft.EntityFrameworkCore.DbContext"/> used to manage the entities
             </typeparam>
         </member>
-        <member name="M:Deveel.Data.EntityRepositoryProvider`2.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions{`1},System.Collections.Generic.IEnumerable{Finbuckle.MultiTenant.IMultiTenantStore{Finbuckle.MultiTenant.TenantInfo}},Microsoft.Extensions.Logging.ILoggerFactory)">
+        <member name="M:Deveel.Data.EntityRepositoryProvider`2.#ctor(Deveel.Data.IDbContextOptionsFactory{`0},System.Collections.Generic.IEnumerable{Finbuckle.MultiTenant.IMultiTenantStore{Finbuckle.MultiTenant.TenantInfo}},Microsoft.Extensions.Logging.ILoggerFactory)">
             <summary>
             Constructs the provider with the given options and tenant stores.
             </summary>
-            <param name="options">
-            The options to use to construct the <see cref="T:Microsoft.EntityFrameworkCore.DbContext"/> instances
+            <param name="optionsFactory">
+            A service that is used to create the options for the context
+            and a specific tenant.
             for the tenants.
             </param>
             <param name="tenantStores">
@@ -210,12 +211,77 @@
             A factory to create loggers for the repositories.
             </param>
         </member>
-        <member name="M:Deveel.Data.EntityRepositoryProvider`2.Finalize">
+        <member name="M:Deveel.Data.EntityRepositoryProvider`2.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions{`0},System.Collections.Generic.IEnumerable{Finbuckle.MultiTenant.IMultiTenantStore{Finbuckle.MultiTenant.TenantInfo}},Microsoft.Extensions.Logging.ILoggerFactory)">
+            <summary>
+            Constructs the provider with the given options and 
+            tenant stores.
+            </summary>
+            <param name="options">
+            The instance of options that are used to create the context
+            for the tenants.
+            </param>
+            <param name="tenantStores">
+            The list of stores to retrieve the tenants from.
+            </param>
+            <param name="loggerFactory">
+            A factory to create loggers for the repositories.
+            </param>
+        </member>
+        <member name="T:Deveel.Data.EntityRepositoryProvider`3">
+            <summary>
+            An implementation of <see cref="T:Deveel.Data.IRepositoryProvider`1"/> that
+            allows to create <see cref="T:Deveel.Data.EntityRepository`1"/> instances
+            in a multi-tenant context.
+            </summary>
+            <typeparam name="TEntity">
+            The type of entity managed by the repository
+            </typeparam>
+            <typeparam name="TContext">
+            The type of <see cref="T:Microsoft.EntityFrameworkCore.DbContext"/> used to manage the entities
+            </typeparam>
+            <typeparam name="TTenantInfo">
+            The type of the tenant that is is ued to resolve the context
+            of the tenant.
+            </typeparam>
+        </member>
+        <member name="M:Deveel.Data.EntityRepositoryProvider`3.#ctor(Deveel.Data.IDbContextOptionsFactory{`0},System.Collections.Generic.IEnumerable{Finbuckle.MultiTenant.IMultiTenantStore{`2}},Microsoft.Extensions.Logging.ILoggerFactory)">
+            <summary>
+            Constructs the provider with the given options factory
+            and tenant stores.
+            </summary>
+            <param name="optionsFactory">
+            A service that is used to create the options for the context
+            and a specific tenant.
+            </param>
+            <param name="tenantStores">
+            A list of the available stores to retrieve the tenants from.
+            </param>
+            <param name="loggerFactory">
+            A factory to create loggers for the repositories.
+            </param>
+        </member>
+        <member name="M:Deveel.Data.EntityRepositoryProvider`3.#ctor(Microsoft.EntityFrameworkCore.DbContextOptions{`0},System.Collections.Generic.IEnumerable{Finbuckle.MultiTenant.IMultiTenantStore{`2}},Microsoft.Extensions.Logging.ILoggerFactory)">
+            <summary>
+            Constructs the provider with the given options and 
+            tenant stores.
+            </summary>
+            <param name="options">
+            The instance of options that are used to create the context
+            for the tenants.
+            </param>
+            <param name="tenantStores">
+            The list of stores to retrieve the tenants from.
+            </param>
+            <param name="loggerFactory">
+            A factory to create loggers for the repositories.
+            </param>
+        </member>
+        <member name="M:Deveel.Data.EntityRepositoryProvider`3.Finalize">
             <summary>
             Destroys the instance of the provider.
             </summary>
         </member>
-        <member name="M:Deveel.Data.EntityRepositoryProvider`2.GetRepositoryAsync(System.String,System.Threading.CancellationToken)">
+        <member name="M:Deveel.Data.EntityRepositoryProvider`3.GetRepositoryAsync(System.String,System.Threading.CancellationToken)">
             <summary>
             Gets a repository for the given tenant.
             </summary>
@@ -234,7 +300,7 @@
             constructed with the given tenant.
             </exception>
         </member>
-        <member name="M:Deveel.Data.EntityRepositoryProvider`2.CreateLogger">
+        <member name="M:Deveel.Data.EntityRepositoryProvider`3.CreateLogger">
             <summary>
             Creates a logger for a repository.
             </summary>
@@ -243,7 +309,7 @@
             to log messages from the repository.
             </returns>
         </member>
-        <member name="M:Deveel.Data.EntityRepositoryProvider`2.CreateRepository(`1,Finbuckle.MultiTenant.ITenantInfo)">
+        <member name="M:Deveel.Data.EntityRepositoryProvider`3.CreateRepository(`0,Finbuckle.MultiTenant.ITenantInfo)">
             <summary>
             Creates a repository for the given context and tenant.
             </summary>
@@ -253,7 +319,7 @@
             <param name="tenantInfo"></param>
             <returns></returns>
         </member>
-        <member name="M:Deveel.Data.EntityRepositoryProvider`2.Dispose(System.Boolean)">
+        <member name="M:Deveel.Data.EntityRepositoryProvider`3.Dispose(System.Boolean)">
             <summary>
             Dispose the provider and all the repositories and contexts
             </summary>
@@ -261,7 +327,7 @@
             Indicates if the provider is disposing.
             </param>
         </member>
-        <member name="M:Deveel.Data.EntityRepositoryProvider`2.Dispose">
+        <member name="M:Deveel.Data.EntityRepositoryProvider`3.Dispose">
             <inheritdoc/>
         </member>
         <member name="T:Deveel.Data.ServiceCollectionExtensions">

--- a/src/Deveel.Repository.Manager/Data/EntityManager.cs
+++ b/src/Deveel.Repository.Manager/Data/EntityManager.cs
@@ -811,6 +811,9 @@ namespace Deveel.Data {
             if (existing == null)
                 return false;
 
+			if (Repository is IEqualityComparer<TEntity> comparer)
+				return comparer.Equals(existing, other);
+
 			if (typeof(IEquatable<TEntity>).IsAssignableFrom(typeof(TEntity)))
 				return ((IEquatable<TEntity>)existing).Equals(other);
 

--- a/src/Deveel.Repository.Manager/Deveel.Repository.Manager.xml
+++ b/src/Deveel.Repository.Manager/Deveel.Repository.Manager.xml
@@ -2023,3 +2023,12 @@
         </member>
     </members>
 </doc>
+textAccessor"/>
+            into the collection of services, if not already registered.
+            </remarks>
+            <returns>
+            Returns the given collection of services for chaining calls.
+            </returns>
+        </member>
+    </members>
+</doc>

--- a/src/Deveel.Repsotiory.MongoFramework/Deveel.Repository.MongoFramework.xml
+++ b/src/Deveel.Repsotiory.MongoFramework/Deveel.Repository.MongoFramework.xml
@@ -44,27 +44,6 @@
             </typeparam>
             <seealso cref="T:MongoFramework.IMongoDbConnection"/>
         </member>
-        <member name="T:Deveel.Data.LoggerExtensions.__TraceFindingByIdForTenantStruct">
-            <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
-        </member>
-        <member name="T:Deveel.Data.LoggerExtensions.__TraceFoundByIdForTenantStruct">
-            <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
-        </member>
-        <member name="T:Deveel.Data.LoggerExtensions.__TraceDeletingForTenantStruct">
-            <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
-        </member>
-        <member name="T:Deveel.Data.LoggerExtensions.__TraceDeletedForTenantStruct">
-            <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
-        </member>
-        <member name="T:Deveel.Data.LoggerExtensions.__TraceCreatedForTenantStruct">
-            <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
-        </member>
-        <member name="T:Deveel.Data.LoggerExtensions.__TraceUpdatingForTenantStruct">
-            <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
-        </member>
-        <member name="T:Deveel.Data.LoggerExtensions.__TraceUpdatedForTenantStruct">
-            <summary> This API supports the logging infrastructure and is not intended to be used directly from your code. It is subject to change in the future. </summary>
-        </member>
         <member name="T:Deveel.Data.MongoConnectionBuilder">
             <summary>
             An object that is used to build a <see cref="T:MongoFramework.IMongoDbConnection"/>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <RootNamespace>Deveel</RootNamespace>
-    <VersionPrefix>1.2.5</VersionPrefix>
+    <VersionPrefix>1.2.6</VersionPrefix>
     <Authors>Antonello Provenzano</Authors>
     <Company>Deveel AS</Company>
     <Copyright>(C) 2022-2023 Deveel AS</Copyright>

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/DependencyInjectionTests.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/DependencyInjectionTests.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Finbuckle.MultiTenant;
+
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Deveel.Data {
 	public static class DependencyInjectionTests {
 		[Fact]
-		public static void AddEntityRepository() {
+		public static void AddDefaultEntityRepositoryForEntity() {
 			var services = new ServiceCollection();
 			services.AddDbContext<DbContext, PersonDbContext>(options =>
 				options.UseSqlite("Data Source=:memory:", x => x.UseNetTopologySuite()));
@@ -16,5 +18,82 @@ namespace Deveel.Data {
 			Assert.NotNull(scope.ServiceProvider.GetService<IRepository<DbPerson>>());
 			Assert.NotNull(scope.ServiceProvider.GetService<EntityRepository<DbPerson>>());
 		}
+
+		[Fact]
+		public static void AddEntityRepository() {
+			var services = new ServiceCollection();
+			services.AddDbContext<DbContext, PersonDbContext>(options =>
+							options.UseSqlite("Data Source=:memory:", x => x.UseNetTopologySuite()));
+			services.AddRepository<EntityRepository<DbPerson>>(ServiceLifetime.Scoped);
+
+			var provider = services.BuildServiceProvider();
+			var scope = provider.CreateScope();
+
+			Assert.NotNull(scope.ServiceProvider.GetService<IRepository<DbPerson>>());
+			Assert.NotNull(scope.ServiceProvider.GetService<EntityRepository<DbPerson>>());
+		}
+
+		[Fact]
+		public static void AddDefaultEntityRepositoryProvider_SharedConnection() {
+			var tenantId = Guid.NewGuid().ToString();
+			var services = new ServiceCollection();
+			services.AddMultiTenant<TenantInfo>()
+				.WithInMemoryStore(options => {
+					options.Tenants.Add(new TenantInfo {
+						Id = tenantId,
+						Identifier = tenantId,
+						Name = "Test Tenant"
+					});
+				})
+				.WithStaticStrategy(tenantId);
+
+			services.AddDbContext<DbContext, PersonDbContext>((sp, options) =>
+					options.UseSqlite("Data Source=:memory:", x => x.UseNetTopologySuite()));
+
+			services.AddEntityRepositoryProvider<PersonDbContext, DbPerson>();
+
+			var provider = services.BuildServiceProvider();
+
+			Assert.NotNull(provider.GetService<IRepositoryProvider<DbPerson>>());
+			Assert.NotNull(provider.GetService<EntityRepositoryProvider<PersonDbContext, DbPerson>>());
+
+			var repository = provider.GetRequiredService<IRepositoryProvider<DbPerson>>().GetRepository(tenantId);
+
+			Assert.NotNull(repository);
+			Assert.IsType<EntityRepository<DbPerson>>(repository);
+		}
+
+		[Fact]
+		public static void AddDefaultEntityRepositoryProvider_PerTenantConnection() {
+			var tenantId = Guid.NewGuid().ToString();
+			var services = new ServiceCollection();
+			services.AddMultiTenant<TenantInfo>()
+				.WithInMemoryStore(options => {
+					options.Tenants.Add(new TenantInfo {
+						Id = tenantId,
+						Identifier = tenantId,
+						Name = "Test Tenant",
+						ConnectionString = $"Data Source=:memory:;TenantID={tenantId}"
+					});
+				})
+				.WithStaticStrategy(tenantId);
+
+			services.AddEntityRepositoryProvider<DbPerson, PersonDbContext>(tenant => {
+				return new DbContextOptionsBuilder<PersonDbContext>()
+				.UseSqlite(tenant.ConnectionString, x => x.UseNetTopologySuite())
+				.Options;
+			});
+
+			var provider = services.BuildServiceProvider();
+
+			Assert.NotNull(provider.GetService<IRepositoryProvider<DbPerson>>());
+			Assert.NotNull(provider.GetService<EntityRepositoryProvider<PersonDbContext, DbPerson>>());
+
+			var repository = provider.GetRequiredService<IRepositoryProvider<DbPerson>>().GetRepository(tenantId);
+
+			Assert.NotNull(repository);
+			Assert.IsType<EntityRepository<DbPerson>>(repository);
+		}
+
 	}
 }

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityRepositoryProviderTestSuite.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityRepositoryProviderTestSuite.cs
@@ -69,7 +69,7 @@ namespace Deveel.Data {
 				builder.UseSqlite(sqliteConnection, x => x.UseNetTopologySuite());
 				builder.LogTo(TestOutput!.WriteLine);
 			})
-				.AddRepositoryProvider<EntityRepositoryProvider<DbTenantPerson, TestDbContext>>();
+				.AddRepositoryProvider<EntityRepositoryProvider<TestDbContext, DbTenantPerson>>();
 
 			base.ConfigureServices(services);
 		}

--- a/test/Deveel.Repository.Manager.XUnit/Data/EntityManagerTestSuite_1.cs
+++ b/test/Deveel.Repository.Manager.XUnit/Data/EntityManagerTestSuite_1.cs
@@ -56,6 +56,7 @@ namespace Deveel.Data {
 			await Repository.RemoveRangeAsync(People);
 
 			await scope.DisposeAsync();
+			(Services as IDisposable)?.Dispose();
 		}
 
 		[Fact]

--- a/test/Deveel.Repository.MongoFramework.XUnit/Data/DependencyInjectionTests.cs
+++ b/test/Deveel.Repository.MongoFramework.XUnit/Data/DependencyInjectionTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using MongoFramework;
 using System.Data;
 using Finbuckle.MultiTenant;
+using Microsoft.Extensions.Logging;
 
 namespace Deveel.Data {
 	public static class DependencyInjectionTests {
@@ -117,6 +118,184 @@ namespace Deveel.Data {
 			Assert.NotNull(provider.GetService<IPageableRepository<MongoPerson>>());
 			Assert.NotNull(provider.GetService<IFilterableRepository<MongoPerson>>());
 			Assert.NotNull(provider.GetService<IQueryableRepository<MongoPerson>>());
+		}
+
+		[Fact]
+		public static void AddDefaultMongoRepositoryProvider_SharedConnection() {
+			var tenantId = Guid.NewGuid().ToString();
+
+			var services = new ServiceCollection();
+
+			services.AddMultiTenant<TenantInfo>()
+				.WithInMemoryStore(options => {
+					options.Tenants.Add(new TenantInfo {
+						Name = "test-tenant",
+						Id = tenantId,
+						Identifier = tenantId,
+						ConnectionString = "mongodb://localhost:27017/testdb"
+					});
+				});
+
+			services.AddMongoDbContext<MongoDbTenantContext>(builder => {
+				builder.UseConnection("mongodb://localhost:27017/testdb");
+			});
+
+			services.AddRepositoryProvider<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>();
+
+			var provider = services.BuildServiceProvider();
+
+			Assert.NotNull(provider.GetService<IRepositoryProvider<MongoPerson>>());
+			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>());
+
+			var repository = provider.GetRequiredService<IRepositoryProvider<MongoPerson>>().GetRepository(tenantId);
+
+			Assert.NotNull(repository);
+
+			Assert.IsType<MongoRepository<MongoPerson>>(repository);
+		}
+
+		[Fact]
+		public static void AddDefaultMongoRepositoryProvider_TenantConnection() {
+			var tenantId = Guid.NewGuid().ToString();
+			var services = new ServiceCollection();
+
+			services.AddMultiTenant<TenantInfo>()
+				.WithInMemoryStore(options => {
+					options.Tenants.Add(new TenantInfo {
+						Id = tenantId,
+						Identifier = tenantId,
+						ConnectionString = "mongodb://localhost:27017/testdb"
+					});
+				});
+
+			services.AddMongoDbContext<MongoDbTenantContext>((tenant, builder) => {
+				builder.UseConnection(tenant!.ConnectionString!);
+			});
+
+			services.AddRepositoryProvider<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>();
+
+			var provider = services.BuildServiceProvider();
+
+			Assert.NotNull(provider.GetService<IRepositoryProvider<MongoPerson>>());
+			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>());
+
+			var repository = provider.GetRequiredService<IRepositoryProvider<MongoPerson>>().GetRepository(tenantId);
+
+			Assert.NotNull(repository);
+			Assert.IsType<MongoRepository<MongoPerson>>(repository);
+		}
+
+		// Custom Repository
+
+		[Fact]
+		public static void AddCustomMongoRepository() {
+			var services = new ServiceCollection();
+
+			services.AddMongoDbContext<MongoDbContext>(builder => {
+				builder.UseConnection("mongodb://localhost:27017/testdb");
+			});
+
+			services.AddRepository<MyMongoPersonRepository>();
+
+			var provider = services.BuildServiceProvider();
+
+			Assert.NotNull(provider.GetService<MyMongoPersonRepository>());
+			Assert.NotNull(provider.GetService<MongoRepository<MongoPerson>>());
+			Assert.NotNull(provider.GetService<IRepository<MongoPerson>>());
+			Assert.NotNull(provider.GetService<IPageableRepository<MongoPerson>>());
+			Assert.NotNull(provider.GetService<IFilterableRepository<MongoPerson>>());
+			Assert.NotNull(provider.GetService<IQueryableRepository<MongoPerson>>());
+		}
+
+		[Fact]
+		public static void AddCustomMongoRepositoryProvider_SharedConnection() {
+			var tenantId = Guid.NewGuid().ToString();
+
+			var services = new ServiceCollection();
+
+			services.AddMultiTenant<TenantInfo>()
+				.WithInMemoryStore(options => {
+					options.Tenants.Add(new TenantInfo {
+						Name = "test-tenant",
+						Id = tenantId,
+						Identifier = tenantId,
+						ConnectionString = "mongodb://localhost:27017/testdb"
+					});
+				});
+
+			services.AddMongoDbContext<MongoDbTenantContext>(builder => {
+				builder.UseConnection("mongodb://localhost:27017/testdb");
+			});
+
+			services.AddRepositoryProvider<MyMongoPersonRepositoryProvider>();
+
+			var provider = services.BuildServiceProvider();
+
+			Assert.NotNull(provider.GetService<MyMongoPersonRepositoryProvider>());
+			Assert.NotNull(provider.GetService<IRepositoryProvider<MongoPerson>>());
+			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>());
+
+			var repository = provider.GetRequiredService<IRepositoryProvider<MongoPerson>>().GetRepository(tenantId);
+
+			Assert.NotNull(repository);
+
+			Assert.IsNotAssignableFrom<IMyMongoPersonRepository>(repository);
+			Assert.IsType<MongoRepository<MongoPerson>>(repository);
+		}
+
+		[Fact]
+		public static void AddCustomMongoRepositoryProvider_TenantConnection() {
+			var tenantId = Guid.NewGuid().ToString();
+			var services = new ServiceCollection();
+
+			services.AddMultiTenant<TenantInfo>()
+				.WithInMemoryStore(options => {
+					options.Tenants.Add(new TenantInfo {
+						Id = tenantId,
+						Identifier = tenantId,
+						ConnectionString = "mongodb://localhost:27017/testdb"
+					});
+				});
+
+			services.AddMongoDbContext<MongoDbTenantContext>((tenant, builder) => {
+				builder.UseConnection(tenant!.ConnectionString!);
+			});
+
+			services.AddRepositoryProvider<MyMongoPersonRepositoryProvider>();
+
+			var provider = services.BuildServiceProvider();
+
+			Assert.NotNull(provider.GetService<MyMongoPersonRepositoryProvider>());
+			Assert.NotNull(provider.GetService<IRepositoryProvider<MongoPerson>>());
+			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>());
+
+			var repository = provider.GetRequiredService<IRepositoryProvider<MongoPerson>>().GetRepository(tenantId);
+
+			Assert.NotNull(repository);
+			Assert.IsNotAssignableFrom<IMyMongoPersonRepository>(repository);
+			Assert.IsType<MongoRepository<MongoPerson>>(repository);
+		}
+
+		interface IMyMongoPersonRepository : IRepository<MongoPerson> {
+		}
+
+		interface IMyMongoPersonRepositoryProvider : IRepositoryProvider<MongoPerson> {
+			new Task<IMyMongoPersonRepository> GetRepositoryAsync(string tenantId, CancellationToken cancellationToken);
+		}
+
+		class MyMongoPersonRepository : MongoRepository<MongoPerson>, IMyMongoPersonRepository {
+			public MyMongoPersonRepository(IMongoDbContext context, ILogger<MyMongoPersonRepository>? logger = null) : base(context, logger) {
+			}
+		}
+
+		class MyMongoPersonRepositoryProvider : MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>, IMyMongoPersonRepositoryProvider {
+			public MyMongoPersonRepositoryProvider(IEnumerable<IMultiTenantStore<TenantInfo>> tenantStores, ILoggerFactory? loggerFactory = null) 
+				: base(tenantStores, loggerFactory) {
+			}
+
+			public new async Task<IMyMongoPersonRepository> GetRepositoryAsync(string tenantId, CancellationToken cancellationToken) {
+				return (MyMongoPersonRepository) await base.GetRepositoryAsync(tenantId, cancellationToken);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Review of the design of the IRepositoryProvider implementations

* The `EntityRepositoryProvider` is now using also a factory for the `DbContextOptions<TContext>`, to separate the scenarios of total separation of the databases per tenant
* Construction of the MongoRepositoryProvider has been optimized and tested