### PR TITLE
Update Entity Framework Core and SQLitePCLRaw for .NET 8.0-10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: echo "DOTNET_FX_VERSION=net10.0" >> $GITHUB_ENV
              
     - name: Setup .NET ${{ matrix.dotnet }} Framework
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ matrix.dotnet }}
      

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -27,7 +27,7 @@ jobs:
       run: echo "DOTNET_FX_VERSION=net8.0" >> $GITHUB_ENV
     
     - name: Setup .NET ${{ matrix.dotnet }} Framework
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: ${{ matrix.dotnet }}
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Emit .NET 10.0 Framework Version
       if: matrix.dotnet == '10.0.x'
-      run: echo "DOTNET_FX_VERSION=net8.0" >> $GITHUB_ENV
+      run: echo "DOTNET_FX_VERSION=net10.0" >> $GITHUB_ENV
     
     - name: Setup .NET ${{ matrix.dotnet }} Framework
       uses: actions/setup-dotnet@v5

--- a/benchmarks/Deveel.Repository.EntityFramework.Benchmarks/Deveel.Repository.EntityFramework.Benchmarks.csproj
+++ b/benchmarks/Deveel.Repository.EntityFramework.Benchmarks/Deveel.Repository.EntityFramework.Benchmarks.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Testcontainers.MySql" Version="4.6.0" />
+    <PackageReference Include="Testcontainers.MySql" Version="4.11.0" />
     <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="8.0.14" Condition="$(TargetFramework) == 'net8.0'"/>
       <PackageReference Include="MySql.EntityFrameworkCore" Version="9.0.11" Condition="$(TargetFramework) == 'net9.0'"/>

--- a/src/Deveel.Repository.EntityFramework/Deveel.Repository.EntityFramework.csproj
+++ b/src/Deveel.Repository.EntityFramework/Deveel.Repository.EntityFramework.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.14" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.15" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />

--- a/test/Deveel.Repository.Core.XUnit/Deveel.Repository.Core.XUnit.csproj
+++ b/test/Deveel.Repository.Core.XUnit/Deveel.Repository.Core.XUnit.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />

--- a/test/Deveel.Repository.DynamicLinq.XUnit/Deveel.Repository.DynamicLinq.XUnit.csproj
+++ b/test/Deveel.Repository.DynamicLinq.XUnit/Deveel.Repository.DynamicLinq.XUnit.csproj
@@ -8,4 +8,8 @@
     <ProjectReference Include="..\..\src\Deveel.Repository.DynamicLinq\Deveel.Repository.DynamicLinq.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+  </ItemGroup>
+
 </Project>

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/DependencyInjectionTests.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/DependencyInjectionTests.cs
@@ -3,11 +3,13 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using SQLitePCL;
 
 namespace Deveel.Data {
 	public static class DependencyInjectionTests {
-		[Fact]
-		public static void AddDefaultEntityRepositoryForEntity() {
+        [Fact]
+		public static void AddDefaultEntityRepositoryForEntity()
+        {
 			var services = new ServiceCollection();
 			services.AddDbContext<DbContext, PersonDbContext>(options =>
 				options.UseSqlite("Data Source=:memory:", x => x.UseNetTopologySuite()));

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityManagementTestSuite.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityManagementTestSuite.cs
@@ -39,23 +39,21 @@ namespace Deveel.Data {
 			var options = Services.GetRequiredService<DbContextOptions<PersonDbContext>>();
 			using var dbContext = new PersonDbContext(options);
 
-			await dbContext.Database.EnsureDeletedAsync();
-			await dbContext.Database.EnsureCreatedAsync();
+			await dbContext.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
+			await dbContext.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
 
 			await base.InitializeAsync();
 		}
 
 		public override async Task DisposeAsync() {
 			var options = Services.GetRequiredService<DbContextOptions<PersonDbContext>>();
-			using var dbContext = new PersonDbContext(options);
+			await using var dbContext = new PersonDbContext(options);
 
 			dbContext.People!.RemoveRange(dbContext.People);
-			await dbContext.SaveChangesAsync(true);
+			await dbContext.SaveChangesAsync(true, TestContext.Current.CancellationToken);
 
-			await dbContext.Database.EnsureDeletedAsync();
-
-			await dbContext.DisposeAsync();
-
+			await dbContext.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
+            
 			// await base.DisposeAsync();
 		}
 	}

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityRepositoryTestSuite.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityRepositoryTestSuite.cs
@@ -61,9 +61,9 @@ namespace Deveel.Data {
 			var options = Services.GetRequiredService<DbContextOptions<PersonDbContext>>();
 			await using var dbContext = new PersonDbContext(options);
 
-			await dbContext.Database.EnsureDeletedAsync();
-			await dbContext.Database.EnsureCreatedAsync();
-
+			await dbContext.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
+			await dbContext.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
+            
 			await base.InitializeAsync();
 		}
 
@@ -72,9 +72,9 @@ namespace Deveel.Data {
 			await using var dbContext = new PersonDbContext(options);
 
 			dbContext.People!.RemoveRange(dbContext.People);
-			await dbContext.SaveChangesAsync(true);
+			await dbContext.SaveChangesAsync(true, TestContext.Current.CancellationToken);
 
-			await dbContext.Database.EnsureDeletedAsync();
+			await dbContext.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
 		}
 
 		protected override IEnumerable<DbPerson> NaturalOrder(IEnumerable<DbPerson> source) => source.OrderBy(x => x.Id);
@@ -83,7 +83,7 @@ namespace Deveel.Data {
 		public async Task FindByKey_WithRelationships() {
 			var person = await RandomPersonAsync(x => x.Relationships != null);
 
-			var found = await Repository.FindAsync(person.Id!);
+			var found = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(found);
 			Assert.NotNull(found.Relationships);
@@ -95,12 +95,12 @@ namespace Deveel.Data {
 			var newEmail = new Faker().Internet.Email();
 			var person = await RandomPersonAsync(x => x.Email != newEmail);
 
-			var toUpdate = await PersonRepository.FindAsync(person.Id!);
+			var toUpdate = await PersonRepository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
-			await PersonRepository.SetEmailAsync(toUpdate!, newEmail);
-			Assert.True(await PersonRepository.UpdateAsync(toUpdate!));
+			await PersonRepository.SetEmailAsync(toUpdate!, newEmail, TestContext.Current.CancellationToken);
+			Assert.True(await PersonRepository.UpdateAsync(toUpdate!, TestContext.Current.CancellationToken));
 
-			var updated = await PersonRepository.FindAsync(person.Id!);
+			var updated = await PersonRepository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(updated);
 			Assert.Equal(newEmail, updated.Email);
@@ -110,7 +110,9 @@ namespace Deveel.Data {
 		public async Task FindByLocationWithinDistance() {
 			var person = await RandomPersonAsync(x => x.Location != null);
 
-			var found = await PersonRepository.FindAllAsync(x => x.Location!.Distance(person.Location) <= 1000);
+			var found = await PersonRepository.FindAllAsync(x => 
+                x.Location!.Distance(person.Location) <= 1000, 
+                cancellationToken: TestContext.Current.CancellationToken);
 			Assert.NotNull(found);
 			Assert.NotEmpty(found);
 			Assert.Contains(found, x => x.Id == person.Id);

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityTenantRepositoryTestSuite.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/EntityTenantRepositoryTestSuite.cs
@@ -52,9 +52,9 @@ namespace Deveel.Data
 			{
 				await ExecuteInTenantScopeAsync(tenantId, async (IMultiTenantContextAccessor tenantContextAccessor, DbContextOptions<PersonTenantDbContext> options) =>
 				{
-					using var dbContext = new PersonTenantDbContext(tenantContextAccessor, options);
+					await using var dbContext = new PersonTenantDbContext(tenantContextAccessor, options);
 
-					await dbContext.Database.EnsureCreatedAsync();
+					await dbContext.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
 				});
 			}
 
@@ -68,9 +68,9 @@ namespace Deveel.Data
 			{
 				await ExecuteInTenantScopeAsync(tenantId, async (IMultiTenantContextAccessor tenantContextAccessor, DbContextOptions<PersonTenantDbContext> options) =>
 				{
-					using var dbContext = new PersonTenantDbContext(tenantContextAccessor, options);
+					await using var dbContext = new PersonTenantDbContext(tenantContextAccessor, options);
 					dbContext.Persons!.RemoveRange(dbContext.Persons);
-					await dbContext.SaveChangesAsync(true);
+					await dbContext.SaveChangesAsync(true, TestContext.Current.CancellationToken);
 				});
 			}
 		}

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/SqlTestConnection.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/SqlTestConnection.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-
 namespace Deveel.Data {
 	public class SqlTestConnection : IDisposable {
 		public SqlTestConnection() : this("deveel-test") {
 		}
 
-		protected SqlTestConnection(string databaseName) {
+		protected SqlTestConnection(string databaseName)
+        {
 			Connection = new SqliteConnection($"Data Source={databaseName};Mode=Memory;Cache=Shared");
 			if (Connection.State != System.Data.ConnectionState.Open)
 				Connection.Open();

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/SqlTestConnection.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/SqlTestConnection.cs
@@ -10,7 +10,7 @@ namespace Deveel.Data {
 			Connection = new SqliteConnection($"Data Source={databaseName};Mode=Memory;Cache=Shared");
 			if (Connection.State != System.Data.ConnectionState.Open)
 				Connection.Open();
-
+            
 			Connection.EnableExtensions();
 			SpatialiteLoader.Load(Connection);
 		}
@@ -20,7 +20,7 @@ namespace Deveel.Data {
 		public void Dispose() {
 			if (Connection.State != System.Data.ConnectionState.Closed)
 				Connection?.Close();
-
+            
 			Connection?.Dispose();
 		}
 	}

--- a/test/Deveel.Repository.EntityFramework.XUnit/Data/UserEntityRepositoryTestSuite.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Data/UserEntityRepositoryTestSuite.cs
@@ -47,8 +47,8 @@ namespace Deveel.Data
 			var options = Services.GetRequiredService<DbContextOptions<BookDbContext>>();
 			await using var dbContext = new BookDbContext(options, userAccessor);
 
-			await dbContext.Database.EnsureDeletedAsync();
-			await dbContext.Database.EnsureCreatedAsync();
+			await dbContext.Database.EnsureDeletedAsync(TestContext.Current.CancellationToken);
+			await dbContext.Database.EnsureCreatedAsync(TestContext.Current.CancellationToken);
 
 			await base.InitializeAsync();
 		}
@@ -60,7 +60,7 @@ namespace Deveel.Data
 			await using var dbContext = new BookDbContext(options, userAccessor);
 
 			dbContext.Books!.RemoveRange(dbContext.Books);
-			await dbContext.SaveChangesAsync(true);
+			await dbContext.SaveChangesAsync(true, TestContext.Current.CancellationToken);
 
 			await dbContext.Database.EnsureDeletedAsync();
 		}

--- a/test/Deveel.Repository.EntityFramework.XUnit/Deveel.Repository.EntityFramework.XUnit.csproj
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Deveel.Repository.EntityFramework.XUnit.csproj
@@ -5,13 +5,13 @@
 	</PropertyGroup>
     
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="8.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="8.0.26" />
     <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="8.0.0" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.14" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="9.0.14" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.15" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="9.0.15" />
         <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="9.4.7" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
@@ -19,13 +19,13 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="10.0.5" />
         <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="10.0.4" />
     </ItemGroup>
+    
+    <ItemGroup Condition="$(TargetFramework) == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="SQLitePCLRaw.bundle_sqlite3" Version="2.1.10" Condition="'$(OS)' != 'Windows_NT'" />
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" Condition="'$(OS)' == 'Windows_NT'" />
+    </ItemGroup>
 
-
-    <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
-    <PackageReference Include="SQLitePCLRaw.bundle_sqlite3" Version="2.1.10" Condition="'$(OS)' != 'Windows_NT'" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" Condition="'$(OS)' == 'Windows_NT'" />
-  </ItemGroup>
-    <ItemGroup Condition="$(TargetFramework) == 'net9.0' OR $(TargetFramework) == 'net10.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="SQLitePCLRaw.bundle_sqlite3" Version="2.1.11" Condition="'$(OS)' != 'Windows_NT'" />
         <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" Condition="'$(OS)' == 'Windows_NT'" />
     </ItemGroup>

--- a/test/Deveel.Repository.EntityFramework.XUnit/Deveel.Repository.EntityFramework.XUnit.csproj
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Deveel.Repository.EntityFramework.XUnit.csproj
@@ -5,25 +5,26 @@
 	</PropertyGroup>
     
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="8.0.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="8.0.26" />
     <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.15" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="9.0.15" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="9.0.15" />
         <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="9.4.7" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="10.0.5" />
         <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="10.0.4" />
     </ItemGroup>
     
     <ItemGroup>
+        <PackageReference Include="SQLitePCLRaw.provider.sqlite3" Version="2.1.11" />
         <PackageReference Include="SQLitePCLRaw.bundle_sqlite3" Version="2.1.11" Condition="'$(OS)' != 'Windows_NT'" />
-        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" Condition="'$(OS)' == 'Windows_NT'" />
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" Condition="'$(OS)' == 'Windows_NT'" />
     </ItemGroup>
 
 

--- a/test/Deveel.Repository.EntityFramework.XUnit/Deveel.Repository.EntityFramework.XUnit.csproj
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Deveel.Repository.EntityFramework.XUnit.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="8.0.26" />
     <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.15" />
@@ -20,14 +21,9 @@
         <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="10.0.4" />
     </ItemGroup>
     
-    <ItemGroup Condition="$(TargetFramework) == 'net8.0' OR '$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="SQLitePCLRaw.bundle_sqlite3" Version="2.1.10" Condition="'$(OS)' != 'Windows_NT'" />
-        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" Condition="'$(OS)' == 'Windows_NT'" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <ItemGroup>
         <PackageReference Include="SQLitePCLRaw.bundle_sqlite3" Version="2.1.11" Condition="'$(OS)' != 'Windows_NT'" />
-        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" Condition="'$(OS)' == 'Windows_NT'" />
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" Condition="'$(OS)' == 'Windows_NT'" />
     </ItemGroup>
 
 

--- a/test/Deveel.Repository.InMemory.XUnit/Deveel.Repository.InMemory.XUnit.csproj
+++ b/test/Deveel.Repository.InMemory.XUnit/Deveel.Repository.InMemory.XUnit.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />

--- a/test/Deveel.Repository.Management.Tests/TestCancellationTokenSource.cs
+++ b/test/Deveel.Repository.Management.Tests/TestCancellationTokenSource.cs
@@ -1,18 +1,8 @@
-﻿namespace Deveel {
-	public class TestCancellationTokenSource : IOperationCancellationSource, IDisposable {
-		private CancellationTokenSource? source;
+﻿using Xunit;
 
-		public TestCancellationTokenSource() {
-			source = new CancellationTokenSource();
-		}
-
-		public CancellationToken Token => source?.Token ?? default;
-
-		public void Dispose() {
-			if (source != null) {
-				source.Dispose();
-				source = null;
-			}
-		}
-	}
+namespace Deveel {
+	public class TestCancellationTokenSource : IOperationCancellationSource
+    {
+        public CancellationToken Token => TestContext.Current.CancellationToken;
+    }
 }

--- a/test/Deveel.Repository.Manager.EasyCaching.XUnit/Deveel.Repository.Manager.EasyCaching.XUnit.csproj
+++ b/test/Deveel.Repository.Manager.EasyCaching.XUnit/Deveel.Repository.Manager.EasyCaching.XUnit.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="EasyCaching.InMemory" Version="1.9.2" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Deveel.Repository.Manager.XUnit/Deveel.Repository.Manager.XUnit.csproj
+++ b/test/Deveel.Repository.Manager.XUnit/Deveel.Repository.Manager.XUnit.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\Deveel.Repository.Test.Utils\Deveel.Repository.Test.Utils.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+  </ItemGroup>
+
 </Project>

--- a/test/Deveel.Repository.MongoFramework.XUnit/Deveel.Repository.MongoFramework.XUnit.csproj
+++ b/test/Deveel.Repository.MongoFramework.XUnit/Deveel.Repository.MongoFramework.XUnit.csproj
@@ -7,6 +7,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Finbuckle.MultiTenant" Version="8.1.12" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.4.0" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />

--- a/test/Deveel.Repository.Tests.XUnit/Data/RepositoryTestSuite_T3.cs
+++ b/test/Deveel.Repository.Tests.XUnit/Data/RepositoryTestSuite_T3.cs
@@ -12,7 +12,7 @@ namespace Deveel.Data {
 		where TPerson : class, IPerson<TKey>
 		where TKey : notnull
 		where TRelationship : class, IRelationship {
-		private IServiceProvider? services;
+		private IServiceProvider? _services;
 		private AsyncServiceScope scope;
 
 		protected RepositoryTestSuite(ITestOutputHelper? testOutput) {
@@ -61,8 +61,8 @@ namespace Deveel.Data {
 
 			ConfigureServices(services);
 
-			this.services = services.BuildServiceProvider();
-			scope = this.services.CreateAsyncScope();
+			_services = services.BuildServiceProvider();
+			scope = _services.CreateAsyncScope();
 		}
 
 		async ValueTask IAsyncLifetime.InitializeAsync() {
@@ -85,7 +85,7 @@ namespace Deveel.Data {
 			People = null;
 
 			await scope.DisposeAsync();
-			(services as IDisposable)?.Dispose();
+			(_services as IDisposable)?.Dispose();
 		}
         
 		protected virtual ValueTask DisposeAsync() {
@@ -123,13 +123,13 @@ namespace Deveel.Data {
 		public async Task AddNewPerson() {
 			var person = GeneratePerson();
 
-			await Repository.AddAsync(person);
+			await Repository.AddAsync(person, TestContext.Current.CancellationToken);
 
 			var id = Repository.GetEntityKey(person);
 
 			Assert.NotNull(id);
 
-			var found = await Repository.FindAsync(id);
+			var found = await Repository.FindAsync(id, TestContext.Current.CancellationToken);
 			Assert.NotNull(found);
 			Assert.Equal(person.FirstName, found.FirstName);
 			Assert.Equal(person.LastName, found.LastName);
@@ -146,7 +146,7 @@ namespace Deveel.Data {
 
 			Assert.NotNull(id);
 
-			var found = await Repository.FindAsync(id);
+			var found = await Repository.FindAsync(id, TestContext.Current.CancellationToken);
 			
 			Assert.NotNull(found);
 			Assert.Equal(person.FirstName, found.FirstName);
@@ -158,13 +158,13 @@ namespace Deveel.Data {
 		public async Task AddNewPersons() {
 			var entities = GeneratePeople(10);
 
-			await Repository.AddRangeAsync(entities);
+			await Repository.AddRangeAsync(entities, TestContext.Current.CancellationToken);
 
 			foreach (var item in entities) {
 				var key = Repository.GetEntityKey(item);
 				Assert.NotNull(key);
 
-				var found = await Repository.FindAsync(key);
+				var found = await Repository.FindAsync(key, TestContext.Current.CancellationToken);
 				Assert.NotNull(found);
 			}
 		}
@@ -175,7 +175,7 @@ namespace Deveel.Data {
 
 			Assert.NotNull(person);
 
-			var result = await Repository.RemoveAsync(person);
+			var result = await Repository.RemoveAsync(person, TestContext.Current.CancellationToken);
 
 			Assert.True(result);
 		}
@@ -186,7 +186,7 @@ namespace Deveel.Data {
 
 			entity.Id = GeneratePersonId();
 
-			var result = await Repository.RemoveAsync(entity);
+			var result = await Repository.RemoveAsync(entity, TestContext.Current.CancellationToken);
 
 			Assert.False(result);
 		}
@@ -208,7 +208,7 @@ namespace Deveel.Data {
 
 			Assert.NotNull(key);
 
-			var result = await Repository.RemoveByKeyAsync(key);
+			var result = await Repository.RemoveByKeyAsync(key, TestContext.Current.CancellationToken);
 
 			Assert.True(result);
 		}
@@ -228,7 +228,7 @@ namespace Deveel.Data {
 		public async Task RemoveByKey_NotExisting() {
 			var id = GeneratePersonId();
 
-			var result = await Repository.RemoveByKeyAsync(id);
+			var result = await Repository.RemoveByKeyAsync(id, TestContext.Current.CancellationToken);
 
 			Assert.False(result);
 		}
@@ -240,7 +240,7 @@ namespace Deveel.Data {
 
 			await Repository.RemoveRangeAsync(people);
 
-			var result = await Repository.FindAllAsync();
+			var result = await Repository.FindAllAsync(TestContext.Current.CancellationToken);
 			Assert.NotNull(result);
 			Assert.NotEmpty(result);
 			Assert.Equal(peopleCount - 10, result.Count);
@@ -256,7 +256,7 @@ namespace Deveel.Data {
 
 			people.Add(entity);
 
-			await Assert.ThrowsAsync<RepositoryException>(() => Repository.RemoveRangeAsync(people));
+			await Assert.ThrowsAsync<RepositoryException>(() => Repository.RemoveRangeAsync(people, TestContext.Current.CancellationToken));
 
 			var result = await Repository.FindAllAsync();
 			Assert.NotNull(result);
@@ -266,7 +266,7 @@ namespace Deveel.Data {
 
 		[Fact]
 		public async Task CountAll() {
-			var result = await Repository.CountAllAsync();
+			var result = await Repository.CountAllAsync(TestContext.Current.CancellationToken);
 
 			Assert.NotEqual(0, result);
 			Assert.Equal(PeopleCount, result);
@@ -286,7 +286,7 @@ namespace Deveel.Data {
 			var firstName = person.FirstName;
 			var peopleCount = People?.Count(x => x.FirstName == firstName) ?? 0;
 
-			var count = await Repository.CountAsync(p => p.FirstName == firstName);
+			var count = await Repository.CountAsync(p => p.FirstName == firstName, TestContext.Current.CancellationToken);
 
 			Assert.Equal(peopleCount, count);
 		}
@@ -307,7 +307,7 @@ namespace Deveel.Data {
 			var person = await RandomPersonAsync();
 			var id = person.Id!;
 
-			var result = await Repository.FindAsync(id);
+			var result = await Repository.FindAsync(id, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.Equal(id, result.Id);
@@ -318,7 +318,7 @@ namespace Deveel.Data {
 			var person = await RandomPersonAsync();
 			var firstName = person.FirstName;
 
-			var result = await Repository.FindFirstAsync(x => x.FirstName == firstName);
+			var result = await Repository.FindFirstAsync(x => x.FirstName == firstName, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.Equal(firstName, result.FirstName);
@@ -340,7 +340,7 @@ namespace Deveel.Data {
 				.OrderBy(x => x.FirstName)
 				.Query;
 
-			var result = await Repository.FindFirstAsync(query);
+			var result = await Repository.FindFirstAsync(query, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.Equal(expected.FirstName, result.FirstName);
@@ -360,7 +360,7 @@ namespace Deveel.Data {
 			var person = await RandomPersonAsync();
 			var firstName = person.FirstName;
 
-			var result = await Repository.ExistsAsync(x => x.FirstName == firstName);
+			var result = await Repository.ExistsAsync(x => x.FirstName == firstName, TestContext.Current.CancellationToken);
 
 			Assert.True(result);
 		}
@@ -379,7 +379,7 @@ namespace Deveel.Data {
 		public async Task FindByKey_Existing() {
 			var person = await RandomPersonAsync();
 
-			var result = await Repository.FindAsync(person.Id!);
+			var result = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.Equal(person.Id, result.Id);
@@ -413,7 +413,7 @@ namespace Deveel.Data {
 
 			Assert.NotNull(person);
 
-			var result = await Repository.FindAsync(person.Id!);
+			var result = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.NotNull(result.Relationships);
@@ -424,7 +424,7 @@ namespace Deveel.Data {
 		public async Task FindFirst() {
 			var ordered = NaturalOrder(People!).ToList();
 
-			var result = await Repository.FindFirstAsync();
+			var result = await Repository.FindFirstAsync(TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.Equal(ordered[0].FirstName, result.FirstName);
@@ -446,7 +446,7 @@ namespace Deveel.Data {
 
 		[Fact]
 		public async Task FindAll() {
-			var result = await Repository.FindAllAsync();
+			var result = await Repository.FindAllAsync(TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.NotEmpty(result);
@@ -468,7 +468,8 @@ namespace Deveel.Data {
 			var firstName = person.FirstName;
 			var peopleCount = People?.Count(x => x.FirstName == firstName) ?? 0;
 
-			var result = await Repository.FindAllAsync(x => x.FirstName == firstName);
+			var result = await Repository.FindAllAsync(x => x.FirstName == firstName, 
+                TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.NotEmpty(result);
@@ -490,7 +491,7 @@ namespace Deveel.Data {
 				.Where(x => x.FirstName == firstName)
 				.OrderBy(x => x.FirstName);
 
-			var result = await Repository.FindAllAsync(query);
+			var result = await Repository.FindAllAsync(query, TestContext.Current.CancellationToken);
 			Assert.NotNull(result);
 			Assert.NotEmpty(result);
 		}
@@ -501,7 +502,8 @@ namespace Deveel.Data {
 			var firstName = person.FirstName;
 
 			var result = await Assert.ThrowsAsync<RepositoryException>(
-				() => Repository.FindAllAsync(QueryFilter.Where<MailAddress>(m => m.Address == null)));
+				() => Repository.FindAllAsync(QueryFilter.Where<MailAddress>(m => m.Address == null), 
+                    TestContext.Current.CancellationToken));
 		}
 
 		[Fact]
@@ -509,7 +511,7 @@ namespace Deveel.Data {
 			var totalItems = PeopleCount;
 			var totalPages = (int)Math.Ceiling((double)totalItems / 10);
 
-			var result = await Repository.GetPageAsync(1, 10);
+			var result = await Repository.GetPageAsync(1, 10, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.Equal(totalPages, result.TotalPages);
@@ -524,7 +526,7 @@ namespace Deveel.Data {
 			var totalItems = PeopleCount;
 			var totalPages = (int)Math.Ceiling((double)totalItems / 10);
 
-			var result = await Repository.GetPageAsync(1, 10);
+			var result = await Repository.GetPageAsync(1, 10, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.Equal(totalPages, result.TotalPages);
@@ -545,7 +547,7 @@ namespace Deveel.Data {
 			var request = new PageQuery<TPerson>(1, 10)
 				.Where(x => x.FirstName == firstName);
 
-			var result = await Repository.GetPageAsync(request);
+			var result = await Repository.GetPageAsync(request, TestContext.Current.CancellationToken);
 			Assert.NotNull(result);
 			Assert.Equal(totalPages, result.TotalPages);
 			Assert.Equal(peopleCount, result.TotalItems);
@@ -567,7 +569,7 @@ namespace Deveel.Data {
 			var request = new PageQuery<TPerson>(1, 10)
 				.Where(x => x.FirstName == firstName && x.LastName == lastName);
 
-			var result = await Repository.GetPageAsync(request);
+			var result = await Repository.GetPageAsync(request, TestContext.Current.CancellationToken);
 			Assert.NotNull(result);
 			Assert.Equal(totalPages, result.TotalPages);
 			Assert.Equal(peopleCount, result.TotalItems);
@@ -594,7 +596,7 @@ namespace Deveel.Data {
 				.Where(x => x.FirstName == firstName)
 				.Where(x => x.DateOfBirth >= birthDate);
 
-			var result = await Repository.GetPageAsync(request);
+			var result = await Repository.GetPageAsync(request, TestContext.Current.CancellationToken);
 			Assert.NotNull(result);
 			Assert.Equal(totalPages, result.TotalPages);
 			Assert.Equal(peopleCount, result.TotalItems);
@@ -612,7 +614,7 @@ namespace Deveel.Data {
 			var request = new PageQuery<TPerson>(1, 10)
 				.OrderByDescending(x => x.LastName);
 
-			var result = await Repository.GetPageAsync(request);
+			var result = await Repository.GetPageAsync(request, TestContext.Current.CancellationToken);
 			Assert.NotNull(result);
 			Assert.Equal(10, result.TotalPages);
 			Assert.Equal(100, result.TotalItems);
@@ -632,7 +634,7 @@ namespace Deveel.Data {
 			var request = new PageQuery<TPerson>(1, 10)
 				.OrderBy(x => x.FirstName);
 
-			var result = await Repository.GetPageAsync(request);
+			var result = await Repository.GetPageAsync(request, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(result);
 			Assert.Equal(totalPages, result.TotalPages);
@@ -672,17 +674,17 @@ namespace Deveel.Data {
 		public async Task UpdateExisting() {
 			var person = await RandomPersonAsync(x => x.FirstName != "John");
 
-			var toUpdate = await Repository.FindAsync(person.Id!);
+			var toUpdate = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(toUpdate);
 
 			toUpdate.FirstName = "John";
 
-			var result = await Repository.UpdateAsync(toUpdate);
+			var result = await Repository.UpdateAsync(toUpdate, TestContext.Current.CancellationToken);
 
 			Assert.True(result);
 
-			var updated = await Repository.FindAsync(person.Id!);
+			var updated = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(updated);
 			Assert.Equal(toUpdate.FirstName, updated.FirstName);
@@ -695,7 +697,7 @@ namespace Deveel.Data {
 		public async Task UpdateExisting_Sync() {
 			var person = await RandomPersonAsync(x => x.FirstName != "John");
 
-			var toUpdate = await Repository.FindAsync(person.Id!);
+			var toUpdate = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(toUpdate);
 
@@ -705,7 +707,7 @@ namespace Deveel.Data {
 
 			Assert.True(result);
 
-			var updated = await Repository.FindAsync(person.Id!);
+			var updated = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(updated);
 			Assert.Equal(toUpdate.FirstName, updated.FirstName);
@@ -720,7 +722,7 @@ namespace Deveel.Data {
 
 			person.Id = GeneratePersonId();
 
-			var result = await Repository.UpdateAsync(person);
+			var result = await Repository.UpdateAsync(person, TestContext.Current.CancellationToken);
 
 			Assert.False(result);
 		}
@@ -729,13 +731,13 @@ namespace Deveel.Data {
 		public async Task UpdateExisting_NoChange() {
 			var person = await RandomPersonAsync();
 
-			var toUpdate = await Repository.FindAsync(person.Id!);
+			var toUpdate = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(toUpdate);
 
 			await Repository.UpdateAsync(toUpdate);
 
-			var updated = await Repository.FindAsync(person.Id!);
+			var updated = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 			Assert.NotNull(updated);
 			Assert.Equal(toUpdate, updated);
 		}
@@ -748,17 +750,17 @@ namespace Deveel.Data {
 
 			var relationship = GenerateRelationship();
 
-			var toUpdate = await Repository.FindAsync(person.Id!);
+			var toUpdate = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(toUpdate);
 
 			await AddRelationshipAsync(toUpdate, relationship);
 
-			var result = await Repository.UpdateAsync(toUpdate);
+			var result = await Repository.UpdateAsync(toUpdate, TestContext.Current.CancellationToken);
 
 			Assert.True(result);
 
-			var updated = await Repository.FindAsync(person.Id!);
+			var updated = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(updated);
 			Assert.NotNull(updated.Relationships);
@@ -772,7 +774,7 @@ namespace Deveel.Data {
 
 			Assert.NotNull(person);
 
-			var toUpdate = await Repository.FindAsync(person.Id!);
+			var toUpdate = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 
 			Assert.NotNull(toUpdate);
 
@@ -780,11 +782,11 @@ namespace Deveel.Data {
 
 			await RemoveRelationshipAsync(toUpdate, (TRelationship) toUpdate.Relationships!.First());
 
-			var result = await Repository.UpdateAsync(toUpdate);
+			var result = await Repository.UpdateAsync(toUpdate, TestContext.Current.CancellationToken);
 
 			Assert.True(result);
 
-			var updated = await Repository.FindAsync(person.Id!);
+			var updated = await Repository.FindAsync(person.Id!, TestContext.Current.CancellationToken);
 			Assert.NotNull(updated);
 			Assert.NotNull(updated.Relationships);
 			Assert.Equal(relCount - 1, updated.Relationships.Count());

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -16,14 +16,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="Bogus" Version="35.6.5" />
     <PackageReference Include="MartinCostello.Logging.XUnit.v3" Version="0.7.1" />
-    <PackageReference Include="coverlet.msbuild" Version="6.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request updates package dependencies and simplifies conditional logic in the `Deveel.Repository.EntityFramework.XUnit.csproj` file. The main changes are focused on keeping dependencies up to date and consolidating package reference conditions.

Dependency updates:

* Upgraded `Microsoft.EntityFrameworkCore.Sqlite` and `Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite` to version `8.0.26` for `net8.0` and to `9.0.15` for `net9.0`.

Project file simplification:

* Combined the `SQLitePCLRaw.bundle_sqlite3` and `SQLitePCLRaw.bundle_e_sqlite3` package references for `net8.0` and `net9.0` into a single `ItemGroup`, reducing duplication and simplifying the project file.….NET 8.0, 9.0, and 10.0; adjust target framework conditions