### PR TITLE
Add project configuration for .NET 8.0/10.0 and support HttpRequestCancellationSource

### DIFF
--- a/.github/workflows/clean-packages.yml
+++ b/.github/workflows/clean-packages.yml
@@ -68,6 +68,14 @@ jobs:
         min-versions-to-keep: 10
         delete-only-pre-release-versions: "true"
 
+    - name: Remove the Old Deveel.Repository.Manager.AspNetCore Package
+      uses: actions/delete-package-versions@v4
+      with:
+        package-name: 'Deveel.Repository.Manager.AspNetCore'
+        package-type: 'nuget'
+        min-versions-to-keep: 10
+        delete-only-pre-release-versions: "true"
+
     - name: Remove the Old Deveel.Repository.Manager.DynamicLinq Package
       uses: actions/delete-package-versions@v4
       with:

--- a/Deveel.Repository.sln
+++ b/Deveel.Repository.sln
@@ -66,6 +66,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "utils", "utils", "{6EAA2746
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Repository.MultiTenantContext", "test\Deveel.Repository.MultiTenantContext\Deveel.Repository.MultiTenantContext.csproj", "{C2D6E959-F9A8-4F6B-BF0B-56C8CE3E3FF9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Repository.Manager.AspNetCore", "src\Deveel.Repository.Manager.AspNetCore\Deveel.Repository.Manager.AspNetCore.csproj", "{89676AD8-AE22-40CC-9982-4E6A11E1228B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -156,6 +158,10 @@ Global
 		{C2D6E959-F9A8-4F6B-BF0B-56C8CE3E3FF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C2D6E959-F9A8-4F6B-BF0B-56C8CE3E3FF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C2D6E959-F9A8-4F6B-BF0B-56C8CE3E3FF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89676AD8-AE22-40CC-9982-4E6A11E1228B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89676AD8-AE22-40CC-9982-4E6A11E1228B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89676AD8-AE22-40CC-9982-4E6A11E1228B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89676AD8-AE22-40CC-9982-4E6A11E1228B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -184,6 +190,7 @@ Global
 		{18241CCB-B430-4F43-AFEC-0C0A3F5B5400} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 		{6EAA2746-39E4-4C63-9D86-117248B1C2A3} = {50434E05-0F21-4871-AFB3-A483CEE4A300}
 		{C2D6E959-F9A8-4F6B-BF0B-56C8CE3E3FF9} = {6EAA2746-39E4-4C63-9D86-117248B1C2A3}
+		{89676AD8-AE22-40CC-9982-4E6A11E1228B} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01FD9B16-84B3-4D99-80C1-11B2F3D65B56}

--- a/benchmarks/Deveel.Repository.EntityFramework.Benchmarks/Program.cs
+++ b/benchmarks/Deveel.Repository.EntityFramework.Benchmarks/Program.cs
@@ -33,9 +33,9 @@ public class PersonContext : DbContext
 }
 
 [MemoryDiagnoser]
-//[SimpleJob(RuntimeMoniker.Net60, baseline: true)]
-//[SimpleJob(RuntimeMoniker.Net70)]
-//[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net80, baseline: true)]
+[SimpleJob(RuntimeMoniker.Net90)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
 public class EfRepositoryBenchmarks
 {
     private MySqlContainer? _container;

--- a/src/Deveel.Repository.Manager.AspNetCore/Data/HttpRequestCancellationSource.cs
+++ b/src/Deveel.Repository.Manager.AspNetCore/Data/HttpRequestCancellationSource.cs
@@ -14,7 +14,7 @@
 
 using Microsoft.AspNetCore.Http;
 
-namespace Deveel {
+namespace Deveel.Data {
 	/// <summary>
 	/// An implementation of <see cref="IOperationCancellationSource"/> that
 	/// uses the <see cref="HttpContext.RequestAborted"/> token.

--- a/src/Deveel.Repository.Manager.AspNetCore/Deveel.Repository.Manager.AspNetCore.csproj
+++ b/src/Deveel.Repository.Manager.AspNetCore/Deveel.Repository.Manager.AspNetCore.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <PackageTags>repository;manager;business;httpcontext;aspnetcore;aspnet;http</PackageTags>
+        <Description>Extends the Entity Manager model adding functions for ASP.NET Applications, like cancellations on HTTP connections</Description>
+    </PropertyGroup>
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\Deveel.Repository.Manager\Deveel.Repository.Manager.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/Deveel.Repository.Manager.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.Manager.AspNetCore/ServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Deveel.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deveel
+{
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers a singleton instance of the <see cref="HttpRequestCancellationSource"/> 
+        /// in the collection of services.
+        /// </summary>
+        /// <param name="services">
+        /// The collection of services to register the source.
+        /// </param>
+        /// <remarks>
+        /// This method also tries to register the <see cref="IHttpContextAccessor"/>
+        /// into the collection of services, if not already registered.
+        /// </remarks>
+        /// <returns>
+        /// Returns the given collection of services for chaining calls.
+        /// </returns>
+        public static IServiceCollection AddHttpRequestTokenSource(this IServiceCollection services) {
+            services.AddHttpContextAccessor();
+            services.AddOperationTokenSource<HttpRequestCancellationSource>(ServiceLifetime.Singleton);
+
+            return services;
+        }
+    }
+}

--- a/src/Deveel.Repository.Manager/Deveel.Repository.Manager.csproj
+++ b/src/Deveel.Repository.Manager/Deveel.Repository.Manager.csproj
@@ -5,13 +5,22 @@
     <Description>Extends the Repository model adding management functions, such as validation, caching, logging</Description>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Deveel.Results" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" Condition="'$(TargetFramework)' == 'net9.0'" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <ItemGroup>
+        <PackageReference Include="Deveel.Results" Version="1.2.0" />
+    </ItemGroup>
+    
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.15" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5"/>
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
+    </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Deveel.Repository.Core\Deveel.Repository.Core.csproj" />

--- a/src/Deveel.Repository.Manager/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.Manager/ServiceCollectionExtensions.cs
@@ -16,7 +16,6 @@ using System.ComponentModel.DataAnnotations;
 
 using Deveel.Data;
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -104,28 +103,7 @@ namespace Deveel {
 
 			return services;
 		}
-
-		/// <summary>
-		/// Registers a singleton instance of the <see cref="HttpRequestCancellationSource"/> 
-		/// in the collection of services.
-		/// </summary>
-		/// <param name="services">
-		/// The collection of services to register the source.
-		/// </param>
-		/// <remarks>
-		/// This method also tries to register the <see cref="IHttpContextAccessor"/>
-		/// into the collection of services, if not already registered.
-		/// </remarks>
-		/// <returns>
-		/// Returns the given collection of services for chaining calls.
-		/// </returns>
-		public static IServiceCollection AddHttpRequestTokenSource(this IServiceCollection services) {
-			services.AddHttpContextAccessor();
-			services.AddOperationTokenSource<HttpRequestCancellationSource>(ServiceLifetime.Singleton);
-
-			return services;
-		}
-
+        
 		class OperationErrorFactoryDecorator<TEntity> : IOperationErrorFactory<TEntity> where TEntity : class {
 			private readonly OperationErrorFactory errorFactory;
 

--- a/test/Deveel.Repository.Manager.XUnit/Deveel.Repository.Manager.XUnit.csproj
+++ b/test/Deveel.Repository.Manager.XUnit/Deveel.Repository.Manager.XUnit.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Deveel.Repository.InMemory\Deveel.Repository.InMemory.csproj" />
+    <ProjectReference Include="..\..\src\Deveel.Repository.Manager.AspNetCore\Deveel.Repository.Manager.AspNetCore.csproj" />
     <ProjectReference Include="..\Deveel.Repository.Management.Tests\Deveel.Repository.Management.Tests.csproj" />
     <ProjectReference Include="..\Deveel.Repository.Test.Utils\Deveel.Repository.Test.Utils.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This pull request introduces a new `Deveel.Repository.Manager.AspNetCore` package to provide ASP.NET Core-specific functionality, refactors the registration of HTTP request cancellation tokens, and updates package references for better framework targeting. It also improves the solution structure and maintenance scripts.

**ASP.NET Core Integration:**
- Added a new project, `Deveel.Repository.Manager.AspNetCore`, to the solution, providing ASP.NET Core-specific extensions and services such as `HttpRequestCancellationSource` and an `AddHttpRequestTokenSource` extension method for service registration. [[1]](diffhunk://#diff-53d96e24532d138683684ee910a6df3bcb3cb7a7e0277308e6135cb685b6efa6R69-R70) [[2]](diffhunk://#diff-53d96e24532d138683684ee910a6df3bcb3cb7a7e0277308e6135cb685b6efa6R161-R164) [[3]](diffhunk://#diff-53d96e24532d138683684ee910a6df3bcb3cb7a7e0277308e6135cb685b6efa6R193) [[4]](diffhunk://#diff-3d861cadd1d61b42639fa3c415faff4476ab33278777ccccc4e966fb04e31cc2R1-R30) [[5]](diffhunk://#diff-600c55eaae8bf33875960d3f4f7614f36f62f379309b76e5775f36a3bdf3e55fL17-R17) [[6]](diffhunk://#diff-265b1a61b77468f0054845af34436a4bc3ea22278761265cb6079327c842421cR14)

**Refactoring and Code Organization:**
- Moved `HttpRequestCancellationSource` from the core manager project to the new ASP.NET Core-specific package and updated its namespace to `Deveel.Data`.
- Removed the ASP.NET Core-specific `AddHttpRequestTokenSource` method from the core `ServiceCollectionExtensions` and relocated it to the new ASP.NET Core package. [[1]](diffhunk://#diff-b1383333135c2511fbe002832e427dc3f7e9940147bf98d4d3225d8ace420becL108-L128) [[2]](diffhunk://#diff-3d861cadd1d61b42639fa3c415faff4476ab33278777ccccc4e966fb04e31cc2R1-R30)

**Dependency and Project Reference Updates:**
- Updated `Deveel.Repository.Manager` to use conditional `PackageReference` and `ItemGroup` elements for multi-targeting, and added missing `Microsoft.Extensions.Options.ConfigurationExtensions` dependencies for each supported .NET version.
- Added a project reference to `Deveel.Repository.Manager.AspNetCore` in the test project to enable testing of ASP.NET Core-specific features.

**Benchmark Configuration:**
- Updated the benchmark project to use .NET 8.0 as the baseline and include .NET 9.0 and 10.0 jobs for performance testing.

**Maintenance Workflow:**
- Updated the GitHub Actions workflow to clean up old pre-release versions of the new `Deveel.Repository.Manager.AspNetCore` NuGet package.