### PR TITLE
Finbuckle Tenant Resolver Service

### DIFF
--- a/.github/workflows/clean-packages.yml
+++ b/.github/workflows/clean-packages.yml
@@ -75,3 +75,11 @@ jobs:
         package-type: 'nuget'
         min-versions-to-keep: 10
         delete-only-pre-release-versions: "true"
+
+    - name: Remove the Old Deveel.Repository.Finbuckle.MultiTenant Package
+      uses: actions/delete-package-versions@v4
+      with:
+        package-name: 'Deveel.Repository.Finbuckle.MultiTenant'
+        package-type: 'nuget'
+        min-versions-to-keep: 10
+        delete-only-pre-release-versions: "true"

--- a/Deveel.Repository.sln
+++ b/Deveel.Repository.sln
@@ -52,6 +52,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Repository.Manager.E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deveel.Repository.Manager.EasyCaching.XUnit", "test\Deveel.Repository.Manager.EasyCaching.XUnit\Deveel.Repository.Manager.EasyCaching.XUnit.csproj", "{F47C196B-758D-4C05-8918-FB63C61649EB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Repository.Finbuckle.MultiTenant", "src\Deveel.Repository.Finbuckle.MultiTenant\Deveel.Repository.Finbuckle.MultiTenant.csproj", "{69E01D54-C430-4A1E-989E-5A61AB4C5B54}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -126,6 +128,10 @@ Global
 		{F47C196B-758D-4C05-8918-FB63C61649EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F47C196B-758D-4C05-8918-FB63C61649EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F47C196B-758D-4C05-8918-FB63C61649EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69E01D54-C430-4A1E-989E-5A61AB4C5B54}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69E01D54-C430-4A1E-989E-5A61AB4C5B54}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69E01D54-C430-4A1E-989E-5A61AB4C5B54}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69E01D54-C430-4A1E-989E-5A61AB4C5B54}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,6 +154,7 @@ Global
 		{638851EF-B000-490C-9035-A962279A3E9B} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 		{84D55BE2-7DAD-4CA3-A3E2-EFB4D41FA3CA} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 		{F47C196B-758D-4C05-8918-FB63C61649EB} = {50434E05-0F21-4871-AFB3-A483CEE4A300}
+		{69E01D54-C430-4A1E-989E-5A61AB4C5B54} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01FD9B16-84B3-4D99-80C1-11B2F3D65B56}

--- a/src/Deveel.Repository.Core/Data/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.Core/Data/ServiceCollectionExtensions.cs
@@ -89,7 +89,30 @@ namespace Deveel.Data {
 			return services;
 		}
 
-        public static IServiceCollection AddRepositoryProvider<TProvider>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Singleton)
+		/// <summary>
+		/// Registers a repository of the given type in the service collection.
+		/// </summary>
+		/// <typeparam name="TProvider">
+		/// The type of the repository to register.
+		/// </typeparam>
+		/// <param name="services">
+		/// The service collection to register the repository.
+		/// </param>
+		/// <param name="lifetime">
+		/// the lifetime of the repository in the service collection.
+		/// </param>
+		/// <returns>
+		/// Returns the same <see cref="IServiceCollection"/> to allow chaining.
+		/// </returns>
+		/// <exception cref="ArgumentException">
+		/// Thrown when the given <typeparamref name="TProvider"/> is not
+		/// a class or is abstract.
+		/// </exception>
+		/// <exception cref="RepositoryException">
+		/// Thrown when the given <typeparamref name="TProvider"/> is not a valid
+		/// repository type.
+		/// </exception>
+		public static IServiceCollection AddRepositoryProvider<TProvider>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Singleton)
             where TProvider : class
 			=> services.AddRepositoryProvider(typeof(TProvider), lifetime);
 

--- a/src/Deveel.Repository.EntityFramework/Data/EntityRepositoryProvider_T3.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/EntityRepositoryProvider_T3.cs
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Reflection;
-
 using Finbuckle.MultiTenant;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Deveel.Data {
 	/// <summary>
@@ -30,69 +26,17 @@ namespace Deveel.Data {
 	/// <typeparam name="TEntity">
 	/// The type of entity managed by the repository
 	/// </typeparam>
+	/// <typeparam name="TKey">
+	/// The type of the key of the entity managed by the repository.
+	/// </typeparam>
 	/// <typeparam name="TContext">
 	/// The type of <see cref="DbContext"/> used to manage the entities
 	/// </typeparam>
-	public class EntityRepositoryProvider<TContext, TEntity> : EntityRepositoryProvider<TContext, TEntity, TenantInfo>
+	public class EntityRepositoryProvider<TContext, TEntity, TKey> : EntityRepositoryProviderBase<TContext, TEntity>,
+		IRepositoryProvider<TEntity, TKey>
 		where TContext : DbContext
-		where TEntity : class {
-		/// <summary>
-		/// Constructs the provider with the given options and tenant stores.
-		/// </summary>
-		/// <param name="optionsFactory">
-		/// A service that is used to create the options for the context
-		/// and a specific tenant.
-		/// for the tenants.
-		/// </param>
-		/// <param name="tenantStores">
-		/// A list of the available stores to retrieve the tenants from.
-		/// </param>
-		/// <param name="loggerFactory">
-		/// A factory to create loggers for the repositories.
-		/// </param>
-		public EntityRepositoryProvider(IDbContextOptionsFactory<TContext> optionsFactory, IEnumerable<IMultiTenantStore<TenantInfo>> tenantStores, ILoggerFactory? loggerFactory = null) 
-			: base(optionsFactory, tenantStores, loggerFactory) {
-		}
-
-		/// <summary>
-		/// Constructs the provider with the given options and 
-		/// tenant stores.
-		/// </summary>
-		/// <param name="options">
-		/// The instance of options that are used to create the context
-		/// for the tenants.
-		/// </param>
-		/// <param name="tenantStores">
-		/// The list of stores to retrieve the tenants from.
-		/// </param>
-		/// <param name="loggerFactory">
-		/// A factory to create loggers for the repositories.
-		/// </param>
-		public EntityRepositoryProvider(DbContextOptions<TContext> options, IEnumerable<IMultiTenantStore<TenantInfo>> tenantStores, ILoggerFactory? loggerFactory = null) 
-			: base(options, tenantStores, loggerFactory) {
-		}
-	}
-
-	/// <summary>
-	/// An implementation of <see cref="IRepositoryProvider{TEntity}"/> that
-	/// allows to create <see cref="EntityRepository{TEntity}"/> instances
-	/// in a multi-tenant context.
-	/// </summary>
-	/// <typeparam name="TEntity">
-	/// The type of entity managed by the repository
-	/// </typeparam>
-	/// <typeparam name="TContext">
-	/// The type of <see cref="DbContext"/> used to manage the entities
-	/// </typeparam>
-	/// <typeparam name="TTenantInfo">
-	/// The type of the tenant that is is ued to resolve the context
-	/// of the tenant.
-	/// </typeparam>
-	public class EntityRepositoryProvider<TContext, TEntity, TTenantInfo> : EntityRepositoryProviderBase<TContext, TEntity, TTenantInfo>,
-		IRepositoryProvider<TEntity>
-        where TContext : DbContext
-        where TEntity : class 
-		where TTenantInfo : class, ITenantInfo, new() {
+		where TEntity : class 
+		where TKey : notnull {
 
 		/// <summary>
 		/// Constructs the provider with the given options factory
@@ -102,17 +46,17 @@ namespace Deveel.Data {
 		/// A service that is used to create the options for the context
 		/// and a specific tenant.
 		/// </param>
-		/// <param name="tenantStores">
-		/// A list of the available stores to retrieve the tenants from.
+		/// <param name="tenantResolver">
+		/// A service that is used to resolve the tenant for a given context.
 		/// </param>
 		/// <param name="loggerFactory">
 		/// A factory to create loggers for the repositories.
 		/// </param>
-        public EntityRepositoryProvider(
+		public EntityRepositoryProvider(
 			IDbContextOptionsFactory<TContext> optionsFactory,
-			IEnumerable<IMultiTenantStore<TTenantInfo>> tenantStores,
-			ILoggerFactory? loggerFactory = null) : base(optionsFactory, tenantStores, loggerFactory) {
-        }
+			IRepositoryTenantResolver tenantResolver,
+			ILoggerFactory? loggerFactory = null) : base(optionsFactory, tenantResolver, loggerFactory) {
+		}
 
 		/// <summary>
 		/// Constructs the provider with the given options and 
@@ -122,17 +66,17 @@ namespace Deveel.Data {
 		/// The instance of options that are used to create the context
 		/// for the tenants.
 		/// </param>
-		/// <param name="tenantStores">
-		/// The list of stores to retrieve the tenants from.
+		/// <param name="tenantResolver">
+		/// A service that is used to resolve the tenant for a given context.
 		/// </param>
 		/// <param name="loggerFactory">
 		/// A factory to create loggers for the repositories.
 		/// </param>
 		public EntityRepositoryProvider(
 			DbContextOptions<TContext> options,
-			IEnumerable<IMultiTenantStore<TTenantInfo>> tenantStores,
-			ILoggerFactory? loggerFactory = null) 
-			: base(options, tenantStores, loggerFactory) {
+			IRepositoryTenantResolver tenantResolver,
+			ILoggerFactory? loggerFactory = null)
+			: base(options, tenantResolver, loggerFactory) {
 
 		}
 
@@ -153,14 +97,11 @@ namespace Deveel.Data {
 		/// Thrown when the tenant was not found or the repository could not be
 		/// constructed with the given tenant.
 		/// </exception>
-        protected virtual async Task<EntityRepository<TEntity>> GetRepositoryAsync(string tenantId, CancellationToken cancellationToken = default) {
-			return await base.GetRepositoryAsync<EntityRepository<TEntity>>(tenantId);
-        }
+		protected virtual async Task<EntityRepository<TEntity, TKey>> GetRepositoryAsync(string tenantId, CancellationToken cancellationToken = default) {
+			return await base.GetRepositoryAsync<EntityRepository<TEntity, TKey>>(tenantId);
+		}
 
-		async Task<IRepository<TEntity>> IRepositoryProvider<TEntity>.GetRepositoryAsync(string tenantId, CancellationToken cancellationToken)
-			=> await GetRepositoryAsync(tenantId, cancellationToken);
-
-		async Task<IRepository<TEntity, object>> IRepositoryProvider<TEntity, object>.GetRepositoryAsync(string tenantId, CancellationToken cancellationToken)
+		async Task<IRepository<TEntity, TKey>> IRepositoryProvider<TEntity, TKey>.GetRepositoryAsync(string tenantId, CancellationToken cancellationToken)
 			=> await GetRepositoryAsync(tenantId, cancellationToken);
 
 		/// <summary>
@@ -171,11 +112,11 @@ namespace Deveel.Data {
 		/// </param>
 		/// <param name="tenantInfo"></param>
 		/// <returns></returns>
-        protected virtual EntityRepository<TEntity> CreateRepository(TContext dbContext, ITenantInfo tenantInfo) {
-            var logger = base.CreateLogger();
-            return new EntityRepository<TEntity>(dbContext, tenantInfo, logger);
-        }
+		protected virtual EntityRepository<TEntity, TKey> CreateRepository(TContext dbContext, ITenantInfo tenantInfo) {
+			var logger = CreateLogger();
+			return new EntityRepository<TEntity, TKey>(dbContext, tenantInfo, logger);
+		}
 
-		internal override object CreateRepositoryInternal(TContext context, TTenantInfo tenant) => CreateRepository(context, tenant);
+		internal override object CreateRepositoryInternal(TContext context, ITenantInfo tenant) => CreateRepository(context, tenant);
 	}
 }

--- a/src/Deveel.Repository.EntityFramework/Deveel.Repository.EntityFramework.csproj
+++ b/src/Deveel.Repository.EntityFramework/Deveel.Repository.EntityFramework.csproj
@@ -19,6 +19,7 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Deveel.Repository.Core\Deveel.Repository.Core.csproj" />
+	  <ProjectReference Include="..\Deveel.Repository.Finbuckle.MultiTenant\Deveel.Repository.Finbuckle.MultiTenant.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Deveel.Repository.Finbuckle.MultiTenant/Data/IRepositoryTenantResolver.cs
+++ b/src/Deveel.Repository.Finbuckle.MultiTenant/Data/IRepositoryTenantResolver.cs
@@ -1,0 +1,39 @@
+﻿// Copyright 2023 Deveel AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Finbuckle.MultiTenant;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// A service that resolves the tenant information
+	/// from a given identifier.
+	/// </summary>
+	public interface IRepositoryTenantResolver {
+		/// <summary>
+		/// Finds the tenant information from the given identifier.
+		/// </summary>
+		/// <param name="tenantId">
+		/// The unique identifier of the tenant to find.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token that can be used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <see cref="ITenantInfo"/> that
+		/// describes the tenant identified by the given identifier,
+		/// or <c>null</c> if no tenant was found.
+		/// </returns>
+		Task<ITenantInfo?> FindTenantAsync(string tenantId, CancellationToken cancellationToken = default);
+	}
+}

--- a/src/Deveel.Repository.Finbuckle.MultiTenant/Data/RepositoryTenantResolver.cs
+++ b/src/Deveel.Repository.Finbuckle.MultiTenant/Data/RepositoryTenantResolver.cs
@@ -1,0 +1,71 @@
+﻿// Copyright 2023 Deveel AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Finbuckle.MultiTenant;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// A default implementation of <see cref="IRepositoryTenantResolver"/>
+	/// that uses the registered instances of <see cref="IMultiTenantStore{TTenantInfo}"/>
+	/// to resolve the tenant information.	
+	/// </summary>
+	/// <typeparam name="TTenantInfo">
+	/// The type of the tenant information object to resolve.
+	/// </typeparam>
+	public class RepositoryTenantResolver<TTenantInfo> : IRepositoryTenantResolver where TTenantInfo : class, ITenantInfo, new() {
+		private readonly IEnumerable<IMultiTenantStore<TTenantInfo>>? stores;
+
+		/// <summary>
+		/// Constructs the resolver by using the given stores.
+		/// </summary>
+		/// <param name="stores">
+		/// The list of stores to use to resolve the tenant information.
+		/// </param>
+		public RepositoryTenantResolver(IEnumerable<IMultiTenantStore<TTenantInfo>>? stores) {
+			this.stores = stores;
+		}
+
+		/// <inheritdoc/>
+		public async Task<ITenantInfo?> FindTenantAsync(string tenantId, CancellationToken cancellationToken = default) {
+			try {
+				if (stores == null)
+					return null;
+
+				foreach (var store in stores) {
+					var tenant = await store.TryGetAsync(tenantId);
+					if (tenant != null)
+						return tenant;
+
+					tenant = await store.TryGetByIdentifierAsync(tenantId);
+
+					if (tenant != null)
+						return tenant;
+
+					cancellationToken.ThrowIfCancellationRequested();
+				}
+
+				return null;
+			} catch (Exception ex) {
+				// TODO: should we log this?
+				throw new RepositoryException("Unable to resolve the tenant because of an error", ex);
+			}
+		}
+	}
+}

--- a/src/Deveel.Repository.Finbuckle.MultiTenant/Data/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.Finbuckle.MultiTenant/Data/ServiceCollectionExtensions.cs
@@ -1,0 +1,74 @@
+﻿// Copyright 2023 Deveel AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Finbuckle.MultiTenant;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// Extends the <see cref="IServiceCollection"/> to add methods
+	/// to register the <see cref="IRepositoryTenantResolver"/> service.
+	/// </summary>
+	public static class ServiceCollectionExtensions {
+		/// <summary>
+		/// Registers the default <see cref="IRepositoryTenantResolver"/> service.
+		/// </summary>
+		/// <typeparam name="TTenantInfo">
+		/// The type of the tenant information object.
+		/// </typeparam>
+		/// <param name="services">
+		/// The collection of services to register the resolver into.
+		/// </param>
+		/// <returns>
+		/// Returns the same instance of the <paramref name="services"/>
+		/// for chaining calls.
+		/// </returns>
+		public static IServiceCollection AddRepositoryTenantResolver<TTenantInfo>(this IServiceCollection services)
+			where TTenantInfo : class, ITenantInfo, new()
+			=> services.AddRepositoryTenantResolver(typeof(RepositoryTenantResolver<TTenantInfo>), ServiceLifetime.Scoped);
+
+		/// <summary>
+		/// Registers the given tenant resolver service.
+		/// </summary>
+		/// <param name="services">
+		/// The collection of services to register the resolver into.
+		/// </param>
+		/// <param name="serviceType">
+		/// The type of the resolver to register.
+		/// </param>
+		/// <param name="lifetime">
+		/// The lifetime of the service.
+		/// </param>
+		/// <returns>
+		/// Returns the same instance of the <paramref name="services"/>
+		/// for chaining calls.
+		/// </returns>
+		/// <exception cref="ArgumentException"></exception>
+		public static IServiceCollection AddRepositoryTenantResolver(this IServiceCollection services, Type serviceType, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
+			ArgumentNullException.ThrowIfNull(serviceType);
+
+			if (!typeof(IRepositoryTenantResolver).IsAssignableFrom(serviceType))
+				throw new ArgumentException($"The type {serviceType} is not assignable to {typeof(IRepositoryTenantResolver)}");
+
+			if (!serviceType.IsClass || serviceType.IsAbstract)
+				throw new ArgumentException($"The type {serviceType} is not a concrete class");
+
+			services.TryAdd(ServiceDescriptor.Describe(typeof(IRepositoryTenantResolver), serviceType, lifetime));
+			services.Add(ServiceDescriptor.Describe(serviceType, serviceType, lifetime));
+			return services;
+		}
+	}
+}

--- a/src/Deveel.Repository.Finbuckle.MultiTenant/Deveel.Repository.Finbuckle.MultiTenant.csproj
+++ b/src/Deveel.Repository.Finbuckle.MultiTenant/Deveel.Repository.Finbuckle.MultiTenant.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>Deveel Repository Finbuckle Multi-Tenant Extension</Title>
+    <Description>This package provides some helpers and extensions to the Finbuckle Multi-Tenant framework to work with repositories</Description>
+    <PackageTags>repository;multitenant;finbuckle;extensions;tenant;tenantinfo;store;data;multitenancy</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Finbuckle.MultiTenant" Version="6.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Deveel.Repository.Core\Deveel.Repository.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Deveel.Repsotiory.MongoFramework/Data/MongoRepositoryProvider_T3.cs
+++ b/src/Deveel.Repsotiory.MongoFramework/Data/MongoRepositoryProvider_T3.cs
@@ -32,35 +32,31 @@ namespace Deveel.Data {
 	/// <typeparam name="TEntity">
 	/// The type of the entity to be managed by the repository.
 	/// </typeparam>
-	/// <typeparam name="TTenantInfo">
-	/// The type of the tenant information to be used to create the context
+	/// <typeparam name="TKey">
+	/// The type of the key of the entity to be managed by the repository.
 	/// </typeparam>
-	public class MongoRepositoryProvider<TContext, TEntity, TTenantInfo> : MongoRepositoryProviderBase<TContext, TEntity, TTenantInfo>,
-		IRepositoryProvider<TEntity>
+	public class MongoRepositoryProvider<TContext, TEntity, TKey> : MongoRepositoryProviderBase<TContext, TEntity>,
+		IRepositoryProvider<TEntity, TKey>
 		where TContext : class, IMongoDbContext
-		where TTenantInfo : class, ITenantInfo, new()
-		where TEntity : class {
+		where TEntity : class
+		where TKey : notnull {
 
 		/// <summary>
 		/// Constructs the provider with a given set of stores to be used to
 		/// resolve the tenant information and connection string.
 		/// </summary>
-		/// <param name="stores">
-		/// The set of stores to be used to resolve the tenant information
-		/// and connection string.
+		/// <param name="tenantResolver">
+		/// A service to be used to resolve the tenant information.
 		/// </param>
 		/// <param name="loggerFactory">
 		/// A factory to create the logger to be used by the repository.
 		/// </param>
 		public MongoRepositoryProvider(
-			IEnumerable<IMultiTenantStore<TTenantInfo>>? stores = null,
-			ILoggerFactory? loggerFactory = null) : base(stores, loggerFactory) {
+			IRepositoryTenantResolver tenantResolver,
+			ILoggerFactory? loggerFactory = null) : base(tenantResolver, loggerFactory) {
 		}
 
-		async Task<IRepository<TEntity, object>> IRepositoryProvider<TEntity, object>.GetRepositoryAsync(string tenantId, CancellationToken cancellationToken) 
-			=> await GetRepositoryAsync(tenantId, cancellationToken);
-
-		async Task<IRepository<TEntity>> IRepositoryProvider<TEntity>.GetRepositoryAsync(string tenantId, System.Threading.CancellationToken cancellationToken)
+		async Task<IRepository<TEntity, TKey>> IRepositoryProvider<TEntity, TKey>.GetRepositoryAsync(string tenantId, CancellationToken cancellationToken)
 			=> await GetRepositoryAsync(tenantId, cancellationToken);
 
 		/// <summary>
@@ -75,12 +71,11 @@ namespace Deveel.Data {
 		/// </param>
 		/// <returns></returns>
 		/// <exception cref="RepositoryException"></exception>
-		public async Task<MongoRepository<TEntity>> GetRepositoryAsync(string tenantId, CancellationToken cancellationToken = default) {
-			return await GetRepositoryAsync<MongoRepository<TEntity>>(tenantId, cancellationToken);
+		public async Task<MongoRepository<TEntity, TKey>> GetRepositoryAsync(string tenantId, CancellationToken cancellationToken = default) {
+			return await GetRepositoryAsync<MongoRepository<TEntity, TKey>>(tenantId, cancellationToken);
 		}
 
-		internal override object CreateRepositoryInternal(TContext context) =>
-			CreateRepository(context);
+		internal override object CreateRepositoryInternal(TContext context) => CreateRepository(context);
 
 		/// <summary>
 		/// Creates an instance of <see cref="MongoRepository{TEntity}"/> for
@@ -96,8 +91,8 @@ namespace Deveel.Data {
 		/// Returns an instance of <see cref="MongoRepository{TEntity}"/> that
 		/// can be used to manage the entity of type <typeparamref name="TEntity"/>.
 		/// </returns>
-		protected virtual MongoRepository<TEntity> CreateRepository(TContext context, ILogger logger) {
-			return new MongoRepository<TEntity>(context, logger);
+		protected virtual MongoRepository<TEntity, TKey> CreateRepository(TContext context, ILogger logger) {
+			return new MongoRepository<TEntity, TKey>(context, logger);
 		}
 
 		/// <summary>
@@ -110,8 +105,8 @@ namespace Deveel.Data {
 		/// Returns an instance of <see cref="MongoRepository{TEntity}"/> that
 		/// is used to manage the entity of type <typeparamref name="TEntity"/>.
 		/// </returns>
-        protected virtual MongoRepository<TEntity> CreateRepository(TContext context) {
-            return CreateRepository(context, CreateLogger());
-        }
+		protected virtual MongoRepository<TEntity, TKey> CreateRepository(TContext context) {
+			return CreateRepository(context, CreateLogger());
+		}
 	}
 }

--- a/src/Deveel.Repsotiory.MongoFramework/Deveel.Repository.MongoFramework.csproj
+++ b/src/Deveel.Repsotiory.MongoFramework/Deveel.Repository.MongoFramework.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="MongoFramework" Version="0.29.0" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\Deveel.Repository.Core\Deveel.Repository.Core.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Deveel.Repository.Finbuckle.MultiTenant\Deveel.Repository.Finbuckle.MultiTenant.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <RootNamespace>Deveel</RootNamespace>
-    <VersionPrefix>1.2.7</VersionPrefix>
+    <VersionPrefix>1.2.8</VersionPrefix>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/DependencyInjectionTests.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/DependencyInjectionTests.cs
@@ -45,9 +45,9 @@ namespace Deveel.Data {
 						Identifier = tenantId,
 						Name = "Test Tenant"
 					});
-				})
-				.WithStaticStrategy(tenantId);
+				});
 
+			services.AddRepositoryTenantResolver<TenantInfo>();
 			services.AddDbContext<DbContext, PersonDbContext>((sp, options) =>
 					options.UseSqlite("Data Source=:memory:", x => x.UseNetTopologySuite()));
 
@@ -76,8 +76,9 @@ namespace Deveel.Data {
 						Name = "Test Tenant",
 						ConnectionString = $"Data Source=:memory:;TenantID={tenantId}"
 					});
-				})
-				.WithStaticStrategy(tenantId);
+				});
+
+			services.AddRepositoryTenantResolver<TenantInfo>();
 
 			services.AddEntityRepositoryProvider<DbPerson, PersonDbContext>((tenant, builder) => {
 				builder.UseSqlite(tenant.ConnectionString!, x => x.UseNetTopologySuite());
@@ -106,8 +107,9 @@ namespace Deveel.Data {
 						Name = "Test Tenant",
 						ConnectionString = $"Data Source=:memory:;TenantID={tenantId}"
 					});
-				})
-				.WithStaticStrategy(tenantId);
+				});
+
+			services.AddRepositoryTenantResolver<TenantInfo>();
 
 			services.AddDbContextOptionsFactory<PersonDbContext>((tenant, builder) => {
 				builder.UseSqlite(tenant.ConnectionString!, x => x.UseNetTopologySuite());
@@ -138,8 +140,9 @@ namespace Deveel.Data {
 						Name = "Test Tenant",
 						ConnectionString = $"Data Source=:memory:;TenantID={tenantId}"
 					});
-				})
-				.WithStaticStrategy(tenantId);
+				});
+
+			services.AddRepositoryTenantResolver<TenantInfo>();
 
 			services.AddDbContextOptionsFactory<PersonDbContext>((tenant, builder) => {
 				builder.UseSqlite(tenant.ConnectionString!, x => x.UseNetTopologySuite());
@@ -165,8 +168,8 @@ namespace Deveel.Data {
 		}
 
 		class MyEntityRepositoryProviderWithNoKey : EntityRepositoryProvider<PersonDbContext, DbPerson> {
-			public MyEntityRepositoryProviderWithNoKey(IDbContextOptionsFactory<PersonDbContext> factory, IEnumerable<IMultiTenantStore<TenantInfo>> tenantStores, ILoggerFactory? loggerFactory = null) 
-				: base(factory, tenantStores, loggerFactory) {
+			public MyEntityRepositoryProviderWithNoKey(IDbContextOptionsFactory<PersonDbContext> factory, IRepositoryTenantResolver tenantResolver, ILoggerFactory? loggerFactory = null) 
+				: base(factory, tenantResolver, loggerFactory) {
 			}
 
 			protected override EntityRepository<DbPerson> CreateRepository(PersonDbContext dbContext, ITenantInfo tenantInfo) 
@@ -178,11 +181,11 @@ namespace Deveel.Data {
 			}
 		}
 
-		class MyEntityRepositoryProvider : EntityRepositoryProvider<PersonDbContext, DbPerson, Guid, TenantInfo> {
-			public MyEntityRepositoryProvider(IDbContextOptionsFactory<PersonDbContext> optionsFactory, IEnumerable<IMultiTenantStore<TenantInfo>> tenantStores, ILoggerFactory? loggerFactory = null) : base(optionsFactory, tenantStores, loggerFactory) {
+		class MyEntityRepositoryProvider : EntityRepositoryProvider<PersonDbContext, DbPerson, Guid> {
+			public MyEntityRepositoryProvider(IDbContextOptionsFactory<PersonDbContext> optionsFactory, IRepositoryTenantResolver tenantResolver, ILoggerFactory? loggerFactory = null) : base(optionsFactory, tenantResolver, loggerFactory) {
 			}
 
-			public MyEntityRepositoryProvider(DbContextOptions<PersonDbContext> options, IEnumerable<IMultiTenantStore<TenantInfo>> tenantStores, ILoggerFactory? loggerFactory = null) : base(options, tenantStores, loggerFactory) {
+			public MyEntityRepositoryProvider(DbContextOptions<PersonDbContext> options, IRepositoryTenantResolver tenantResolver, ILoggerFactory? loggerFactory = null) : base(options, tenantResolver, loggerFactory) {
 			}
 
 			protected override EntityRepository<DbPerson, Guid> CreateRepository(PersonDbContext dbContext, ITenantInfo tenantInfo)

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityRepositoryProviderTestSuite.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityRepositoryProviderTestSuite.cs
@@ -64,6 +64,7 @@ namespace Deveel.Data {
 					options.Tenants.Add(TenantInfo);
 				});
 
+			services.AddRepositoryTenantResolver<TenantInfo>();
 			services.AddDbContext<DbContext, TestDbContext>(builder => {
 				builder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTrackingWithIdentityResolution);
 				builder.UseSqlite(sqliteConnection, x => x.UseNetTopologySuite());

--- a/test/Deveel.Repository.MongoFramework.XUnit/Data/CustomMongoRepositoryProviderTests.cs
+++ b/test/Deveel.Repository.MongoFramework.XUnit/Data/CustomMongoRepositoryProviderTests.cs
@@ -41,6 +41,8 @@ namespace Deveel.Data {
                     });
                 });
 
+			services.AddRepositoryTenantResolver<TenantInfo>();
+
             AddMongoDbContext(services);
 
             services.AddRepositoryController();
@@ -78,12 +80,12 @@ namespace Deveel.Data {
 			Assert.IsType<PersonRepositoryProvider>(RepositoryProvider);
 		}
 
-		protected class PersonRepositoryProvider : MongoRepositoryProvider<PersonsDbContext, MongoTenantPerson, TenantInfo> {
-            public PersonRepositoryProvider(IEnumerable<IMultiTenantStore<TenantInfo>> stores, ILoggerFactory? loggerFactory = null) 
-				:base(stores, loggerFactory) {
+		protected class PersonRepositoryProvider : MongoRepositoryProvider<PersonsDbContext, MongoTenantPerson> {
+            public PersonRepositoryProvider(IRepositoryTenantResolver tenantResolver, ILoggerFactory? loggerFactory = null) 
+				:base(tenantResolver, loggerFactory) {
             }
 
-            protected override PersonsDbContext CreateContext(IMongoDbConnection connection, TenantInfo tenantInfo) {
+            protected override PersonsDbContext CreateContext(IMongoDbConnection connection, ITenantInfo tenantInfo) {
                 return new PersonsDbContext(connection.ForContext<PersonsDbContext>(), tenantInfo?.Id ?? throw new InvalidOperationException());
             }
 

--- a/test/Deveel.Repository.MongoFramework.XUnit/Data/DependencyInjectionTests.cs
+++ b/test/Deveel.Repository.MongoFramework.XUnit/Data/DependencyInjectionTests.cs
@@ -137,16 +137,18 @@ namespace Deveel.Data {
 					});
 				});
 
+			services.AddRepositoryTenantResolver<TenantInfo>();
+
 			services.AddMongoDbContext<MongoDbTenantContext>(builder => {
 				builder.UseConnection("mongodb://localhost:27017/testdb");
 			});
 
-			services.AddRepositoryProvider<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>();
+			services.AddRepositoryProvider<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson>>();
 
 			var provider = services.BuildServiceProvider();
 
 			Assert.NotNull(provider.GetService<IRepositoryProvider<MongoPerson>>());
-			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>());
+			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson>>());
 
 			var repository = provider.GetRequiredService<IRepositoryProvider<MongoPerson>>().GetRepository(tenantId);
 
@@ -169,16 +171,18 @@ namespace Deveel.Data {
 					});
 				});
 
+			services.AddRepositoryTenantResolver<TenantInfo>();
+
 			services.AddMongoDbContext<MongoDbTenantContext>((tenant, builder) => {
 				builder.UseConnection(tenant!.ConnectionString!);
 			});
 
-			services.AddRepositoryProvider<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>();
+			services.AddRepositoryProvider<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson>>();
 
 			var provider = services.BuildServiceProvider();
 
 			Assert.NotNull(provider.GetService<IRepositoryProvider<MongoPerson>>());
-			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>());
+			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson>>());
 
 			var repository = provider.GetRequiredService<IRepositoryProvider<MongoPerson>>().GetRepository(tenantId);
 
@@ -224,6 +228,8 @@ namespace Deveel.Data {
 					});
 				});
 
+			services.AddRepositoryTenantResolver<TenantInfo>();
+
 			services.AddMongoDbContext<MongoDbTenantContext>(builder => {
 				builder.UseConnection("mongodb://localhost:27017/testdb");
 			});
@@ -234,7 +240,7 @@ namespace Deveel.Data {
 
 			Assert.NotNull(provider.GetService<MyMongoPersonRepositoryProviderNoKey>());
 			Assert.NotNull(provider.GetService<IRepositoryProvider<MongoPerson>>());
-			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>());
+			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson>>());
 
 			var repository = provider.GetRequiredService<IRepositoryProvider<MongoPerson>>().GetRepository(tenantId);
 
@@ -259,6 +265,8 @@ namespace Deveel.Data {
 					});
 				});
 
+			services.AddRepositoryTenantResolver<TenantInfo>();
+
 			services.AddMongoDbContext<MongoDbTenantContext>((tenant, builder) => {
 				builder.UseConnection(tenant!.ConnectionString!);
 			});
@@ -269,7 +277,7 @@ namespace Deveel.Data {
 
 			Assert.NotNull(provider.GetService<MyMongoPersonRepositoryProviderNoKey>());
 			Assert.NotNull(provider.GetService<IRepositoryProvider<MongoPerson>>());
-			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>>());
+			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson>>());
 
 			var repository = provider.GetRequiredService<IRepositoryProvider<MongoPerson>>().GetRepository(tenantId);
 
@@ -292,6 +300,8 @@ namespace Deveel.Data {
 					});
 				});
 
+			services.AddRepositoryTenantResolver<TenantInfo>();
+
 			services.AddMongoDbContext<MongoDbTenantContext>((tenant, builder) => {
 				builder.UseConnection(tenant!.ConnectionString!);
 			});
@@ -302,7 +312,7 @@ namespace Deveel.Data {
 
 			Assert.NotNull(provider.GetService<MyMongoPersonRepositoryProvider>());
 			Assert.NotNull(provider.GetService<IRepositoryProvider<MongoPerson, ObjectId>>());
-			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, ObjectId, TenantInfo>>());
+			Assert.NotNull(provider.GetService<MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, ObjectId>>());
 
 			var repository = provider.GetRequiredService<IRepositoryProvider<MongoPerson, ObjectId>>().GetRepository(tenantId);
 
@@ -324,9 +334,9 @@ namespace Deveel.Data {
 			}
 		}
 
-		class MyMongoPersonRepositoryProviderNoKey : MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, TenantInfo>, IMyMongoPersonRepositoryProvider {
-			public MyMongoPersonRepositoryProviderNoKey(IEnumerable<IMultiTenantStore<TenantInfo>> tenantStores, ILoggerFactory? loggerFactory = null) 
-				: base(tenantStores, loggerFactory) {
+		class MyMongoPersonRepositoryProviderNoKey : MongoRepositoryProvider<MongoDbTenantContext, MongoPerson>, IMyMongoPersonRepositoryProvider {
+			public MyMongoPersonRepositoryProviderNoKey(IRepositoryTenantResolver tenantResolver, ILoggerFactory? loggerFactory = null) 
+				: base(tenantResolver, loggerFactory) {
 			}
 
 			protected override MongoRepository<MongoPerson> CreateRepository(MongoDbTenantContext context)
@@ -342,9 +352,9 @@ namespace Deveel.Data {
 			}
 		}
 
-		class MyMongoPersonRepositoryProvider : MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, ObjectId, TenantInfo> {
-			public MyMongoPersonRepositoryProvider(IEnumerable<IMultiTenantStore<TenantInfo>> tenantStores, ILoggerFactory? loggerFactory = null)
-				: base(tenantStores, loggerFactory) {
+		class MyMongoPersonRepositoryProvider : MongoRepositoryProvider<MongoDbTenantContext, MongoPerson, ObjectId> {
+			public MyMongoPersonRepositoryProvider(IRepositoryTenantResolver tenantResolver, ILoggerFactory? loggerFactory = null)
+				: base(tenantResolver, loggerFactory) {
 			}
 
 			protected override MongoRepository<MongoPerson, ObjectId> CreateRepository(MongoDbTenantContext context) 

--- a/test/Deveel.Repository.MongoFramework.XUnit/Data/MongoRepositoryProviderTests.cs
+++ b/test/Deveel.Repository.MongoFramework.XUnit/Data/MongoRepositoryProviderTests.cs
@@ -42,6 +42,8 @@ namespace Deveel.Data {
 					}) ;
 				});
 
+			services.AddRepositoryTenantResolver<TenantInfo>();
+
 			AddMongoDbContext(services);
 			
 			services.AddRepositoryController();
@@ -51,7 +53,7 @@ namespace Deveel.Data {
 			//var builder = services.AddMongoTenantContext();
 			//builder.UseTenantConnection();
 
-			services.AddRepositoryProvider<MongoRepositoryProvider<MongoDbTenantContext, MongoTenantPerson, TenantInfo>>();
+			services.AddRepositoryProvider<MongoRepositoryProvider<MongoDbTenantContext, MongoTenantPerson>>();
 		}
 
         protected override async Task InitializeAsync() {


### PR DESCRIPTION
Changes to the design of the IRepositoryProvider<TEntity, TKey> implementations for the MongoDB and EntityFramework layers.

* Implementation of a new library Deveel.Repository.Finbuckle.MultiTenant to provide the tenant resolution service
* The TenantInfo constraint was removed from the  MongoRepositoryProvider and EntityRepositoryProvider implementations