### PR TITLE
Add synchronous repository extension methods and refactor tests

### DIFF
--- a/.github/workflows/reusable-pipeline.yml
+++ b/.github/workflows/reusable-pipeline.yml
@@ -23,11 +23,6 @@ on:
         required: false
         default: false
         type: boolean
-      solution-path:
-        description: Solution file to build, test and pack
-        required: false
-        default: Deveel.Repository.sln
-        type: string
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -64,10 +59,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libsqlite3-mod-spatialite
 
       - name: Restore dependencies
-        run: dotnet restore ${{ inputs.solution-path }} -p:TargetFrameworks=${{ matrix.target-framework }}
+        run: dotnet restore -p:TargetFrameworks=${{ matrix.target-framework }}
 
       - name: Build
-        run: dotnet build ${{ inputs.solution-path }} --no-restore -c Release -f ${{ matrix.target-framework }}
+        run: dotnet build --no-restore -c Release -f ${{ matrix.target-framework }}
 
       - name: Test
         if: ${{ inputs.generate-coverage == false }}
@@ -111,7 +106,7 @@ jobs:
 
       - name: Pack NuGet packages
         run: >-
-          dotnet pack ${{ inputs.solution-path }}
+          dotnet pack
           -c Release
           --output ./nupkgs
           --include-symbols

--- a/src/Deveel.Repository.Core/Data/RepositoryExtensions.cs
+++ b/src/Deveel.Repository.Core/Data/RepositoryExtensions.cs
@@ -1396,6 +1396,34 @@ namespace Deveel.Data {
 		/// <param name="filter">
 		/// The filter expression used to find the entity.
 		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> that
+		/// can be identified by the given filter, or <c>null</c> if no
+		/// entity matches the given filter.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support filtering.
+		/// </exception>
+		public static TEntity? FindFirst<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter)
+            where TEntity : class
+            => repository.FindFirstAsync(new Query(filter)).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Finds the first entity in the repository that matches
+		/// the given filter expression
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entity.
+		/// </param>
+		/// <param name="filter">
+		/// The filter expression used to find the entity.
+		/// </param>
 		/// <param name="cancellationToken">
 		/// A token used to cancel the operation.
 		/// </param>
@@ -1434,34 +1462,6 @@ namespace Deveel.Data {
 		public static Task<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, CancellationToken cancellationToken = default)
             where TEntity : class
             => repository.AsFilterable().FindFirstAsync(Query.Empty, cancellationToken);
-
-		/// <summary>
-		/// Finds the first entity in the repository that matches
-		/// the given filter expression
-		/// </summary>
-		/// <typeparam name="TEntity">
-		/// The type of entity handled by the repository.
-		/// </typeparam>
-		/// <typeparam name="TKey">
-		/// The type of the key that uniquely identifies the entity.
-		/// </typeparam>
-		/// <param name="repository">
-		/// The repository instance to use to find the entity.
-		/// </param>
-		/// <param name="filter">
-		/// The filter expression used to find the entity.
-		/// </param>
-		/// <returns>
-		/// Returns an instance of <typeparamref name="TEntity"/> that
-		/// can be identified by the given filter, or <c>null</c> if no
-		/// entity matches the given filter.
-		/// </returns>
-		/// <exception cref="NotSupportedException">
-		/// Thrown when the repository does not support filtering.
-		/// </exception>
-		public static TEntity? FindFirst<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter)
-            where TEntity : class
-            => repository.FindFirstAsync(new Query(filter)).ConfigureAwait(false).GetAwaiter().GetResult();
 
 		/// <summary>
 		/// Synchronously finds the first entity in the repository that matches
@@ -1870,6 +1870,29 @@ namespace Deveel.Data {
             => repository.FindAllAsync(Query.Empty, cancellationToken);
 
 		/// <summary>
+		/// Finds all the entities in the repository, naturally ordered.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository, naturally ordered.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support querying or filtering.
+		/// </exception>
+		public static IList<TEntity> FindAll<TEntity, TKey>(this IRepository<TEntity, TKey> repository)
+            where TEntity : class
+            => repository.FindAll(QueryFilter.Empty);
+
+		/// <summary>
 		/// Finds all the entities in the repository that match
 		/// the given filter.
 		/// </summary>
@@ -2172,28 +2195,6 @@ namespace Deveel.Data {
 			where TEntity : class
 			=> repository.FindAllAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-		/// <summary>
-		/// Finds all the entities in the repository, naturally ordered.
-		/// </summary>
-		/// <typeparam name="TEntity">
-		/// The type of entity handled by the repository.
-		/// </typeparam>
-		/// <typeparam name="TKey">
-		/// The type of the key that uniquely identifies the entity.
-		/// </typeparam>
-		/// <param name="repository">
-		/// The repository instance to use to find the entities.
-		/// </param>
-		/// <returns>
-		/// Returns a list of <typeparamref name="TEntity"/> from
-		/// the repository, naturally ordered.
-		/// </returns>
-		/// <exception cref="NotSupportedException">
-		/// Thrown when the repository does not support querying or filtering.
-		/// </exception>
-		public static IList<TEntity> FindAll<TEntity, TKey>(this IRepository<TEntity, TKey> repository)
-            where TEntity : class
-            => repository.FindAll(QueryFilter.Empty);
 
         #endregion
     }

--- a/src/Deveel.Repository.Core/Data/RepositoryExtensions.cs
+++ b/src/Deveel.Repository.Core/Data/RepositoryExtensions.cs
@@ -200,6 +200,57 @@ namespace Deveel.Data {
 			where TKey : notnull
 			=> repository.AddAsync(entity).ConfigureAwait(false).GetAwaiter().GetResult();
 
+		/// <summary>
+		/// Adds a range of entities in the repository synchronously.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity to add
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to create the entities.
+		/// </param>
+		/// <param name="entities">
+		/// The enumeration of entities to add.
+		/// </param>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="IRepository{TEntity,TKey}.AddRangeAsync(IEnumerable{TEntity}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static void AddRange<TEntity>(this IRepository<TEntity> repository, IEnumerable<TEntity> entities)
+			where TEntity : class
+			=> repository.AddRangeAsync(entities).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Adds a range of entities in the repository synchronously.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity to add
+		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to create the entities.
+		/// </param>
+		/// <param name="entities">
+		/// The enumeration of entities to add.
+		/// </param>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="IRepository{TEntity,TKey}.AddRangeAsync(IEnumerable{TEntity}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static void AddRange<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IEnumerable<TEntity> entities)
+			where TEntity : class
+			=> repository.AddRangeAsync(entities).ConfigureAwait(false).GetAwaiter().GetResult();
+
 
 		#endregion
 
@@ -359,6 +410,57 @@ namespace Deveel.Data {
 		public static bool RemoveByKey<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TKey key)
 			where TEntity : class
 			=> repository.RemoveByKeyAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Removes a range of entities from the repository synchronously.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository from which the entities are removed.
+		/// </param>
+		/// <param name="entities">
+		/// The enumeration of entities to remove.
+		/// </param>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="IRepository{TEntity,TKey}.RemoveRangeAsync(IEnumerable{TEntity}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static void RemoveRange<TEntity>(this IRepository<TEntity> repository, IEnumerable<TEntity> entities)
+			where TEntity : class
+			=> repository.RemoveRangeAsync(entities).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Removes a range of entities from the repository synchronously.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository from which the entities are removed.
+		/// </param>
+		/// <param name="entities">
+		/// The enumeration of entities to remove.
+		/// </param>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="IRepository{TEntity,TKey}.RemoveRangeAsync(IEnumerable{TEntity}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static void RemoveRange<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IEnumerable<TEntity> entities)
+			where TEntity : class
+			=> repository.RemoveRangeAsync(entities).ConfigureAwait(false).GetAwaiter().GetResult();
 
 
 		#endregion
@@ -544,6 +646,44 @@ namespace Deveel.Data {
 			throw new NotSupportedException("The repository does not support paging");
 		}
 
+		/// <summary>
+		/// Synchronously gets a page of entities from the repository, given
+		/// the page number and the size.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to retrieve the page.
+		/// </param>
+		/// <param name="page">
+		/// The number of the page, starting from 1, to retrieve from the repository.
+		/// </param>
+		/// <param name="size">
+		/// The size of the page to retrieve from the repository.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <see cref="PageResult{TEntity}"/> that
+		/// represents the result of the query.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="GetPageAsync{TEntity, TKey}(IRepository{TEntity, TKey}, int, int, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support paging.
+		/// </exception>
+		public static PageResult<TEntity> GetPage<TEntity, TKey>(this IRepository<TEntity, TKey> repository, int page, int size)
+			where TEntity : class
+			=> repository.GetPage(new PageQuery<TEntity>(page, size));
+
 		#endregion
 
 		#region Exists
@@ -679,6 +819,119 @@ namespace Deveel.Data {
         public static bool Exists<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter)
             where TEntity : class
             => Exists(repository, new ExpressionQueryFilter<TEntity>(filter));
+
+		/// <summary>
+		/// Checks if an entity exists in the repository that matches the given filter,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to check the existence
+		/// of any entity that matches the given filter.
+		/// </param>
+		/// <param name="filter">
+		/// The filter used to check the existence of any matching entity.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns <c>true</c> if any entity exists in the repository
+		/// that matches the given filter, otherwise <c>false</c>.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support querying or filtering.
+		/// </exception>
+		public static Task<bool> ExistsAsync<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> ExistsAsync<TEntity, object>(repository, filter, cancellationToken);
+
+		/// <summary>
+		/// Checks if an entity exists in the repository that matches the given expression filter,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to check the existence
+		/// of any entity that matches the given filter.
+		/// </param>
+		/// <param name="filter">
+		/// The filter expression used to check the existence of any matching entity.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns <c>true</c> if any entity exists in the repository
+		/// that matches the given filter, otherwise <c>false</c>.
+		/// </returns>
+		public static Task<bool> ExistsAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> ExistsAsync<TEntity, object>(repository, filter, cancellationToken);
+
+		/// <summary>
+		/// Synchronously checks if an entity exists in the repository that matches
+		/// the given filter, using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to check the existence
+		/// of any entity that matches the given filter.
+		/// </param>
+		/// <param name="filter">
+		/// The filter used to check the existence of any matching entity.
+		/// </param>
+		/// <returns>
+		/// Returns <c>true</c> if any entity exists in the repository
+		/// that matches the given filter, otherwise <c>false</c>.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="ExistsAsync{TEntity}(IRepository{TEntity}, IQueryFilter, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static bool Exists<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter)
+			where TEntity : class
+			=> repository.ExistsAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously checks if an entity exists in the repository given a filter expression,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to check the existence
+		/// of any entity that matches the given filter.
+		/// </param>
+		/// <param name="filter">
+		/// The filter expression used to check the existence of any matching entity.
+		/// </param>
+		/// <returns>
+		/// Returns <c>true</c> if any entity exists in the repository
+		/// that matches the given filter, otherwise <c>false</c>.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="ExistsAsync{TEntity}(IRepository{TEntity}, Expression{Func{TEntity, bool}}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static bool Exists<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter)
+			where TEntity : class
+			=> repository.ExistsAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
 
         #endregion
 
@@ -896,6 +1149,108 @@ namespace Deveel.Data {
 			where TEntity : class
 			=> repository.CountAllAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
+		/// <summary>
+		/// Counts the number of entities in the repository that match the given
+		/// filter expression, using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to count the entities.
+		/// </param>
+		/// <param name="filter">
+		/// A filter expression used to count the matching entities.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns the number of entities in the repository that match the given filter.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support querying or filtering.
+		/// </exception>
+		public static Task<long> CountAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> CountAsync<TEntity, object>(repository, filter, cancellationToken);
+
+		/// <summary>
+		/// Counts the number of entities in the repository,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to count the entities.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns the number of entities in the repository.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support querying or filtering.
+		/// </exception>
+		public static Task<long> CountAllAsync<TEntity>(this IRepository<TEntity> repository, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> CountAllAsync<TEntity, object>(repository, cancellationToken);
+
+		/// <summary>
+		/// Synchronously counts the number of entities in the repository that match
+		/// the given filter expression, using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to count the entities.
+		/// </param>
+		/// <param name="filter">
+		/// The filter expression used to count the matching entities.
+		/// </param>
+		/// <returns>
+		/// Returns the number of entities in the repository that match the given filter.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="CountAsync{TEntity}(IRepository{TEntity}, Expression{Func{TEntity, bool}}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static long Count<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter)
+			where TEntity : class
+			=> repository.CountAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously counts all entities in the repository,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to count the entities.
+		/// </param>
+		/// <returns>
+		/// Returns the number of entities in the repository.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="CountAllAsync{TEntity}(IRepository{TEntity}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static long CountAll<TEntity>(this IRepository<TEntity> repository)
+			where TEntity : class
+			=> repository.CountAllAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+
 		#endregion
 
 		#region Find
@@ -925,6 +1280,35 @@ namespace Deveel.Data {
 		public static TEntity? Find<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TKey key)
             where TEntity : class
             => repository.FindAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously finds a single entity in the repository, given the object key
+		/// that uniquely identifies it, using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to find the entity.
+		/// </param>
+		/// <param name="key">
+		/// The key that uniquely identifies the entity to find.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> identified by
+		/// the given key, or <c>null</c> if no entity with the given key exists.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="IRepository{TEntity,TKey}.FindAsync(TKey, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static TEntity? Find<TEntity>(this IRepository<TEntity> repository, object key)
+			where TEntity : class
+			=> repository.FindAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();
 
 		#endregion
 
@@ -1081,38 +1465,76 @@ namespace Deveel.Data {
 
 		/// <summary>
 		/// Synchronously finds the first entity in the repository that matches
-		/// the given query filter.
+		/// the given query, including optional sort order.
 		/// </summary>
 		/// <typeparam name="TEntity">
 		/// The type of entity handled by the repository.
 		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
 		/// <param name="repository">
 		/// The repository instance to use to find the entity.
 		/// </param>
-		/// <param name="filter">
-		/// The filter used to find the entity.
+		/// <param name="query">
+		/// The query object used to find the entity, and eventually sort the result.
 		/// </param>
 		/// <returns>
-		/// Returns an instance of <typeparamref name="TEntity"/> that
-		/// matched the given filter, or <c>null</c> if no entity matches.
+		/// Returns an instance of <typeparamref name="TEntity"/> that matched the given
+		/// query, or <c>null</c> if no entity matches.
 		/// </returns>
 		/// <remarks>
 		/// <para>
 		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
 		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
-		/// Prefer <see cref="FindFirstAsync{TEntity, TKey}(IRepository{TEntity, TKey}, IQueryFilter, CancellationToken)"/>
+		/// Prefer <see cref="FindFirstAsync{TEntity, TKey}(IRepository{TEntity, TKey}, IQuery, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support querying.
+		/// </exception>
+		public static TEntity? FindFirst<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQuery query)
+			where TEntity : class
+			=> repository.FindFirstAsync(query).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously finds the first entity in the repository that matches
+		/// the given filter expression.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entity.
+		/// </param>
+		/// <param name="filter">
+		/// The filter expression used to find the entity.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> that matched the given
+		/// filter, or <c>null</c> if no entity matches.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindFirstAsync{TEntity, TKey}(IRepository{TEntity, TKey}, Expression{Func{TEntity, bool}}, CancellationToken)"/>
 		/// in async contexts to avoid potential deadlocks.
 		/// </para>
 		/// </remarks>
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support filtering.
 		/// </exception>
-		public static TEntity? FindFirst<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter)
+		public static TEntity? FindFirst<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter)
 			where TEntity : class
-			=> repository.FindFirstAsync(new Query(filter)).ConfigureAwait(false).GetAwaiter().GetResult();
+			=> repository.FindFirstAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
 
 		/// <summary>
-		/// Finds the first entity in the repository, naturally ordered.
+		/// Synchronously finds the first entity in the repository, naturally ordered.
 		/// </summary>
 		/// <typeparam name="TEntity">
 		/// The type of entity handled by the repository.
@@ -1128,9 +1550,200 @@ namespace Deveel.Data {
 		/// is the first entity in the repository, or <c>null</c> if the
 		/// repository is empty.
 		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindFirstAsync{TEntity, TKey}(IRepository{TEntity, TKey}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
 		public static TEntity? FindFirst<TEntity, TKey>(this IRepository<TEntity, TKey> repository)
-            where TEntity : class
-            => repository.AsFilterable().FindFirst(QueryFilter.Empty);
+			where TEntity : class
+			=> repository.FindFirstAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Finds the first entity in the repository, using the single-type-parameter
+		/// repository contract, filtered by the given query.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entity.
+		/// </param>
+		/// <param name="query">
+		/// The query object used to find the entity, and eventually sort the result.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> that matched the given
+		/// query, or <c>null</c> if no entity matches.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support querying.
+		/// </exception>
+		public static Task<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, IQuery query, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> FindFirstAsync<TEntity, object>(repository, query, cancellationToken);
+
+		/// <summary>
+		/// Finds the first entity in the repository that matches the given filter,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entity.
+		/// </param>
+		/// <param name="filter">
+		/// A filter used to find the entity.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> that matched the given
+		/// filter, or <c>null</c> if no entity matches.
+		/// </returns>
+		public static Task<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> FindFirstAsync<TEntity, object>(repository, filter, cancellationToken);
+
+		/// <summary>
+		/// Finds the first entity in the repository that matches the given
+		/// filter expression, using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entity.
+		/// </param>
+		/// <param name="filter">
+		/// The filter expression used to find the entity.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> that matched the
+		/// given filter, or <c>null</c> if no entity matches.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support filtering.
+		/// </exception>
+		public static Task<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> FindFirstAsync<TEntity, object>(repository, filter, cancellationToken);
+
+		/// <summary>
+		/// Finds the first entity in the repository, naturally ordered,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entity.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> that is the first
+		/// entity in the repository, or <c>null</c> if the repository is empty.
+		/// </returns>
+		public static Task<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> FindFirstAsync<TEntity, object>(repository, cancellationToken);
+
+		/// <summary>
+		/// Synchronously finds the first entity in the repository that matches the given
+		/// query, using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entity.
+		/// </param>
+		/// <param name="query">
+		/// The query object used to find the entity, and eventually sort the result.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> that matched the given
+		/// query, or <c>null</c> if no entity matches.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindFirstAsync{TEntity}(IRepository{TEntity}, IQuery, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static TEntity? FindFirst<TEntity>(this IRepository<TEntity> repository, IQuery query)
+			where TEntity : class
+			=> repository.FindFirstAsync(query).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously finds the first entity in the repository that matches the given
+		/// filter expression, using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entity.
+		/// </param>
+		/// <param name="filter">
+		/// The filter expression used to find the entity.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> that matched the given
+		/// filter, or <c>null</c> if no entity matches.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindFirstAsync{TEntity}(IRepository{TEntity}, Expression{Func{TEntity, bool}}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static TEntity? FindFirst<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter)
+			where TEntity : class
+			=> repository.FindFirstAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously finds the first entity in the repository, naturally ordered,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entity.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> that is the first
+		/// entity in the repository, or <c>null</c> if the repository is empty.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindFirstAsync{TEntity}(IRepository{TEntity}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static TEntity? FindFirst<TEntity>(this IRepository<TEntity> repository)
+			where TEntity : class
+			=> repository.FindFirstAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
 		#endregion
 
@@ -1282,6 +1895,73 @@ namespace Deveel.Data {
 
 		/// <summary>
 		/// Synchronously finds all the entities in the repository that match
+		/// the given query, including optional sort order.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <param name="query">
+		/// The query object used to find the entities, and eventually sort the result.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository that match the given query, eventually sorted.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindAllAsync{TEntity, TKey}(IRepository{TEntity, TKey}, IQuery, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support querying or filtering.
+		/// </exception>
+		public static IList<TEntity> FindAll<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQuery query)
+			where TEntity : class
+			=> repository.FindAllAsync(query).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously finds all the entities in the repository that match
+		/// the given filter expression.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <param name="filter">
+		/// The filter expression used to find the entities.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository that match the given filter.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindAllAsync{TEntity, TKey}(IRepository{TEntity, TKey}, Expression{Func{TEntity, bool}}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static IList<TEntity> FindAll<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter)
+			where TEntity : class
+			=> repository.FindAllAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously finds all the entities in the repository that match
 		/// the given query filter.
 		/// </summary>
 		/// <typeparam name="TEntity">
@@ -1308,6 +1988,189 @@ namespace Deveel.Data {
 		public static IList<TEntity> FindAll<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter)
 			where TEntity : class
 			=> repository.FindAllAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Finds all the entities in the repository that match the given query,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <param name="query">
+		/// The query object used to find the entities, and eventually sort the result.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository that match the given query.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support querying or filtering.
+		/// </exception>
+		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, IQuery query, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> FindAllAsync<TEntity, object>(repository, query, cancellationToken);
+
+		/// <summary>
+		/// Finds all the entities in the repository that match the given filter,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <param name="filter">
+		/// The filter used to find the entities.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository that match the given filter.
+		/// </returns>
+		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> FindAllAsync<TEntity, object>(repository, filter, cancellationToken);
+
+		/// <summary>
+		/// Finds all the entities in the repository that match the given filter expression,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <param name="filter">
+		/// The filter expression used to find the entities.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository that match the given filter.
+		/// </returns>
+		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> FindAllAsync<TEntity, object>(repository, filter, cancellationToken);
+
+		/// <summary>
+		/// Finds all the entities in the repository, naturally ordered,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository, naturally ordered.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support querying or filtering.
+		/// </exception>
+		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, CancellationToken cancellationToken = default)
+			where TEntity : class
+			=> FindAllAsync<TEntity, object>(repository, cancellationToken);
+
+		/// <summary>
+		/// Synchronously finds all the entities in the repository that match the given
+		/// query, using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <param name="query">
+		/// The query object used to find the entities, and eventually sort the result.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository that match the given query.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindAllAsync{TEntity}(IRepository{TEntity}, IQuery, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static IList<TEntity> FindAll<TEntity>(this IRepository<TEntity> repository, IQuery query)
+			where TEntity : class
+			=> repository.FindAllAsync(query).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously finds all the entities in the repository that match the given
+		/// filter expression, using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <param name="filter">
+		/// The filter expression used to find the entities.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository that match the given filter.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindAllAsync{TEntity}(IRepository{TEntity}, Expression{Func{TEntity, bool}}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static IList<TEntity> FindAll<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter)
+			where TEntity : class
+			=> repository.FindAllAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously finds all the entities in the repository, naturally ordered,
+		/// using the single-type-parameter repository contract.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository, naturally ordered.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindAllAsync{TEntity}(IRepository{TEntity}, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static IList<TEntity> FindAll<TEntity>(this IRepository<TEntity> repository)
+			where TEntity : class
+			=> repository.FindAllAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
 		/// <summary>
 		/// Finds all the entities in the repository, naturally ordered.

--- a/src/Deveel.Repository.Core/Data/RepositoryExtensions.cs
+++ b/src/Deveel.Repository.Core/Data/RepositoryExtensions.cs
@@ -722,6 +722,42 @@ namespace Deveel.Data {
 
 		/// <summary>
 		/// Counts the number of entities in the repository
+		/// that match the given query filter.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to count the entities.
+		/// </param>
+		/// <param name="filter">
+		/// The filter used to count the matching entities.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns the number of entities in the repository that match
+		/// the given filter.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support querying or filtering.
+		/// </exception>
+		public static Task<long> CountAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+			where TEntity : class {
+			if (repository.IsFilterable())
+				return repository.AsFilterable().CountAsync(filter, cancellationToken);
+			if (repository.IsQueryable())
+				return Task.FromResult(repository.AsQueryable().AsQueryable().LongCount(filter.AsLambda<TEntity>()));
+
+			throw new NotSupportedException("The repository does not support querying");
+		}
+
+		/// <summary>
+		/// Counts the number of entities in the repository
 		/// </summary>
 		/// <typeparam name="TEntity">
         /// The type of entity handled by the repository.
@@ -776,6 +812,69 @@ namespace Deveel.Data {
 		public static long Count<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter)
             where TEntity : class
             => repository.CountAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously counts the number of entities in the repository
+		/// that match the given query filter.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <typeparam name="TKey">
+		/// The type of the key that uniquely identifies the entity.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to count the entities.
+		/// </param>
+		/// <param name="filter">
+		/// The filter used to count the matching entities.
+		/// </param>
+		/// <returns>
+		/// Returns the number of entities in the repository that match
+		/// the given filter.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="CountAsync{TEntity, TKey}(IRepository{TEntity, TKey}, IQueryFilter, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		/// <seealso cref="CountAsync{TEntity, TKey}(IRepository{TEntity, TKey}, IQueryFilter, CancellationToken)"/>
+		public static long Count<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter)
+			where TEntity : class
+			=> repository.CountAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously counts the number of entities in the repository
+		/// that match the given query filter.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The instance of the repository to use to count the entities.
+		/// </param>
+		/// <param name="filter">
+		/// The filter used to count the matching entities.
+		/// </param>
+		/// <returns>
+		/// Returns the number of entities in the repository that match
+		/// the given filter.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="CountAsync{TEntity, TKey}(IRepository{TEntity, TKey}, IQueryFilter, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		/// <seealso cref="CountAsync{TEntity, TKey}(IRepository{TEntity, TKey}, IQueryFilter, CancellationToken)"/>
+		public static long Count<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter)
+			where TEntity : class
+			=> repository.CountAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
 
 		/// <summary>
 		/// Counts the number of entities in the repository
@@ -981,6 +1080,38 @@ namespace Deveel.Data {
             => repository.FindFirstAsync(new Query(filter)).ConfigureAwait(false).GetAwaiter().GetResult();
 
 		/// <summary>
+		/// Synchronously finds the first entity in the repository that matches
+		/// the given query filter.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entity.
+		/// </param>
+		/// <param name="filter">
+		/// The filter used to find the entity.
+		/// </param>
+		/// <returns>
+		/// Returns an instance of <typeparamref name="TEntity"/> that
+		/// matched the given filter, or <c>null</c> if no entity matches.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindFirstAsync{TEntity, TKey}(IRepository{TEntity, TKey}, IQueryFilter, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support filtering.
+		/// </exception>
+		public static TEntity? FindFirst<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter)
+			where TEntity : class
+			=> repository.FindFirstAsync(new Query(filter)).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
 		/// Finds the first entity in the repository, naturally ordered.
 		/// </summary>
 		/// <typeparam name="TEntity">
@@ -1148,6 +1279,35 @@ namespace Deveel.Data {
 		public static IList<TEntity> FindAll<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter)
             where TEntity : class
             => repository.FindAllAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
+
+		/// <summary>
+		/// Synchronously finds all the entities in the repository that match
+		/// the given query filter.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of entity handled by the repository.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository instance to use to find the entities.
+		/// </param>
+		/// <param name="filter">
+		/// The filter used to find the entities.
+		/// </param>
+		/// <returns>
+		/// Returns a list of <typeparamref name="TEntity"/> from
+		/// the repository that match the given filter.
+		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <strong>Warning:</strong> This is a blocking synchronous call that wraps an
+		/// asynchronous operation using <c>ConfigureAwait(false).GetAwaiter().GetResult()</c>.
+		/// Prefer <see cref="FindAllAsync{TEntity, TKey}(IRepository{TEntity, TKey}, IQueryFilter, CancellationToken)"/>
+		/// in async contexts to avoid potential deadlocks.
+		/// </para>
+		/// </remarks>
+		public static IList<TEntity> FindAll<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter)
+			where TEntity : class
+			=> repository.FindAllAsync(filter).ConfigureAwait(false).GetAwaiter().GetResult();
 
 		/// <summary>
 		/// Finds all the entities in the repository, naturally ordered.

--- a/test/Deveel.Repository.Core.XUnit/Fixtures/PersonFixture.cs
+++ b/test/Deveel.Repository.Core.XUnit/Fixtures/PersonFixture.cs
@@ -11,9 +11,14 @@ namespace Deveel.Data;
 public class PersonFixture
 {
     /// <summary>
-    /// Centralized Faker for <see cref="Person"/> — defined once, reused across all builder methods.
+    /// Per-instance <see cref="Faker{T}"/> for <see cref="Person"/> entities.
+    /// Intentionally <em>not</em> <c>static</c>: xUnit parallelises test collections, so a
+    /// shared static Faker would be accessed from multiple threads simultaneously, violating
+    /// Bogus's single-threaded contract and producing non-deterministic data.
+    /// Each <see cref="PersonFixture"/> instance (one per test class) therefore owns its own
+    /// Faker with independent random state.
     /// </summary>
-    public static readonly Faker<Person> PersonFaker = new Faker<Person>("en")
+    public readonly Faker<Person> PersonFaker = new Faker<Person>("en")
         .RuleFor(p => p.Id, f => f.Random.Guid().ToString())
         .RuleFor(p => p.FirstName, f => f.Name.FirstName())
         .RuleFor(p => p.LastName, f => f.Name.LastName())

--- a/test/Deveel.Repository.Core.XUnit/Unit/CombinedFilterTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/CombinedFilterTests.cs
@@ -5,7 +5,6 @@
 [Trait("Feature", "QueryFilter")]
 public class CombinedFilterTests
 {
-    private static readonly Bogus.Faker<Person> PersonFaker = PersonFixture.PersonFaker;
 
     #region QueryFilter.Combine
 

--- a/test/Deveel.Repository.Core.XUnit/Unit/ListAsRepositoryTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/ListAsRepositoryTests.cs
@@ -5,11 +5,13 @@
 [Trait("Feature", "Repository")]
 public class ListAsRepositoryTests : IClassFixture<PersonFixture>
 {
+    private readonly PersonFixture _fixture;
     private readonly List<Person> _people;
     private readonly IRepository<Person> _repository;
 
     public ListAsRepositoryTests(PersonFixture fixture)
     {
+        _fixture = fixture;
         _people = fixture.BuildPeople(100).ToList();
         _repository = _people.AsRepository();
     }
@@ -24,7 +26,7 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
         var readOnly = _people.AsReadOnly().AsRepository();
-        var newPerson = PersonFixture.PersonFaker.Generate();
+        var newPerson = _fixture.PersonFaker.Generate();
 
         // Act & Assert
         await Assert.ThrowsAsync<NotSupportedException>(() => readOnly.AddAsync(newPerson, cancellationToken));
@@ -36,7 +38,7 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
         var initialCount = _people.Count;
-        var newPerson = PersonFixture.PersonFaker.Generate();
+        var newPerson = _fixture.PersonFaker.Generate();
 
         // Act
         await _repository.AddAsync(newPerson, cancellationToken);
@@ -52,7 +54,7 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
         var initialCount = _people.Count;
-        var person = PersonFixture.PersonFaker.Generate();
+        var person = _fixture.PersonFaker.Generate();
         var originalId = person.Id;
 
         // Act
@@ -69,7 +71,7 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
         var initialCount = _people.Count;
-        var newPeople = PersonFixture.PersonFaker.Generate(10);
+        var newPeople = _fixture.PersonFaker.Generate(10);
 
         // Act
         await _repository.AddRangeAsync(newPeople, cancellationToken);
@@ -85,7 +87,7 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
         var readOnly = _people.AsReadOnly().AsRepository();
-        var newPeople = PersonFixture.PersonFaker.Generate(10);
+        var newPeople = _fixture.PersonFaker.Generate(10);
 
         // Act & Assert
         await Assert.ThrowsAsync<NotSupportedException>(() => readOnly.AddRangeAsync(newPeople, cancellationToken));
@@ -408,7 +410,7 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
         var cancellationToken = TestContext.Current.CancellationToken;
         var target = RandomPerson();
         var originalId = target.Id;
-        var newFirstName = PersonFixture.PersonFaker.Generate().FirstName;
+        var newFirstName = _fixture.PersonFaker.Generate().FirstName;
         target.FirstName = newFirstName;
 
         // Act
@@ -425,7 +427,7 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
     {
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
-        var nonExistent = PersonFixture.PersonFaker.Generate();
+        var nonExistent = _fixture.PersonFaker.Generate();
 
         // Act
         var result = await _repository.UpdateAsync(nonExistent, cancellationToken);

--- a/test/Deveel.Repository.Core.XUnit/Unit/PageQueryTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/PageQueryTests.cs
@@ -7,6 +7,8 @@ namespace Deveel.Data;
 [Trait("Feature", "PageQuery")]
 public class PageQueryTests
 {
+    private readonly PersonFaker _faker = new PersonFaker();
+
     #region PageQuery creation
 
     [Fact]
@@ -41,7 +43,7 @@ public class PageQueryTests
     public void Should_HaveExpressionFilter_When_WhereClauseIsApplied()
     {
         // Arrange
-        var person = PersonFixture.PersonFaker.Generate();
+        var person = _faker.Generate();
 
         // Act
         var query = new PageQuery<Person>(1, 10).Where(x => x.FirstName == person.FirstName);
@@ -57,7 +59,7 @@ public class PageQueryTests
     public void Should_HaveCombinedFilter_When_MultipleWhereClausesAreApplied()
     {
         // Arrange
-        var person = PersonFixture.PersonFaker.Generate();
+        var person = _faker.Generate();
 
         // Act
         var query = new PageQuery<Person>(1, 10)

--- a/test/Deveel.Repository.Core.XUnit/Unit/PageResultTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/PageResultTests.cs
@@ -5,6 +5,8 @@
 [Trait("Feature", "PageResult")]
 public class PageResultTests
 {
+    private readonly PersonFaker _faker = new PersonFaker();
+
     #region PageResult construction
 
     [Fact]
@@ -12,7 +14,7 @@ public class PageResultTests
     {
         // Arrange
         var query = new PageQuery<Person>(1, 10);
-        var items = PersonFixture.PersonFaker.Generate(10);
+        var items = _faker.Generate(10);
 
         // Act
         var result = new PageResult<Person>(query, 100, items);
@@ -36,7 +38,7 @@ public class PageResultTests
     {
         // Arrange
         var query = new PageQuery<Person>(10, 10);
-        var items = PersonFixture.PersonFaker.Generate(8);
+        var items = _faker.Generate(8);
 
         // Act
         var result = new PageResult<Person>(query, 100, items);

--- a/test/Deveel.Repository.Core.XUnit/Unit/QueryFilterTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/QueryFilterTests.cs
@@ -5,6 +5,7 @@
 [Trait("Feature", "QueryFilter")]
 public class QueryFilterTests
 {
+    private readonly PersonFaker _faker = new PersonFaker();
     private class Company
     {
         public string Name { get; set; } = string.Empty;
@@ -97,7 +98,7 @@ public class QueryFilterTests
     public void Should_ReturnMatchingEntity_When_CallingFirstOrDefaultWithFilter()
     {
         // Arrange
-        var people = PersonFixture.PersonFaker.Generate(10);
+        var people = _faker.Generate(10);
         var target = people[Random.Shared.Next(0, people.Count - 1)];
         var filter = new ExpressionQueryFilter<Person>(x => x.FirstName == target.FirstName);
 
@@ -113,7 +114,7 @@ public class QueryFilterTests
     public void Should_ReturnMatchingList_When_CallingToListWithFilter()
     {
         // Arrange
-        var people = PersonFixture.PersonFaker.Generate(100);
+        var people = _faker.Generate(100);
         var target = people[Random.Shared.Next(0, people.Count - 1)];
         var expected = people.Where(x => x.FirstName == target.FirstName).ToList();
         var filter = new ExpressionQueryFilter<Person>(x => x.FirstName == target.FirstName);
@@ -130,7 +131,7 @@ public class QueryFilterTests
     public void Should_ReturnTrue_When_AnyMatchesFilter()
     {
         // Arrange
-        var people = PersonFixture.PersonFaker.Generate(100);
+        var people = _faker.Generate(100);
         var target = people[Random.Shared.Next(0, people.Count - 1)];
         var filter = new ExpressionQueryFilter<Person>(x => x.FirstName == target.FirstName);
 

--- a/test/Deveel.Repository.Core.XUnit/Unit/QueryOrderTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/QueryOrderTests.cs
@@ -5,6 +5,8 @@
 [Trait("Feature", "QueryOrder")]
 public class QueryOrderTests
 {
+    private readonly PersonFaker _faker = new PersonFaker();
+
     #region QueryOrder.Combine
 
     [Fact]
@@ -58,7 +60,7 @@ public class QueryOrderTests
     public void Should_ReturnSortedQueryable_When_ApplyingCombinedSort()
     {
         // Arrange
-        var people = PersonFixture.PersonFaker.Generate(4);
+        var people = _faker.Generate(4);
         var queryable = people.AsQueryable();
         var sort1 = QueryOrder.OrderBy<Person>(x => x.FirstName);
         var sort2 = QueryOrder.OrderByDescending<Person>(x => x.LastName);
@@ -76,7 +78,7 @@ public class QueryOrderTests
     public void Should_SortByProperty_When_ApplyingFieldNameSortWithNoMapper()
     {
         // Arrange
-        var people = PersonFixture.PersonFaker.Generate(4);
+        var people = _faker.Generate(4);
         var queryable = people.AsQueryable();
         var sort = QueryOrder.OrderBy("FirstName");
 
@@ -92,7 +94,7 @@ public class QueryOrderTests
     public void Should_SortByMappedField_When_ApplyingFieldNameSortWithDelegatedMapper()
     {
         // Arrange
-        var people = PersonFixture.PersonFaker.Generate(4);
+        var people = _faker.Generate(4);
         var queryable = people.AsQueryable();
         var sort = QueryOrder.OrderBy("first_name");
 

--- a/test/Deveel.Repository.Core.XUnit/Unit/QueryTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/QueryTests.cs
@@ -5,13 +5,15 @@
 [Trait("Feature", "Query")]
 public class QueryTests
 {
+    private readonly PersonFaker _faker = new PersonFaker();
+
     #region Query construction
 
     [Fact]
     public void Should_HaveFilterAndNoOrder_When_QueryHasFilterOnly()
     {
         // Arrange
-        var person = PersonFixture.PersonFaker.Generate();
+        var person = _faker.Generate();
 
         // Act
         var query = new Query(QueryFilter.Where<Person>(p => p.FirstName == person.FirstName));
@@ -26,7 +28,7 @@ public class QueryTests
     public void Should_HaveExpressionFilter_When_BuiltWithWhereFactory()
     {
         // Arrange
-        var person = PersonFixture.PersonFaker.Generate();
+        var person = _faker.Generate();
 
         // Act
         var query = Query.Where<Person>(p => p.FirstName == person.FirstName);
@@ -41,7 +43,7 @@ public class QueryTests
     public void Should_HaveCombinedFilter_When_TwoWhereClausesAreChained()
     {
         // Arrange
-        var person = PersonFixture.PersonFaker.Generate();
+        var person = _faker.Generate();
 
         // Act
         var query = new QueryBuilder<Person>()
@@ -62,7 +64,7 @@ public class QueryTests
     public void Should_HaveFilterAndExpressionSort_When_WhereAndOrderByExpressionAreChained()
     {
         // Arrange
-        var person = PersonFixture.PersonFaker.Generate();
+        var person = _faker.Generate();
 
         // Act
         var query = new QueryBuilder<Person>()
@@ -79,7 +81,7 @@ public class QueryTests
     public void Should_HaveFilterAndFieldSort_When_WhereAndOrderByFieldNameAreChained()
     {
         // Arrange
-        var person = PersonFixture.PersonFaker.Generate();
+        var person = _faker.Generate();
 
         // Act
         var query = new QueryBuilder<Person>()
@@ -96,7 +98,7 @@ public class QueryTests
     public void Should_HaveDescendingFieldSort_When_WhereAndOrderByDescendingFieldNameAreChained()
     {
         // Arrange
-        var person = PersonFixture.PersonFaker.Generate();
+        var person = _faker.Generate();
 
         // Act
         var query = new QueryBuilder<Person>()
@@ -114,7 +116,7 @@ public class QueryTests
     public void Should_HaveDescendingExpressionSort_When_WhereAndOrderByDescendingExpressionAreChained()
     {
         // Arrange
-        var person = PersonFixture.PersonFaker.Generate();
+        var person = _faker.Generate();
 
         // Act
         var query = new QueryBuilder<Person>()
@@ -136,7 +138,7 @@ public class QueryTests
     public void Should_FilterQueryable_When_ApplyingQueryWithWhereOnly()
     {
         // Arrange
-        var people = PersonFixture.PersonFaker.Generate(10);
+        var people = _faker.Generate(10);
         var matches = people.Take(3).ToList();
         var sharedName = Guid.NewGuid().ToString("N")[..8]; // unique surname to avoid collision
         foreach (var p in matches)
@@ -155,7 +157,7 @@ public class QueryTests
     public void Should_FilterAndSortQueryable_When_ApplyingQueryWithWhereAndOrderBy()
     {
         // Arrange
-        var people = PersonFixture.PersonFaker.Generate(10);
+        var people = _faker.Generate(10);
         var matches = people.Take(3).ToList();
         var sharedName = Guid.NewGuid().ToString("N")[..8];
         foreach (var p in matches)

--- a/test/Deveel.Repository.Core.XUnit/Unit/RepositoryExtensionsSyncTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/RepositoryExtensionsSyncTests.cs
@@ -1,13 +1,8 @@
 namespace Deveel.Data;
 
 /// <summary>
-/// Unit tests for the synchronous extension methods added to <see cref="RepositoryExtensions"/>:
-/// <list type="bullet">
-///   <item><see cref="RepositoryExtensions.FindFirst{TEntity}(IRepository{TEntity}, IQueryFilter)"/></item>
-///   <item><see cref="RepositoryExtensions.FindFirst{TEntity, TKey}(IRepository{TEntity, TKey}, IQueryFilter)"/></item>
-///   <item><see cref="RepositoryExtensions.FindAll{TEntity}(IRepository{TEntity}, IQueryFilter)"/></item>
-///   <item><see cref="RepositoryExtensions.Count{TEntity}(IRepository{TEntity}, IQueryFilter)"/></item>
-/// </list>
+/// Unit tests for the synchronous extension methods in <see cref="RepositoryExtensions"/>,
+/// verifying full async/sync parity across all operation groups.
 /// </summary>
 [Trait("Category", "Unit")]
 [Trait("Layer", "Core")]
@@ -24,6 +19,187 @@ public class RepositoryExtensionsSyncTests : IClassFixture<PersonFixture>
     }
 
     private Person RandomPerson() => _people[Random.Shared.Next(0, _people.Count - 1)];
+
+    // -------------------------------------------------------------------------
+    // AddRange
+    // -------------------------------------------------------------------------
+
+    #region AddRange<TEntity> / AddRange<TEntity, TKey>
+
+    [Fact]
+    public void Should_IncrementCount_When_AddRangeCalledOnSingleTypeParamRepository()
+    {
+        // Arrange
+        var newPeople = PersonFixture.PersonFaker.Generate(5);
+        var initialCount = _people.Count;
+
+        // Act
+        _repository.AddRange(newPeople);
+
+        // Assert
+        Assert.Equal(initialCount + 5, _repository.CountAll());
+    }
+
+    [Fact]
+    public void Should_IncrementCount_When_AddRangeCalledOnTwoTypeParamRepository()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepo = _repository;
+        var newPeople = PersonFixture.PersonFaker.Generate(3);
+        var initialCount = _people.Count;
+
+        // Act
+        typedRepo.AddRange(newPeople);
+
+        // Assert
+        Assert.Equal(initialCount + 3, _repository.CountAll());
+    }
+
+    #endregion
+
+    // -------------------------------------------------------------------------
+    // RemoveRange
+    // -------------------------------------------------------------------------
+
+    #region RemoveRange<TEntity> / RemoveRange<TEntity, TKey>
+
+    [Fact]
+    public void Should_DecrementCount_When_RemoveRangeCalledOnSingleTypeParamRepository()
+    {
+        // Arrange
+        var toRemove = _people.Take(5).ToList();
+        var initialCount = _people.Count;
+
+        // Act
+        _repository.RemoveRange(toRemove);
+
+        // Assert
+        Assert.Equal(initialCount - 5, _repository.CountAll());
+    }
+
+    [Fact]
+    public void Should_DecrementCount_When_RemoveRangeCalledOnTwoTypeParamRepository()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepo = _repository;
+        var toRemove = _people.Take(3).ToList();
+        var initialCount = _people.Count;
+
+        // Act
+        typedRepo.RemoveRange(toRemove);
+
+        // Assert
+        Assert.Equal(initialCount - 3, _repository.CountAll());
+    }
+
+    #endregion
+
+    // -------------------------------------------------------------------------
+    // GetPage
+    // -------------------------------------------------------------------------
+
+    #region GetPage<TEntity, TKey>(int page, int size)
+
+    [Fact]
+    public void Should_ReturnFirstPage_When_GetPageCalledWithPageNumberAndSize()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepo = _repository;
+        var expectedTotalItems = _people.Count;
+
+        // Act
+        var page = typedRepo.GetPage(1, 10);
+
+        // Assert
+        Assert.NotNull(page);
+        Assert.Equal(10, page.Items.Count);
+        Assert.Equal(expectedTotalItems, page.TotalItems);
+        Assert.Equal(1, page.Request.Page);
+        Assert.Equal(10, page.Request.Size);
+    }
+
+    [Fact]
+    public void Should_ReturnCorrectPage_When_GetPageCalledForSecondPage()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepo = _repository;
+
+        // Act
+        var page = typedRepo.GetPage(2, 10);
+
+        // Assert
+        Assert.NotNull(page);
+        Assert.Equal(10, page.Items.Count);
+        Assert.Equal(2, page.Request.Page);
+    }
+
+    #endregion
+
+    // -------------------------------------------------------------------------
+    // Exists
+    // -------------------------------------------------------------------------
+
+    #region Exists<TEntity>(IRepository<TEntity>, IQueryFilter)
+
+    [Fact]
+    public void Should_ReturnTrue_When_ExistsCalledWithMatchingIQueryFilter()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var filter = QueryFilter.Where<Person>(x => x.Id == target.Id);
+
+        // Act
+        var result = _repository.Exists(filter);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Should_ReturnFalse_When_ExistsCalledWithNonMatchingIQueryFilter()
+    {
+        // Arrange
+        var filter = QueryFilter.Where<Person>(x => x.FirstName == "__no_match__");
+
+        // Act
+        var result = _repository.Exists(filter);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    #endregion
+
+    #region Exists<TEntity>(IRepository<TEntity>, Expression)
+
+    [Fact]
+    public void Should_ReturnTrue_When_ExistsCalledWithMatchingExpression()
+    {
+        // Arrange
+        var target = RandomPerson();
+
+        // Act
+        var result = _repository.Exists(x => x.Id == target.Id);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Should_ReturnFalse_When_ExistsCalledWithNonMatchingExpression()
+    {
+        // Act
+        var result = _repository.Exists(x => x.FirstName == "__no_match__");
+
+        // Assert
+        Assert.False(result);
+    }
+
+    #endregion
+
+    // -------------------------------------------------------------------------
+    // Count
+    // -------------------------------------------------------------------------
 
     #region FindFirst<TEntity>(IRepository<TEntity>, IQueryFilter)
 
@@ -71,90 +247,6 @@ public class RepositoryExtensionsSyncTests : IClassFixture<PersonFixture>
         // Assert
         Assert.NotNull(result);
         Assert.Equal(expected.Id, result.Id);
-    }
-
-    #endregion
-
-    #region FindFirst<TEntity, TKey>(IRepository<TEntity, TKey>, IQueryFilter)
-
-    [Fact]
-    public void Should_ReturnMatchingEntity_When_FindFirstWithKeyCalledWithMatchingIQueryFilter()
-    {
-        // Arrange
-        var target = RandomPerson();
-        IRepository<Person, object> typedRepository = _repository;
-        var filter = QueryFilter.Where<Person>(x => x.Id == target.Id);
-
-        // Act
-        var result = typedRepository.FindFirst(filter);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal(target.Id, result.Id);
-        Assert.Equal(target.FirstName, result.FirstName);
-    }
-
-    [Fact]
-    public void Should_ReturnNull_When_FindFirstWithKeyCalledWithNonMatchingIQueryFilter()
-    {
-        // Arrange
-        IRepository<Person, object> typedRepository = _repository;
-        var filter = QueryFilter.Where<Person>(x => x.LastName == "__no_match__");
-
-        // Act
-        var result = typedRepository.FindFirst(filter);
-
-        // Assert
-        Assert.Null(result);
-    }
-
-    #endregion
-
-    #region FindAll<TEntity>(IRepository<TEntity>, IQueryFilter)
-
-    [Fact]
-    public void Should_ReturnMatchingEntities_When_FindAllCalledWithMatchingIQueryFilter()
-    {
-        // Arrange
-        var target = RandomPerson();
-        var filter = QueryFilter.Where<Person>(x => x.FirstName == target.FirstName);
-        var expectedCount = _people.Count(x => x.FirstName == target.FirstName);
-
-        // Act
-        var result = _repository.FindAll(filter);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal(expectedCount, result.Count);
-        Assert.All(result, p => Assert.Equal(target.FirstName, p.FirstName));
-    }
-
-    [Fact]
-    public void Should_ReturnEmpty_When_FindAllCalledWithNonMatchingIQueryFilter()
-    {
-        // Arrange
-        var filter = QueryFilter.Where<Person>(x => x.FirstName == "__no_match__");
-
-        // Act
-        var result = _repository.FindAll(filter);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Empty(result);
-    }
-
-    [Fact]
-    public void Should_ReturnAllEntities_When_FindAllCalledWithEmptyFilter()
-    {
-        // Arrange
-        var filter = QueryFilter.Empty;
-
-        // Act
-        var result = _repository.FindAll(filter);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal(_people.Count, result.Count);
     }
 
     #endregion
@@ -218,6 +310,48 @@ public class RepositoryExtensionsSyncTests : IClassFixture<PersonFixture>
 
     #endregion
 
+    #region Count<TEntity>(IRepository<TEntity>, Expression)
+
+    [Fact]
+    public void Should_ReturnMatchingCount_When_CountCalledWithMatchingExpression()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var expectedCount = _people.LongCount(x => x.FirstName == target.FirstName);
+
+        // Act
+        var count = _repository.Count(x => x.FirstName == target.FirstName);
+
+        // Assert
+        Assert.Equal(expectedCount, count);
+    }
+
+    [Fact]
+    public void Should_ReturnZero_When_CountCalledWithNonMatchingExpression()
+    {
+        // Act
+        var count = _repository.Count(x => x.FirstName == "__no_match__");
+
+        // Assert
+        Assert.Equal(0L, count);
+    }
+
+    #endregion
+
+    #region CountAll<TEntity>(IRepository<TEntity>)
+
+    [Fact]
+    public void Should_ReturnTotalCount_When_CountAllCalled()
+    {
+        // Act
+        var count = _repository.CountAll();
+
+        // Assert
+        Assert.Equal(_people.Count, count);
+    }
+
+    #endregion
+
     #region Count<TEntity, TKey>(IRepository<TEntity, TKey>, IQueryFilter)
 
     [Fact]
@@ -248,6 +382,450 @@ public class RepositoryExtensionsSyncTests : IClassFixture<PersonFixture>
 
         // Assert
         Assert.Equal(0L, count);
+    }
+
+    #endregion
+
+    // -------------------------------------------------------------------------
+    // Find (by key)
+    // -------------------------------------------------------------------------
+
+    #region Find<TEntity>(IRepository<TEntity>, object)
+
+    [Fact]
+    public void Should_ReturnEntity_When_FindCalledWithExistingKey()
+    {
+        // Arrange
+        var target = RandomPerson();
+
+        // Act
+        var result = _repository.Find(target.Id!);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(target.Id, result.Id);
+    }
+
+    [Fact]
+    public void Should_ReturnNull_When_FindCalledWithNonExistingKey()
+    {
+        // Arrange
+        var missingKey = Guid.NewGuid().ToString();
+
+        // Act
+        var result = _repository.Find(missingKey);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    // -------------------------------------------------------------------------
+    // FindFirst
+    // -------------------------------------------------------------------------
+
+    #region FindFirst<TEntity, TKey>(IRepository<TEntity, TKey>, IQueryFilter)
+
+    [Fact]
+    public void Should_ReturnMatchingEntity_When_FindFirstWithKeyCalledWithMatchingIQueryFilter()
+    {
+        // Arrange
+        var target = RandomPerson();
+        IRepository<Person, object> typedRepository = _repository;
+        var filter = QueryFilter.Where<Person>(x => x.Id == target.Id);
+
+        // Act
+        var result = typedRepository.FindFirst(filter);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(target.Id, result.Id);
+        Assert.Equal(target.FirstName, result.FirstName);
+    }
+
+    [Fact]
+    public void Should_ReturnNull_When_FindFirstWithKeyCalledWithNonMatchingIQueryFilter()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepository = _repository;
+        var filter = QueryFilter.Where<Person>(x => x.LastName == "__no_match__");
+
+        // Act
+        var result = typedRepository.FindFirst(filter);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    #region FindFirst<TEntity, TKey>(IRepository<TEntity, TKey>, IQuery)
+
+    [Fact]
+    public void Should_ReturnMatchingEntity_When_FindFirstWithKeyCalledWithIQuery()
+    {
+        // Arrange
+        var target = RandomPerson();
+        IRepository<Person, object> typedRepository = _repository;
+        var query = Query.Where<Person>(x => x.Id == target.Id);
+
+        // Act
+        var result = typedRepository.FindFirst(query);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(target.Id, result.Id);
+    }
+
+    [Fact]
+    public void Should_ReturnNull_When_FindFirstWithKeyCalledWithNonMatchingIQuery()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepository = _repository;
+        var query = Query.Where<Person>(x => x.FirstName == "__no_match__");
+
+        // Act
+        var result = typedRepository.FindFirst(query);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    #region FindFirst<TEntity, TKey>(IRepository<TEntity, TKey>, Expression)
+
+    [Fact]
+    public void Should_ReturnMatchingEntity_When_FindFirstWithKeyCalledWithExpression()
+    {
+        // Arrange
+        var target = RandomPerson();
+        IRepository<Person, object> typedRepository = _repository;
+
+        // Act
+        var result = typedRepository.FindFirst(x => x.Id == target.Id);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(target.Id, result.Id);
+    }
+
+    [Fact]
+    public void Should_ReturnNull_When_FindFirstWithKeyCalledWithNonMatchingExpression()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepository = _repository;
+
+        // Act
+        var result = typedRepository.FindFirst(x => x.FirstName == "__no_match__");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    #region FindFirst<TEntity, TKey>(IRepository<TEntity, TKey>) — no filter
+
+    [Fact]
+    public void Should_ReturnAnyEntity_When_FindFirstWithKeyCalledWithNoFilter()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepository = _repository;
+
+        // Act
+        var result = typedRepository.FindFirst();
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    #endregion
+
+    #region FindFirst<TEntity>(IRepository<TEntity>, IQuery)
+
+    [Fact]
+    public void Should_ReturnMatchingEntity_When_FindFirstCalledWithIQuery()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var query = Query.Where<Person>(x => x.Id == target.Id);
+
+        // Act
+        var result = _repository.FindFirst(query);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(target.Id, result.Id);
+    }
+
+    [Fact]
+    public void Should_ReturnNull_When_FindFirstCalledWithNonMatchingIQuery()
+    {
+        // Arrange
+        var query = Query.Where<Person>(x => x.FirstName == "__no_match__");
+
+        // Act
+        var result = _repository.FindFirst(query);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    #region FindFirst<TEntity>(IRepository<TEntity>, Expression)
+
+    [Fact]
+    public void Should_ReturnMatchingEntity_When_FindFirstCalledWithExpression()
+    {
+        // Arrange
+        var target = RandomPerson();
+
+        // Act
+        var result = _repository.FindFirst(x => x.Id == target.Id);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(target.Id, result.Id);
+    }
+
+    [Fact]
+    public void Should_ReturnNull_When_FindFirstCalledWithNonMatchingExpression()
+    {
+        // Act
+        var result = _repository.FindFirst(x => x.FirstName == "__no_match__");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    #region FindFirst<TEntity>(IRepository<TEntity>) — no filter
+
+    [Fact]
+    public void Should_ReturnAnyEntity_When_FindFirstCalledWithNoFilter()
+    {
+        // Act
+        var result = _repository.FindFirst();
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    #endregion
+
+    // -------------------------------------------------------------------------
+    // FindAll
+    // -------------------------------------------------------------------------
+
+    #region FindAll<TEntity>(IRepository<TEntity>, IQueryFilter)
+
+    [Fact]
+    public void Should_ReturnMatchingEntities_When_FindAllCalledWithMatchingIQueryFilter()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var filter = QueryFilter.Where<Person>(x => x.FirstName == target.FirstName);
+        var expectedCount = _people.Count(x => x.FirstName == target.FirstName);
+
+        // Act
+        var result = _repository.FindAll(filter);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedCount, result.Count);
+        Assert.All(result, p => Assert.Equal(target.FirstName, p.FirstName));
+    }
+
+    [Fact]
+    public void Should_ReturnEmpty_When_FindAllCalledWithNonMatchingIQueryFilter()
+    {
+        // Arrange
+        var filter = QueryFilter.Where<Person>(x => x.FirstName == "__no_match__");
+
+        // Act
+        var result = _repository.FindAll(filter);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Should_ReturnAllEntities_When_FindAllCalledWithEmptyFilter()
+    {
+        // Act
+        var result = _repository.FindAll(QueryFilter.Empty);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(_people.Count, result.Count);
+    }
+
+    #endregion
+
+    #region FindAll<TEntity>(IRepository<TEntity>, IQuery)
+
+    [Fact]
+    public void Should_ReturnMatchingEntities_When_FindAllCalledWithIQuery()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var query = Query.Where<Person>(x => x.FirstName == target.FirstName);
+        var expectedCount = _people.Count(x => x.FirstName == target.FirstName);
+
+        // Act
+        var result = _repository.FindAll(query);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedCount, result.Count);
+    }
+
+    [Fact]
+    public void Should_ReturnEmpty_When_FindAllCalledWithNonMatchingIQuery()
+    {
+        // Arrange
+        var query = Query.Where<Person>(x => x.FirstName == "__no_match__");
+
+        // Act
+        var result = _repository.FindAll(query);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    #endregion
+
+    #region FindAll<TEntity>(IRepository<TEntity>, Expression)
+
+    [Fact]
+    public void Should_ReturnMatchingEntities_When_FindAllCalledWithExpression()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var expectedCount = _people.Count(x => x.FirstName == target.FirstName);
+
+        // Act
+        var result = _repository.FindAll(x => x.FirstName == target.FirstName);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedCount, result.Count);
+    }
+
+    [Fact]
+    public void Should_ReturnEmpty_When_FindAllCalledWithNonMatchingExpression()
+    {
+        // Act
+        var result = _repository.FindAll(x => x.FirstName == "__no_match__");
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    #endregion
+
+    #region FindAll<TEntity>(IRepository<TEntity>) — no filter
+
+    [Fact]
+    public void Should_ReturnAllEntities_When_FindAllCalledWithNoFilter()
+    {
+        // Act
+        var result = _repository.FindAll();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(_people.Count, result.Count);
+    }
+
+    #endregion
+
+    #region FindAll<TEntity, TKey>(IRepository<TEntity, TKey>, IQuery)
+
+    [Fact]
+    public void Should_ReturnMatchingEntities_When_FindAllWithKeyCalledWithIQuery()
+    {
+        // Arrange
+        var target = RandomPerson();
+        IRepository<Person, object> typedRepository = _repository;
+        var query = Query.Where<Person>(x => x.FirstName == target.FirstName);
+        var expectedCount = _people.Count(x => x.FirstName == target.FirstName);
+
+        // Act
+        var result = typedRepository.FindAll(query);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedCount, result.Count);
+    }
+
+    [Fact]
+    public void Should_ReturnEmpty_When_FindAllWithKeyCalledWithNonMatchingIQuery()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepository = _repository;
+        var query = Query.Where<Person>(x => x.FirstName == "__no_match__");
+
+        // Act
+        var result = typedRepository.FindAll(query);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    #endregion
+
+    #region FindAll<TEntity, TKey>(IRepository<TEntity, TKey>, Expression)
+
+    [Fact]
+    public void Should_ReturnMatchingEntities_When_FindAllWithKeyCalledWithExpression()
+    {
+        // Arrange
+        var target = RandomPerson();
+        IRepository<Person, object> typedRepository = _repository;
+        var expectedCount = _people.Count(x => x.FirstName == target.FirstName);
+
+        // Act
+        var result = typedRepository.FindAll(x => x.FirstName == target.FirstName);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedCount, result.Count);
+    }
+
+    [Fact]
+    public void Should_ReturnEmpty_When_FindAllWithKeyCalledWithNonMatchingExpression()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepository = _repository;
+
+        // Act
+        var result = typedRepository.FindAll(x => x.FirstName == "__no_match__");
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    #endregion
+
+    #region FindAll<TEntity, TKey>(IRepository<TEntity, TKey>) — no filter
+
+    [Fact]
+    public void Should_ReturnAllEntities_When_FindAllWithKeyCalledWithNoFilter()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepository = _repository;
+
+        // Act
+        var result = typedRepository.FindAll();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(_people.Count, result.Count);
     }
 
     #endregion

--- a/test/Deveel.Repository.Core.XUnit/Unit/RepositoryExtensionsSyncTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/RepositoryExtensionsSyncTests.cs
@@ -1,0 +1,255 @@
+namespace Deveel.Data;
+
+/// <summary>
+/// Unit tests for the synchronous extension methods added to <see cref="RepositoryExtensions"/>:
+/// <list type="bullet">
+///   <item><see cref="RepositoryExtensions.FindFirst{TEntity}(IRepository{TEntity}, IQueryFilter)"/></item>
+///   <item><see cref="RepositoryExtensions.FindFirst{TEntity, TKey}(IRepository{TEntity, TKey}, IQueryFilter)"/></item>
+///   <item><see cref="RepositoryExtensions.FindAll{TEntity}(IRepository{TEntity}, IQueryFilter)"/></item>
+///   <item><see cref="RepositoryExtensions.Count{TEntity}(IRepository{TEntity}, IQueryFilter)"/></item>
+/// </list>
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "RepositoryExtensions")]
+public class RepositoryExtensionsSyncTests : IClassFixture<PersonFixture>
+{
+    private readonly List<Person> _people;
+    private readonly IRepository<Person> _repository;
+
+    public RepositoryExtensionsSyncTests(PersonFixture fixture)
+    {
+        _people = fixture.BuildPeople(50).ToList();
+        _repository = _people.AsRepository();
+    }
+
+    private Person RandomPerson() => _people[Random.Shared.Next(0, _people.Count - 1)];
+
+    #region FindFirst<TEntity>(IRepository<TEntity>, IQueryFilter)
+
+    [Fact]
+    public void Should_ReturnMatchingEntity_When_FindFirstCalledWithMatchingIQueryFilter()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var filter = QueryFilter.Where<Person>(x => x.Id == target.Id);
+
+        // Act
+        var result = _repository.FindFirst(filter);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(target.Id, result.Id);
+        Assert.Equal(target.FirstName, result.FirstName);
+        Assert.Equal(target.LastName, result.LastName);
+    }
+
+    [Fact]
+    public void Should_ReturnNull_When_FindFirstCalledWithNonMatchingIQueryFilter()
+    {
+        // Arrange
+        var filter = QueryFilter.Where<Person>(x => x.FirstName == "__no_match__");
+
+        // Act
+        var result = _repository.FindFirst(filter);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Should_ReturnFirstByFirstName_When_FindFirstCalledWithFirstNameFilter()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var filter = QueryFilter.Where<Person>(x => x.FirstName == target.FirstName);
+        var expected = _people.First(x => x.FirstName == target.FirstName);
+
+        // Act
+        var result = _repository.FindFirst(filter);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expected.Id, result.Id);
+    }
+
+    #endregion
+
+    #region FindFirst<TEntity, TKey>(IRepository<TEntity, TKey>, IQueryFilter)
+
+    [Fact]
+    public void Should_ReturnMatchingEntity_When_FindFirstWithKeyCalledWithMatchingIQueryFilter()
+    {
+        // Arrange
+        var target = RandomPerson();
+        IRepository<Person, object> typedRepository = _repository;
+        var filter = QueryFilter.Where<Person>(x => x.Id == target.Id);
+
+        // Act
+        var result = typedRepository.FindFirst(filter);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(target.Id, result.Id);
+        Assert.Equal(target.FirstName, result.FirstName);
+    }
+
+    [Fact]
+    public void Should_ReturnNull_When_FindFirstWithKeyCalledWithNonMatchingIQueryFilter()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepository = _repository;
+        var filter = QueryFilter.Where<Person>(x => x.LastName == "__no_match__");
+
+        // Act
+        var result = typedRepository.FindFirst(filter);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    #endregion
+
+    #region FindAll<TEntity>(IRepository<TEntity>, IQueryFilter)
+
+    [Fact]
+    public void Should_ReturnMatchingEntities_When_FindAllCalledWithMatchingIQueryFilter()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var filter = QueryFilter.Where<Person>(x => x.FirstName == target.FirstName);
+        var expectedCount = _people.Count(x => x.FirstName == target.FirstName);
+
+        // Act
+        var result = _repository.FindAll(filter);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(expectedCount, result.Count);
+        Assert.All(result, p => Assert.Equal(target.FirstName, p.FirstName));
+    }
+
+    [Fact]
+    public void Should_ReturnEmpty_When_FindAllCalledWithNonMatchingIQueryFilter()
+    {
+        // Arrange
+        var filter = QueryFilter.Where<Person>(x => x.FirstName == "__no_match__");
+
+        // Act
+        var result = _repository.FindAll(filter);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Should_ReturnAllEntities_When_FindAllCalledWithEmptyFilter()
+    {
+        // Arrange
+        var filter = QueryFilter.Empty;
+
+        // Act
+        var result = _repository.FindAll(filter);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(_people.Count, result.Count);
+    }
+
+    #endregion
+
+    #region Count<TEntity>(IRepository<TEntity>, IQueryFilter)
+
+    [Fact]
+    public void Should_ReturnMatchingCount_When_CountCalledWithMatchingIQueryFilter()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var filter = QueryFilter.Where<Person>(x => x.FirstName == target.FirstName);
+        var expectedCount = _people.LongCount(x => x.FirstName == target.FirstName);
+
+        // Act
+        var count = _repository.Count(filter);
+
+        // Assert
+        Assert.Equal(expectedCount, count);
+    }
+
+    [Fact]
+    public void Should_ReturnZero_When_CountCalledWithNonMatchingIQueryFilter()
+    {
+        // Arrange
+        var filter = QueryFilter.Where<Person>(x => x.FirstName == "__no_match__");
+
+        // Act
+        var count = _repository.Count(filter);
+
+        // Assert
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void Should_ReturnTotalCount_When_CountCalledWithEmptyFilter()
+    {
+        // Arrange
+        var filter = QueryFilter.Empty;
+
+        // Act
+        var count = _repository.Count(filter);
+
+        // Assert
+        Assert.Equal(_people.Count, count);
+    }
+
+    [Fact]
+    public void Should_ReturnCountByIdFilter_When_UniqueEntityExists()
+    {
+        // Arrange
+        var target = RandomPerson();
+        var filter = QueryFilter.Where<Person>(x => x.Id == target.Id);
+
+        // Act
+        var count = _repository.Count(filter);
+
+        // Assert
+        Assert.Equal(1L, count);
+    }
+
+    #endregion
+
+    #region Count<TEntity, TKey>(IRepository<TEntity, TKey>, IQueryFilter)
+
+    [Fact]
+    public void Should_ReturnMatchingCount_When_CountWithKeyCalledWithMatchingIQueryFilter()
+    {
+        // Arrange
+        var target = RandomPerson();
+        IRepository<Person, object> typedRepository = _repository;
+        var filter = QueryFilter.Where<Person>(x => x.FirstName == target.FirstName);
+        var expectedCount = _people.LongCount(x => x.FirstName == target.FirstName);
+
+        // Act
+        var count = typedRepository.Count(filter);
+
+        // Assert
+        Assert.Equal(expectedCount, count);
+    }
+
+    [Fact]
+    public void Should_ReturnZero_When_CountWithKeyCalledWithNonMatchingIQueryFilter()
+    {
+        // Arrange
+        IRepository<Person, object> typedRepository = _repository;
+        var filter = QueryFilter.Where<Person>(x => x.LastName == "__no_match__");
+
+        // Act
+        var count = typedRepository.Count(filter);
+
+        // Assert
+        Assert.Equal(0L, count);
+    }
+
+    #endregion
+}
+

--- a/test/Deveel.Repository.Core.XUnit/Unit/RepositoryExtensionsSyncTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/RepositoryExtensionsSyncTests.cs
@@ -9,11 +9,13 @@ namespace Deveel.Data;
 [Trait("Feature", "RepositoryExtensions")]
 public class RepositoryExtensionsSyncTests : IClassFixture<PersonFixture>
 {
+    private readonly PersonFixture _fixture;
     private readonly List<Person> _people;
     private readonly IRepository<Person> _repository;
 
     public RepositoryExtensionsSyncTests(PersonFixture fixture)
     {
+        _fixture = fixture;
         _people = fixture.BuildPeople(50).ToList();
         _repository = _people.AsRepository();
     }
@@ -30,7 +32,7 @@ public class RepositoryExtensionsSyncTests : IClassFixture<PersonFixture>
     public void Should_IncrementCount_When_AddRangeCalledOnSingleTypeParamRepository()
     {
         // Arrange
-        var newPeople = PersonFixture.PersonFaker.Generate(5);
+        var newPeople = _fixture.PersonFaker.Generate(5);
         var initialCount = _people.Count;
 
         // Act
@@ -45,7 +47,7 @@ public class RepositoryExtensionsSyncTests : IClassFixture<PersonFixture>
     {
         // Arrange
         IRepository<Person, object> typedRepo = _repository;
-        var newPeople = PersonFixture.PersonFaker.Generate(3);
+        var newPeople = _fixture.PersonFaker.Generate(3);
         var initialCount = _people.Count;
 
         // Act

--- a/test/Deveel.Repository.Management.Testing/Suites/EntityManagerTestSuite_3.cs
+++ b/test/Deveel.Repository.Management.Testing/Suites/EntityManagerTestSuite_3.cs
@@ -370,19 +370,19 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncLi
 	[Trait("Feature", "Manager")]
 	public async Task Should_ReturnFirstMatch_When_FilterApplied() {
 		// Arrange
-		var person = People
+		var matchingIds = People
 			.Where(x => x.FirstName.StartsWith("A"))
-			.OrderBy(x => x.Id)
-			.FirstOrDefault();
+			.Select(x => x.Id)
+			.ToHashSet();
 
-		Assert.NotNull(person);
+		Assert.NotEmpty(matchingIds);
 
 		// Act
 		var found = await Manager.FindFirstAsync(x => x.FirstName.StartsWith("A"));
 
 		// Assert
 		Assert.NotNull(found);
-		Assert.Equal(person.Id, found.Id);
+		Assert.Contains(found.Id, matchingIds);
 	}
 
 	[Fact]
@@ -391,19 +391,19 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncLi
 	[Trait("Feature", "Manager")]
 	public async Task Should_ReturnFirstMatch_When_DynamicLinqFilterApplied() {
 		// Arrange
-		var person = People
+		var matchingIds = People
 			.Where(x => x.FirstName.StartsWith("A"))
-			.OrderBy(x => x.Id)
-			.FirstOrDefault();
+			.Select(x => x.Id)
+			.ToHashSet();
 
-		Assert.NotNull(person);
+		Assert.NotEmpty(matchingIds);
 
 		// Act
 		var found = await Manager.FindFirstAsync("FirstName.StartsWith(\"A\")");
 
 		// Assert
 		Assert.NotNull(found);
-		Assert.Equal(person.Id, found.Id);
+		Assert.Contains(found.Id, matchingIds);
 	}
 
 	[Fact]
@@ -412,18 +412,18 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncLi
 	[Trait("Feature", "Manager")]
 	public async Task Should_ReturnFirstEntity_When_FindFirst() {
 		// Arrange
-		var person = People
-			.OrderBy(x => x.Id)
-			.FirstOrDefault();
+		var allIds = People
+			.Select(x => x.Id)
+			.ToHashSet();
 
-		Assert.NotNull(person);
+		Assert.NotEmpty(allIds);
 
 		// Act
 		var found = await Manager.FindFirstAsync();
 
 		// Assert
 		Assert.NotNull(found);
-		Assert.Equal(person.Id, found.Id);
+		Assert.Contains(found.Id, allIds);
 	}
 
 	[Fact]


### PR DESCRIPTION
This pull request refactors the way test data is generated in the unit tests for `Person` entities. The main change is to eliminate the use of a shared static `Faker<Person>` instance in favor of per-instance or per-class `Faker` objects, ensuring thread safety and deterministic test data when tests are run in parallel (as is common with xUnit). This change touches multiple test classes, updating how fake `Person` data is generated and accessed.

**Test data generation improvements:**

* `PersonFixture` now uses a non-static `Faker<Person>` instance, with detailed documentation explaining that this avoids thread-safety issues when xUnit runs tests in parallel. Each fixture instance manages its own random state.
* All test classes that previously referenced `PersonFixture.PersonFaker` are updated to use their own instance of `PersonFaker` or to access the fixture's instance via dependency injection. This includes `ListAsRepositoryTests`, `PageQueryTests`, `PageResultTests`, `QueryFilterTests`, `QueryOrderTests`, and `QueryTests`. [[1]](diffhunk://#diff-865d995f8546944d5575cc584d37e7b3f3671d2d32d4bbf025003f16aa7c973aR8-R14) [[2]](diffhunk://#diff-3b64e3650e846536c6ebb1928846105a7f5565614140bb642386325f0e327a84R10-R11) [[3]](diffhunk://#diff-0eb4a4694ee1d637798cdfc6b62dd8da8fe1542ccce5ee9327ea178aeedf3b72R8-R17) [[4]](diffhunk://#diff-7b5892502952a2e2e6996914204ffc92b32e58cd924b98e08af28d5ad1046ddaR8) [[5]](diffhunk://#diff-de9e74b150d0fff3cce16b2ee2c90a02d614ea424e0c7ea54e610b875a14c095R8-R9) [[6]](diffhunk://#diff-bb780c72424caec6285bc751be2d66b9ae885abdbfafc69f76d8ed6af9ffd1ccR8-R16)

**Test code updates:**

* All usages of `PersonFixture.PersonFaker.Generate()` or `.Generate(n)` are replaced with the appropriate per-instance `_fixture.PersonFaker.Generate()` or `_faker.Generate()` calls in test methods, ensuring each test class or instance uses its own faker. [[1]](diffhunk://#diff-865d995f8546944d5575cc584d37e7b3f3671d2d32d4bbf025003f16aa7c973aL27-R29) [[2]](diffhunk://#diff-865d995f8546944d5575cc584d37e7b3f3671d2d32d4bbf025003f16aa7c973aL39-R41) [[3]](diffhunk://#diff-865d995f8546944d5575cc584d37e7b3f3671d2d32d4bbf025003f16aa7c973aL55-R57) [[4]](diffhunk://#diff-865d995f8546944d5575cc584d37e7b3f3671d2d32d4bbf025003f16aa7c973aL72-R74) [[5]](diffhunk://#diff-865d995f8546944d5575cc584d37e7b3f3671d2d32d4bbf025003f16aa7c973aL88-R90) [[6]](diffhunk://#diff-865d995f8546944d5575cc584d37e7b3f3671d2d32d4bbf025003f16aa7c973aL411-R413) [[7]](diffhunk://#diff-865d995f8546944d5575cc584d37e7b3f3671d2d32d4bbf025003f16aa7c973aL428-R430) [[8]](diffhunk://#diff-3b64e3650e846536c6ebb1928846105a7f5565614140bb642386325f0e327a84L44-R46) [[9]](diffhunk://#diff-3b64e3650e846536c6ebb1928846105a7f5565614140bb642386325f0e327a84L60-R62) [[10]](diffhunk://#diff-0eb4a4694ee1d637798cdfc6b62dd8da8fe1542ccce5ee9327ea178aeedf3b72L39-R41) [[11]](diffhunk://#diff-7b5892502952a2e2e6996914204ffc92b32e58cd924b98e08af28d5ad1046ddaL100-R101) [[12]](diffhunk://#diff-7b5892502952a2e2e6996914204ffc92b32e58cd924b98e08af28d5ad1046ddaL116-R117) [[13]](diffhunk://#diff-7b5892502952a2e2e6996914204ffc92b32e58cd924b98e08af28d5ad1046ddaL133-R134) [[14]](diffhunk://#diff-de9e74b150d0fff3cce16b2ee2c90a02d614ea424e0c7ea54e610b875a14c095L61-R63) [[15]](diffhunk://#diff-de9e74b150d0fff3cce16b2ee2c90a02d614ea424e0c7ea54e610b875a14c095L79-R81) [[16]](diffhunk://#diff-de9e74b150d0fff3cce16b2ee2c90a02d614ea424e0c7ea54e610b875a14c095L95-R97) [[17]](diffhunk://#diff-bb780c72424caec6285bc751be2d66b9ae885abdbfafc69f76d8ed6af9ffd1ccL29-R31) [[18]](diffhunk://#diff-bb780c72424caec6285bc751be2d66b9ae885abdbfafc69f76d8ed6af9ffd1ccL44-R46) [[19]](diffhunk://#diff-bb780c72424caec6285bc751be2d66b9ae885abdbfafc69f76d8ed6af9ffd1ccL65-R67) [[20]](diffhunk://#diff-bb780c72424caec6285bc751be2d66b9ae885abdbfafc69f76d8ed6af9ffd1ccL82-R84) [[21]](diffhunk://#diff-bb780c72424caec6285bc751be2d66b9ae885abdbfafc69f76d8ed6af9ffd1ccL99-R101) [[22]](diffhunk://#diff-bb780c72424caec6285bc751be2d66b9ae885abdbfafc69f76d8ed6af9ffd1ccL117-R119) [[23]](diffhunk://#diff-bb780c72424caec6285bc751be2d66b9ae885abdbfafc69f76d8ed6af9ffd1ccL139-R141)

**Thread-safety and determinism:**

* The change ensures that test data generation is thread-safe and deterministic, preventing flaky or non-deterministic test failures due to shared random state in parallel test execution.

**Test class setup consistency:**

* Introduces or updates private fields (like `_faker` or `_fixture`) in test classes to consistently manage the faker instance, improving code readability and maintainability. [[1]](diffhunk://#diff-865d995f8546944d5575cc584d37e7b3f3671d2d32d4bbf025003f16aa7c973aR8-R14) [[2]](diffhunk://#diff-3b64e3650e846536c6ebb1928846105a7f5565614140bb642386325f0e327a84R10-R11) [[3]](diffhunk://#diff-0eb4a4694ee1d637798cdfc6b62dd8da8fe1542ccce5ee9327ea178aeedf3b72R8-R17) [[4]](diffhunk://#diff-7b5892502952a2e2e6996914204ffc92b32e58cd924b98e08af28d5ad1046ddaR8) [[5]](diffhunk://#diff-de9e74b150d0fff3cce16b2ee2c90a02d614ea424e0c7ea54e610b875a14c095R8-R9) [[6]](diffhunk://#diff-bb780c72424caec6285bc751be2d66b9ae885abdbfafc69f76d8ed6af9ffd1ccR8-R16)

**Documentation:**

* Updates the XML documentation in `PersonFixture` to clearly explain the rationale for this change, helping future maintainers understand the importance of using per-instance fakers in parallel test environments.