### PR TITLE
Refactor async methods to use ValueTask and improve error handling

### DIFF
--- a/benchmarks/repobench/RepositoryCoreBenchmarksBase.cs
+++ b/benchmarks/repobench/RepositoryCoreBenchmarksBase.cs
@@ -98,24 +98,24 @@ public abstract class RepositoryCoreBenchmarksBase<TEntity, TKey>
 	}
 
 	[Benchmark]
-	public Task AddAsync_One() => Repository.AddAsync(_singleToAdd);
+	public async Task AddAsync_One() => await Repository.AddAsync(_singleToAdd);
 
 	[Benchmark]
-	public Task AddRangeAsync_Batch() => Repository.AddRangeAsync(_batchToAdd);
+	public async Task AddRangeAsync_Batch() => await Repository.AddRangeAsync(_batchToAdd);
 
 	[Benchmark]
-	public Task<TEntity?> FindAsync_ByKey() => Repository.FindAsync(_targetId);
+	public async Task<TEntity?> FindAsync_ByKey() => await Repository.FindAsync(_targetId);
 
 	[Benchmark]
-	public Task<bool> UpdateAsync_Entity() => Repository.UpdateAsync(_targetForUpdate);
+	public async Task<bool> UpdateAsync_Entity() => await Repository.UpdateAsync(_targetForUpdate);
 
 	[Benchmark]
-	public Task<bool> RemoveAsync_Entity() => Repository.RemoveAsync(_targetForRemove);
+	public async Task<bool> RemoveAsync_Entity() => await Repository.RemoveAsync(_targetForRemove);
 
 	[Benchmark]
-	public Task<long> CountAsync_Filtered() => Repository.CountAsync(CountPredicate);
+	public async Task<long> CountAsync_Filtered() => await Repository.CountAsync(CountPredicate);
 
 	[Benchmark]
-	public Task<bool> ExistsAsync_Filtered() => Repository.ExistsAsync(ExistsPredicate);
+	public async Task<bool> ExistsAsync_Filtered() => await Repository.ExistsAsync(ExistsPredicate);
 }
 

--- a/src/Deveel.Repository.Core/Data/CombinedQueryFilter.cs
+++ b/src/Deveel.Repository.Core/Data/CombinedQueryFilter.cs
@@ -15,8 +15,6 @@
 using System.Collections;
 using System.Linq.Expressions;
 
-using CommunityToolkit.Diagnostics;
-
 namespace Deveel.Data {
 	/// <summary>
 	/// An object that combines multiple <see cref="IQueryFilter"/> objects
@@ -38,9 +36,9 @@ namespace Deveel.Data {
 		/// Thrown if the given list of filters is empty.
 		/// </exception>
 		public CombinedQueryFilter(ICollection<IQueryFilter> filters) {
-			Guard.IsNotNull(filters, nameof(filters));
-			Guard.IsNotEmpty(filters, nameof(filters));
-
+            ArgumentNullException.ThrowIfNull(filters);
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(filters.Count, 0, nameof(filters));
+            
 			this.filters = filters.ToList().AsReadOnly();
 		}
 
@@ -63,7 +61,7 @@ namespace Deveel.Data {
 		/// Thrown if the given filter is <c>null</c>.
 		/// </exception>
 		public CombinedQueryFilter Combine(IQueryFilter filter) {
-			Guard.IsNotNull(filter, nameof(filter));
+            ArgumentNullException.ThrowIfNull(filter);
 
 			var filters = new List<IQueryFilter>(this.filters);
 			if (filter is CombinedQueryFilter combined) {

--- a/src/Deveel.Repository.Core/Data/DefaultRepositoryController.cs
+++ b/src/Deveel.Repository.Core/Data/DefaultRepositoryController.cs
@@ -103,7 +103,7 @@ namespace Deveel.Data {
 		}
 
 
-		private async Task CreateRepository(IControllableRepository? repository, CancellationToken cancellationToken) {
+		private async ValueTask CreateRepository(IControllableRepository? repository, CancellationToken cancellationToken) {
 			if (repository != null) {
 				try {
 					if (await repository.ExistsAsync(cancellationToken)) {
@@ -143,7 +143,7 @@ namespace Deveel.Data {
 			}
 		}
 
-		private async Task DropRepository(IControllableRepository? repository, CancellationToken cancellationToken) {
+		private async ValueTask DropRepository(IControllableRepository? repository, CancellationToken cancellationToken) {
 			if (repository != null) {
 				try {
 					if (!await repository.ExistsAsync(cancellationToken)) {
@@ -173,7 +173,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task CreateRepositoryAsync<TEntity>(CancellationToken cancellationToken = default)
+		public virtual async ValueTask CreateRepositoryAsync<TEntity>(CancellationToken cancellationToken = default)
 			where TEntity : class {
 			LogTrace("Creating the repository for type '{EntityType}'", typeof(TEntity).Name);
 
@@ -185,7 +185,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task CreateRepositoryAsync<TEntity, TKey>(CancellationToken cancellationToken = default)
+		public virtual async ValueTask CreateRepositoryAsync<TEntity, TKey>(CancellationToken cancellationToken = default)
 			where TEntity : class {
 			LogTrace("Creating the repository for type '{EntityType}'", typeof(TEntity).Name);
 
@@ -198,7 +198,7 @@ namespace Deveel.Data {
 
 
 		/// <inheritdoc/>
-		public virtual async Task DropRepositoryAsync<TEntity>(CancellationToken cancellationToken = default) where TEntity : class {
+		public virtual async ValueTask DropRepositoryAsync<TEntity>(CancellationToken cancellationToken = default) where TEntity : class {
 			LogTrace("Dropping the repository handling the type '{EntityType}'", typeof(TEntity).Name);
 
 			var repository = RequireRepository<TEntity>();
@@ -209,7 +209,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task DropRepositoryAsync<TEntity, TKey>(CancellationToken cancellationToken = default) where TEntity : class {
+		public virtual async ValueTask DropRepositoryAsync<TEntity, TKey>(CancellationToken cancellationToken = default) where TEntity : class {
 			LogTrace("Dropping the repository handling the type '{EntityType}'", typeof(TEntity).Name);
 
 			var repository = RequireRepository<TEntity, TKey>();

--- a/src/Deveel.Repository.Core/Data/IControllableRepository.cs
+++ b/src/Deveel.Repository.Core/Data/IControllableRepository.cs
@@ -28,7 +28,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns <c>true</c> if the repository exists, or <c>false</c>
 		/// </returns>
-		Task<bool> ExistsAsync(CancellationToken cancellationToken = default);
+		ValueTask<bool> ExistsAsync(CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Creates the repository in the underlying storage
@@ -40,7 +40,7 @@ namespace Deveel.Data {
 		/// Returns a <see cref="Task"/> that completes when the repository
 		/// is created in the underlying storage
 		/// </returns>
-		Task CreateAsync(CancellationToken cancellationToken = default);
+		ValueTask CreateAsync(CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Drops the repository from the underlying storage
@@ -52,6 +52,6 @@ namespace Deveel.Data {
 		/// Returns a <see cref="Task"/> that completes when the repository
 		/// is dropped from the underlying storage
 		/// </returns>
-		Task DropAsync(CancellationToken cancellationToken = default);
+		ValueTask DropAsync(CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Repository.Core/Data/IFilterableRepository_T2.cs
+++ b/src/Deveel.Repository.Core/Data/IFilterableRepository_T2.cs
@@ -42,7 +42,7 @@ namespace Deveel.Data {
 		/// <exception cref="ArgumentException">
 		/// Throw if the <paramref name="filter"/> is not supported by the repository
 		/// </exception>
-		Task<bool> ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken = default);
+		ValueTask<bool> ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Counts the number of items in the repository matching the given 
@@ -64,7 +64,7 @@ namespace Deveel.Data {
 		/// <exception cref="ArgumentException">
 		/// Throw if the <paramref name="filter"/> is not supported by the repository
 		/// </exception>
-		Task<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default);
+		ValueTask<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Finds the first item in the repository that matches the given query
@@ -87,7 +87,7 @@ namespace Deveel.Data {
 		/// Throw if the <paramref name="query"/> defines a filter or a sort rule
 		/// that is not supported by the repository
 		/// </exception>
-		Task<TEntity?> FindFirstAsync(IQuery query, CancellationToken cancellationToken = default);
+		ValueTask<TEntity?> FindFirstAsync(IQuery query, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Finds all the items in the repository that match the given filtering condition
@@ -103,6 +103,6 @@ namespace Deveel.Data {
 		/// Returns a list of items in the repository that match the given query,
 		/// or an empty list if none of the items matches the condition.
 		/// </returns>
-		Task<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default);
+		ValueTask<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Repository.Core/Data/IPageableRepository_T2.cs
+++ b/src/Deveel.Repository.Core/Data/IPageableRepository_T2.cs
@@ -45,6 +45,6 @@ namespace Deveel.Data {
 		/// implementation of the repository
 		/// </exception>
 		/// <seealso cref="PageResult{TEntity}"/>
-		Task<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> request, CancellationToken cancellationToken = default);
+		ValueTask<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> request, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Repository.Core/Data/IRepositoryController.cs
+++ b/src/Deveel.Repository.Core/Data/IRepositoryController.cs
@@ -31,7 +31,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns a <see cref="Task"/> that can be used to await the operation
 		/// </returns>
-		Task CreateRepositoryAsync<TEntity>(CancellationToken cancellationToken = default)
+		ValueTask CreateRepositoryAsync<TEntity>(CancellationToken cancellationToken = default)
 			where TEntity : class;
 
 		/// <summary>
@@ -47,9 +47,9 @@ namespace Deveel.Data {
 		/// A token used to cancel the operation
 		/// </param>
 		/// <returns>
-		/// Returns a <see cref="Task"/> that can be used to await the operation
+		/// Returns a <see cref="ValueTask"/> that can be used to await the operation
 		/// </returns>
-		Task CreateRepositoryAsync<TEntity, TKey>(CancellationToken cancellationToken = default)
+		ValueTask CreateRepositoryAsync<TEntity, TKey>(CancellationToken cancellationToken = default)
 			where TEntity : class;
 
 		/// <summary>
@@ -62,9 +62,9 @@ namespace Deveel.Data {
 		/// A token used to cancel the operation
 		/// </param>
 		/// <returns>
-		/// Returns a <see cref="Task"/> that can be used to await the operation
+		/// Returns a <see cref="ValueTask"/> that can be used to await the operation
 		/// </returns>
-		Task DropRepositoryAsync<TEntity>(CancellationToken cancellationToken = default)
+		ValueTask DropRepositoryAsync<TEntity>(CancellationToken cancellationToken = default)
 			where TEntity : class;
 
 		/// <summary>
@@ -80,9 +80,9 @@ namespace Deveel.Data {
 		/// A token used to cancel the operation
 		/// </param>
 		/// <returns>
-		/// Returns a <see cref="Task"/> that can be used to await the operation
+		/// Returns a <see cref="ValueTask"/> that can be used to await the operation
 		/// </returns>
-		Task DropRepositoryAsync<TEntity, TKey>(CancellationToken cancellationToken = default)
+		ValueTask DropRepositoryAsync<TEntity, TKey>(CancellationToken cancellationToken = default)
 			where TEntity : class;
 	}
 }

--- a/src/Deveel.Repository.Core/Data/IRepository_T2.cs
+++ b/src/Deveel.Repository.Core/Data/IRepository_T2.cs
@@ -53,7 +53,7 @@ namespace Deveel.Data {
 		/// <exception cref="ArgumentNullException">
 		/// Thrown if the provided <paramref name="entity"/> is <c>null</c>
 		/// </exception>
-		Task AddAsync(TEntity entity, CancellationToken cancellationToken = default);
+		ValueTask AddAsync(TEntity entity, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Adds a list of entities in the repository in one single operation
@@ -77,7 +77,7 @@ namespace Deveel.Data {
 		/// <exception cref="ArgumentNullException">
 		/// Thrown if the provided list of <paramref name="entities"/> is <c>null</c>
 		/// </exception>
-		Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
+		ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
 
 
 		/// <summary>
@@ -95,7 +95,7 @@ namespace Deveel.Data {
 		/// <exception cref="RepositoryException">
 		/// Thrown if it an error occurred while updating the entity
 		/// </exception>
-		Task<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default);
+		ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Removes an entity from the repository
@@ -112,7 +112,7 @@ namespace Deveel.Data {
 		/// <exception cref="RepositoryException">
 		/// Thrown if it an error occurred while removing the entity
 		/// </exception>
-		Task<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default);
+		ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Removes a list of entities from the repository in one 
@@ -130,7 +130,7 @@ namespace Deveel.Data {
 		/// <exception cref="RepositoryException">
 		/// Thrown if it an error occurred while removing one or more entities
 		/// </exception>
-		Task RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
+		ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Attempts to find in the repository an entity with the 
@@ -145,6 +145,6 @@ namespace Deveel.Data {
 		/// <exception cref="ArgumentNullException">
 		/// Thrown if the provided <paramref name="key"/> is <c>null</c>
 		/// </exception>
-		Task<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default);
+		ValueTask<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Repository.Core/Data/ITrackingRepository_T2.cs
+++ b/src/Deveel.Repository.Core/Data/ITrackingRepository_T2.cs
@@ -51,6 +51,6 @@ namespace Deveel.Data {
 		/// as it was loaded from the data source, or <c>null</c> if the entity is not
 		/// found or it's not being tracked.
 		/// </returns>
-		Task<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken = default);
+		ValueTask<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Repository.Core/Data/PageQuery_T.cs
+++ b/src/Deveel.Repository.Core/Data/PageQuery_T.cs
@@ -15,8 +15,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
-using CommunityToolkit.Diagnostics;
-
 namespace Deveel.Data {
 	/// <summary>
 	/// Describes the request to obtain a page of a given size
@@ -40,8 +38,8 @@ namespace Deveel.Data {
 		/// If either the page number or the page size are smaller than 1.
 		/// </exception>
 		public PageQuery(int page, int size) {
-			Guard.IsGreaterThanOrEqualTo(page, 1, nameof(page));
-			Guard.IsGreaterThanOrEqualTo(size, 1, nameof(size));
+            ArgumentOutOfRangeException.ThrowIfLessThan(page, 1);
+            ArgumentOutOfRangeException.ThrowIfLessThan(size, 1);
 
 			Page = page;
 			Size = size;
@@ -90,7 +88,7 @@ namespace Deveel.Data {
 		/// Thrown if the <paramref name="expression"/> is <c>null</c>.
 		/// </exception>
 		public PageQuery<TEntity> Where(Expression<Func<TEntity, bool>> expression) {
-			Guard.IsNotNull(expression, nameof(expression));
+            ArgumentNullException.ThrowIfNull(expression);
 
 			queryBuilder.Where(expression);
 
@@ -108,7 +106,7 @@ namespace Deveel.Data {
 		/// appended sort rule.
 		/// </returns>
 		public PageQuery<TEntity> OrderBy(Expression<Func<TEntity, object?>> field) {
-			Guard.IsNotNull(field, nameof(field));
+            ArgumentNullException.ThrowIfNull(field);
 
 			return OrderBy(new ExpressionSort<TEntity>(field));
 		}
@@ -124,7 +122,7 @@ namespace Deveel.Data {
 		/// appended sort rule.
 		/// </returns>
 		public PageQuery<TEntity> OrderByDescending(Expression<Func<TEntity, object?>> field) {
-			Guard.IsNotNull(field, nameof(field));
+            ArgumentNullException.ThrowIfNull(field);
 
 			return OrderBy(new ExpressionSort<TEntity>(field, SortDirection.Descending));
 		}
@@ -137,7 +135,7 @@ namespace Deveel.Data {
 		/// </param>
 		/// <returns></returns>
 		public PageQuery<TEntity> OrderBy(IQueryOrder order) {
-			Guard.IsNotNull(order, nameof(order));
+            ArgumentNullException.ThrowIfNull(order);
 
 			queryBuilder.OrderBy(order);
 
@@ -158,7 +156,7 @@ namespace Deveel.Data {
 		/// appended sort rule.
 		/// </returns>
 		public PageQuery<TEntity> OrderBy(string fieldName, SortDirection direction = SortDirection.Ascending) {
-			Guard.IsNotNullOrEmpty(fieldName, nameof(fieldName));
+			ArgumentException.ThrowIfNullOrWhiteSpace(fieldName);
 
 			return OrderBy(new FieldOrder(fieldName, direction));
 		}
@@ -174,7 +172,7 @@ namespace Deveel.Data {
 		/// appended sort rule.
 		/// </returns>
 		public PageQuery<TEntity> OrderByDescending(string fieldName) {
-			Guard.IsNotNullOrEmpty(fieldName, nameof(fieldName));
+            ArgumentException.ThrowIfNullOrWhiteSpace(fieldName);
 
 			return OrderBy(fieldName, SortDirection.Descending);
 		}

--- a/src/Deveel.Repository.Core/Data/PageableRepositoryExtensions.cs
+++ b/src/Deveel.Repository.Core/Data/PageableRepositoryExtensions.cs
@@ -53,7 +53,7 @@ namespace Deveel.Data {
 		/// Thrown when the given page number is less than 1, or
 		/// if the given page size is less than 0.
 		/// </exception>
-		public static Task<PageResult<TEntity>> GetPageAsync<TEntity, TKey>(this IPageableRepository<TEntity, TKey> repository, int page, int size, CancellationToken cancellationToken = default)
+		public static ValueTask<PageResult<TEntity>> GetPageAsync<TEntity, TKey>(this IPageableRepository<TEntity, TKey> repository, int page, int size, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.GetPageAsync(new PageQuery<TEntity>(page, size), cancellationToken);
 

--- a/src/Deveel.Repository.Core/Data/QueryFilter.cs
+++ b/src/Deveel.Repository.Core/Data/QueryFilter.cs
@@ -15,8 +15,6 @@
 using System;
 using System.Linq.Expressions;
 
-using CommunityToolkit.Diagnostics;
-
 namespace Deveel.Data {
 	/// <summary>
 	/// A utility class that provides a set of static methods to create
@@ -123,7 +121,7 @@ namespace Deveel.Data {
 		/// the result of the application of the given filter to the queryable.
 		/// </returns>
 		public static IQueryable<TEntity> Apply<TEntity>(this IQueryFilter filter, IQueryable<TEntity> queryable) where TEntity : class {
-			Guard.IsNotNull(filter, nameof(filter));
+			ArgumentNullException.ThrowIfNull(filter);
 
 			if (filter.IsEmpty())
 				return queryable;
@@ -184,8 +182,8 @@ namespace Deveel.Data {
 		/// Thrown if the given list of filters is empty.
 		/// </exception>
 		public static IQueryFilter Combine(params IQueryFilter[] filters) {
-			Guard.IsNotNull(filters, nameof(filters));
-			Guard.IsNotEmpty(filters, nameof(filters));
+            ArgumentNullException.ThrowIfNull(filters);
+            ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(filters.Length, 0);
 
 			return Combine((IEnumerable<IQueryFilter>)filters);
 		}
@@ -204,8 +202,8 @@ namespace Deveel.Data {
 		/// Thrown if either of the given filters is <c>null</c>.
 		/// </exception>
 		public static CombinedQueryFilter Combine(IQueryFilter filter1, IQueryFilter filter2) {
-			Guard.IsNotNull(filter1, nameof(filter1));
-			Guard.IsNotNull(filter2, nameof(filter2));
+            ArgumentNullException.ThrowIfNull(filter1);
+            ArgumentNullException.ThrowIfNull(filter2);
 
 			if (filter1.IsEmpty() && filter2.IsEmpty())
 				throw new ArgumentException("Cannot combine two empty filters");

--- a/src/Deveel.Repository.Core/Data/RepositoryExtensions.cs
+++ b/src/Deveel.Repository.Core/Data/RepositoryExtensions.cs
@@ -323,7 +323,7 @@ namespace Deveel.Data {
 		/// Returns <c>true</c> if the entity was removed successfully,
 		/// otherwise it returns <c>false</c>.
 		/// </returns>
-		public static async Task<bool> RemoveByKeyAsync<TEntity>(this IRepository<TEntity> repository, object key, CancellationToken cancellationToken = default)
+		public static async ValueTask<bool> RemoveByKeyAsync<TEntity>(this IRepository<TEntity> repository, object key, CancellationToken cancellationToken = default)
             where TEntity : class {
             var entity = await repository.FindAsync(key, cancellationToken);
             if (entity == null)
@@ -355,7 +355,7 @@ namespace Deveel.Data {
 		/// Returns <c>true</c> if the entity was removed successfully,
 		/// otherwise it returns <c>false</c>.
 		/// </returns>
-		public static async Task<bool> RemoveByKeyAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TKey key, CancellationToken cancellationToken = default)
+		public static async ValueTask<bool> RemoveByKeyAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TKey key, CancellationToken cancellationToken = default)
 			where TEntity : class {
 			var entity = await repository.FindAsync(key, cancellationToken);
 			if (entity == null)
@@ -554,12 +554,12 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support paging.
 		/// </exception>
-		public static Task<PageResult<TEntity>> GetPageAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, PageQuery<TEntity> request, CancellationToken cancellationToken = default)
+		public static ValueTask<PageResult<TEntity>> GetPageAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, PageQuery<TEntity> request, CancellationToken cancellationToken = default)
 			where TEntity : class {
 			if (repository.IsPageable())
 				return repository.RequirePageable().GetPageAsync(request, cancellationToken);
 			if (repository.IsQueryable())
-				return Task.FromResult(repository.AsQueryable().GetPage(request));
+				return new ValueTask<PageResult<TEntity>>(repository.AsQueryable().GetPage(request));
 
 			throw new NotSupportedException("The repository does not support paging");
 		}
@@ -597,7 +597,7 @@ namespace Deveel.Data {
 		/// Thrown when the given page number is less than 1, or the given
 		/// size is less than zero.
 		/// </exception>
-		public static Task<PageResult<TEntity>> GetPageAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, int page, int size, CancellationToken cancellationToken = default)
+		public static ValueTask<PageResult<TEntity>> GetPageAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, int page, int size, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.GetPageAsync(new PageQuery<TEntity>(page, size), cancellationToken);
 
@@ -713,7 +713,7 @@ namespace Deveel.Data {
 		/// Returns <c>true</c> if any entity exists in the repository
 		/// that matches the given filter, otherwise <c>false</c>.
 		/// </returns>
-		public static Task<bool> ExistsAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+		public static ValueTask<bool> ExistsAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
             where TEntity : class
             => repository.ExistsAsync(new ExpressionQueryFilter<TEntity>(filter), cancellationToken);
 
@@ -756,12 +756,12 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying or filtering.
 		/// </exception>
-		public static Task<bool> ExistsAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+		public static ValueTask<bool> ExistsAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
 			where TEntity : class {
 			if (repository.IsFilterable())
 				return repository.AsFilterable().ExistsAsync(filter, cancellationToken);
 			if (repository.IsQueryable())
-				return Task.FromResult(repository.AsQueryable().AsQueryable().Any(filter.AsLambda<TEntity>()));
+				return new ValueTask<bool>(repository.AsQueryable().AsQueryable().Any(filter.AsLambda<TEntity>()));
 
 			throw new NotSupportedException("The repository does not support querying");
 		}
@@ -844,7 +844,7 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying or filtering.
 		/// </exception>
-		public static Task<bool> ExistsAsync<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+		public static ValueTask<bool> ExistsAsync<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> ExistsAsync<TEntity, object>(repository, filter, cancellationToken);
 
@@ -869,7 +869,7 @@ namespace Deveel.Data {
 		/// Returns <c>true</c> if any entity exists in the repository
 		/// that matches the given filter, otherwise <c>false</c>.
 		/// </returns>
-		public static Task<bool> ExistsAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+		public static ValueTask<bool> ExistsAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> ExistsAsync<TEntity, object>(repository, filter, cancellationToken);
 
@@ -963,12 +963,12 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying or filtering.
 		/// </exception>
-        public static Task<long> CountAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+        public static ValueTask<long> CountAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
             where TEntity : class {
 			if (repository.IsFilterable())
 				return repository.AsFilterable().CountAsync(new ExpressionQueryFilter<TEntity>(filter), cancellationToken);
 			if (repository.IsQueryable())
-				return Task.FromResult(repository.AsQueryable().AsQueryable().LongCount(filter));
+				return new ValueTask<long>(repository.AsQueryable().AsQueryable().LongCount(filter));
 
 			throw new NotSupportedException("The repository does not support querying");
 		}
@@ -999,12 +999,12 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying or filtering.
 		/// </exception>
-		public static Task<long> CountAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+		public static ValueTask<long> CountAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
 			where TEntity : class {
 			if (repository.IsFilterable())
 				return repository.AsFilterable().CountAsync(filter, cancellationToken);
 			if (repository.IsQueryable())
-				return Task.FromResult(repository.AsQueryable().AsQueryable().LongCount(filter.AsLambda<TEntity>()));
+				return new ValueTask<long>(repository.AsQueryable().AsQueryable().LongCount(filter.AsLambda<TEntity>()));
 
 			throw new NotSupportedException("The repository does not support querying");
 		}
@@ -1031,12 +1031,12 @@ namespace Deveel.Data {
         /// Thrown when the repository does not support querying or filtering.
         /// </exception>
         /// <seealso cref="IFilterableRepository{TEntity, TKey}.CountAsync(IQueryFilter, CancellationToken)"/>
-		public static Task<long> CountAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, CancellationToken cancellationToken = default)
+		public static ValueTask<long> CountAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, CancellationToken cancellationToken = default)
 			where TEntity : class {
 			if (repository.IsFilterable())
 				return repository.AsFilterable().CountAsync(QueryFilter.Empty, cancellationToken);
 			if (repository.IsQueryable())
-				return Task.FromResult(repository.AsQueryable().AsQueryable().LongCount());
+				return new ValueTask<long>(repository.AsQueryable().AsQueryable().LongCount());
 
 			throw new NotSupportedException("The repository does not support querying");
 		}
@@ -1171,7 +1171,7 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying or filtering.
 		/// </exception>
-		public static Task<long> CountAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+		public static ValueTask<long> CountAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> CountAsync<TEntity, object>(repository, filter, cancellationToken);
 
@@ -1194,7 +1194,7 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying or filtering.
 		/// </exception>
-		public static Task<long> CountAllAsync<TEntity>(this IRepository<TEntity> repository, CancellationToken cancellationToken = default)
+		public static ValueTask<long> CountAllAsync<TEntity>(this IRepository<TEntity> repository, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> CountAllAsync<TEntity, object>(repository, cancellationToken);
 
@@ -1342,12 +1342,12 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying.
 		/// </exception>
-		public static Task<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQuery query, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQuery query, CancellationToken cancellationToken = default)
 			where TEntity : class {
 			if (repository.IsFilterable())
 				return repository.AsFilterable().FindFirstAsync(query, cancellationToken);
 			if (repository.IsQueryable())
-				return Task.FromResult(query.Apply(repository.AsQueryable().AsQueryable()).FirstOrDefault());
+				return new ValueTask<TEntity?>(query.Apply(repository.AsQueryable().AsQueryable()).FirstOrDefault());
 
 			throw new NotSupportedException("The repository does not support querying");
 		}
@@ -1376,7 +1376,7 @@ namespace Deveel.Data {
 		/// matched the given filter, or <c>null</c> if no entity matches
 		/// the given filter.
 		/// </returns>
-		public static Task<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.FindFirstAsync(new Query(filter), cancellationToken);
 
@@ -1435,7 +1435,7 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support filtering.
 		/// </exception>
-		public static Task<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
             where TEntity : class
             => repository.FindFirstAsync(Query.Where(filter), cancellationToken);
 
@@ -1459,7 +1459,7 @@ namespace Deveel.Data {
 		/// is the first entity in the repository, or <c>null</c> if the
 		/// repository is empty.
 		/// </returns>
-		public static Task<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, CancellationToken cancellationToken = default)
             where TEntity : class
             => repository.AsFilterable().FindFirstAsync(Query.Empty, cancellationToken);
 
@@ -1585,7 +1585,7 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying.
 		/// </exception>
-		public static Task<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, IQuery query, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, IQuery query, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> FindFirstAsync<TEntity, object>(repository, query, cancellationToken);
 
@@ -1609,7 +1609,7 @@ namespace Deveel.Data {
 		/// Returns an instance of <typeparamref name="TEntity"/> that matched the given
 		/// filter, or <c>null</c> if no entity matches.
 		/// </returns>
-		public static Task<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> FindFirstAsync<TEntity, object>(repository, filter, cancellationToken);
 
@@ -1636,7 +1636,7 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support filtering.
 		/// </exception>
-		public static Task<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> FindFirstAsync<TEntity, object>(repository, filter, cancellationToken);
 
@@ -1657,7 +1657,7 @@ namespace Deveel.Data {
 		/// Returns an instance of <typeparamref name="TEntity"/> that is the first
 		/// entity in the repository, or <c>null</c> if the repository is empty.
 		/// </returns>
-		public static Task<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> FindFirstAsync<TEntity, object>(repository, cancellationToken);
 
@@ -1779,12 +1779,12 @@ namespace Deveel.Data {
 		/// Thrown when the repository does not support querying 
 		/// or filtering.
 		/// </exception>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQuery query, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQuery query, CancellationToken cancellationToken = default)
 			where TEntity : class {
 			if (repository.IsFilterable())
 				return repository.AsFilterable().FindAllAsync(query, cancellationToken);
 			if (repository.IsQueryable())
-				return Task.FromResult<IList<TEntity>>(query.Apply(repository.AsQueryable().AsQueryable()).ToList());
+				return new ValueTask<IList<TEntity>>(query.Apply(repository.AsQueryable().AsQueryable()).ToList());
 
 			throw new NotSupportedException("The repository does not support querying");
 		}
@@ -1812,7 +1812,7 @@ namespace Deveel.Data {
 		/// Returns a list of <typeparamref name="TEntity"/> from
 		/// the repository that match the given filter.
 		/// </returns>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.FindAllAsync(new Query(filter), cancellationToken);
 
@@ -1839,7 +1839,7 @@ namespace Deveel.Data {
 		/// Returns a list of <typeparamref name="TEntity"/> from
 		/// the repository that match the given filter.
 		/// </returns>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
             where TEntity : class
             => repository.FindAllAsync(Query.Where(filter), cancellationToken);
 
@@ -1865,7 +1865,7 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying or filtering.
 		/// </exception>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, CancellationToken cancellationToken = default)
             where TEntity : class
             => repository.FindAllAsync(Query.Empty, cancellationToken);
 
@@ -2035,7 +2035,7 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying or filtering.
 		/// </exception>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, IQuery query, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, IQuery query, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> FindAllAsync<TEntity, object>(repository, query, cancellationToken);
 
@@ -2059,7 +2059,7 @@ namespace Deveel.Data {
 		/// Returns a list of <typeparamref name="TEntity"/> from
 		/// the repository that match the given filter.
 		/// </returns>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, IQueryFilter filter, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> FindAllAsync<TEntity, object>(repository, filter, cancellationToken);
 
@@ -2083,7 +2083,7 @@ namespace Deveel.Data {
 		/// Returns a list of <typeparamref name="TEntity"/> from
 		/// the repository that match the given filter.
 		/// </returns>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> FindAllAsync<TEntity, object>(repository, filter, cancellationToken);
 
@@ -2107,7 +2107,7 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support querying or filtering.
 		/// </exception>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> FindAllAsync<TEntity, object>(repository, cancellationToken);
 

--- a/src/Deveel.Repository.Core/Data/RepositoryWrapper.cs
+++ b/src/Deveel.Repository.Core/Data/RepositoryWrapper.cs
@@ -80,14 +80,14 @@ namespace Deveel.Data {
 			}
 		}
 
-		public Task AddAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public ValueTask AddAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			AssertMutable();
 
 			var id = SetId(entity);
 
 			AddEntity(entity);
 
-			return Task.CompletedTask;
+			return ValueTask.CompletedTask;
 		}
 
 		private string SetId(TEntity entity) {
@@ -105,7 +105,7 @@ namespace Deveel.Data {
 			return entityId;
 		}
 
-		public Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+		public ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
 			AssertMutable();
 
 			foreach (var entity in entities) {
@@ -113,24 +113,24 @@ namespace Deveel.Data {
 				AddEntity(entity);
 			}
 
-			return Task.CompletedTask;
+			return ValueTask.CompletedTask;
 		}
 
-		public Task<TEntity?> FindAsync(object key, CancellationToken cancellationToken = default) {
+		public ValueTask<TEntity?> FindAsync(object key, CancellationToken cancellationToken = default) {
 			var entity = entities.FirstOrDefault(x => GetEntityKey(x) == key);
-			return Task.FromResult<TEntity?>(entity);
+			return new ValueTask<TEntity?>(entity);
 		}
 
-		public Task<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			AssertMutable();
 
 			var key = GetEntityKey(entity);
 			if (key == null)
-				return Task.FromResult(false);
+				return new ValueTask<bool>(false);
 
 			var found = entities.FirstOrDefault(x => GetEntityKey(x) == key);
 			if (found == null)
-				return Task.FromResult(false);
+				return new ValueTask<bool>(false);
 
 			if (entities is IList<TEntity> list) {
 				list.Remove(found);
@@ -140,10 +140,10 @@ namespace Deveel.Data {
 				throw new NotSupportedException("The repository is readonly");
 			}
 
-			return Task.FromResult(true);
+			return new ValueTask<bool>(true);
 		}
 
-		public Task RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+		public ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
 			AssertMutable();
 
 			foreach (var entity in entities) {
@@ -164,19 +164,19 @@ namespace Deveel.Data {
 				}
 			}
 
-			return Task.CompletedTask;
+			return ValueTask.CompletedTask;
 		}
 
-		public Task<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			AssertMutable();
 
 			var key = GetEntityKey(entity);
 			if (key == null)
-				return Task.FromResult(false);
+				return new ValueTask<bool>(false);
 
 			var found = entities.FirstOrDefault(x => GetEntityKey(x) == key);
 			if (found == null)
-				return Task.FromResult(false);
+				return new ValueTask<bool>(false);
 
 			if (entities is IList<TEntity> list) {
 				var index = list.IndexOf(found);
@@ -188,10 +188,10 @@ namespace Deveel.Data {
 				throw new NotSupportedException("The repository is readonly");
 			}
 
-			return Task.FromResult(true);
+			return new ValueTask<bool>(true);
 		}
 
-		public Task<TEntity?> FindFirstAsync(IQuery query, CancellationToken cancellationToken = default) {
+		public ValueTask<TEntity?> FindFirstAsync(IQuery query, CancellationToken cancellationToken = default) {
 			TEntity? result;
 
 			if (entities is IQueryable<TEntity> queryable) {
@@ -204,10 +204,10 @@ namespace Deveel.Data {
 				}
 			}
 
-			return Task.FromResult(result);
+			return new ValueTask<TEntity?>(result);
 		}
 
-		public Task<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default) {
+		public ValueTask<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default) {
 			IEnumerable<TEntity> result;
 
 			if (entities is IQueryable<TEntity> queryable) {
@@ -224,10 +224,10 @@ namespace Deveel.Data {
 				}
 			}
 
-			return Task.FromResult<IList<TEntity>>(result.ToList());
+			return new ValueTask<IList<TEntity>>(result.ToList());
 		}
 
-		public Task<bool> ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
+		public ValueTask<bool> ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
 			bool result;
 
 			if (entities is IQueryable<TEntity> queryable) {
@@ -236,10 +236,10 @@ namespace Deveel.Data {
 				result = entities.Any(filter.AsLambda<TEntity>().Compile());
 			}
 
-			return Task.FromResult(result);
+			return new ValueTask<bool>(result);
 		}
 
-		public Task<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
+		public ValueTask<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
 			long result;
 
 			if (entities is IQueryable<TEntity> queryable) {
@@ -248,7 +248,7 @@ namespace Deveel.Data {
 				result = entities.LongCount(filter.AsLambda<TEntity>().Compile());
 			}
 
-			return Task.FromResult(result);
+			return new ValueTask<long>(result);
 		}
 	}
 }

--- a/src/Deveel.Repository.Core/Deveel.Repository.Core.csproj
+++ b/src/Deveel.Repository.Core/Deveel.Repository.Core.csproj
@@ -21,7 +21,6 @@
         <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
     </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.2.1" />
     <PackageReference Include="Deveel.Filters" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Deveel.Repository.DynamicLinq/Data/RepositoryExtensions.cs
+++ b/src/Deveel.Repository.DynamicLinq/Data/RepositoryExtensions.cs
@@ -45,7 +45,7 @@ namespace Deveel.Data {
 		/// Returns an instance of <typeparamref name="TEntity"/> that matches the given expression,
 		/// otherwise <c>null</c> if no entity is found.
 		/// </returns>
-		public static Task<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, string paramName, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, string paramName, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.FindFirstAsync(new DynamicLinqFilter(paramName, expression), cancellationToken);
 
@@ -74,7 +74,7 @@ namespace Deveel.Data {
 		/// Returns an instance of <typeparamref name="TEntity"/> that matches the given expression,
 		/// otherwise <c>null</c> if no entity is found.
 		/// </returns>
-		public static Task<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string paramName, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string paramName, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.FindFirstAsync(new DynamicLinqFilter(paramName, expression), cancellationToken);
 
@@ -98,7 +98,7 @@ namespace Deveel.Data {
 		/// Returns an instance of <typeparamref name="TEntity"/> that matches the given expression,
 		/// otherwise <c>null</c> if no entity is found.
 		/// </returns>
-		public static Task<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity>(this IRepository<TEntity> repository, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.FindFirstAsync(new DynamicLinqFilter(expression), cancellationToken);
 
@@ -124,7 +124,7 @@ namespace Deveel.Data {
 		/// Returns an instance of <typeparamref name="TEntity"/> that matches the given expression,
 		/// otherwise <c>null</c> if no entity is found.
 		/// </returns>
-		public static Task<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.FindFirstAsync(new DynamicLinqFilter(expression), cancellationToken);
 
@@ -156,7 +156,7 @@ namespace Deveel.Data {
 		/// Returns a list of <typeparamref name="TEntity"/> that match the 
 		/// given expression.
 		/// </returns>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, string paramName, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, string paramName, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.FindAllAsync(new DynamicLinqFilter(paramName, expression), cancellationToken);
 
@@ -186,7 +186,7 @@ namespace Deveel.Data {
 		/// Returns a list of <typeparamref name="TEntity"/> that match the 
 		/// given expression.
 		/// </returns>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string paramName, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string paramName, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.FindAllAsync(new DynamicLinqFilter(paramName, expression), cancellationToken);
 
@@ -211,7 +211,7 @@ namespace Deveel.Data {
 		/// Returns a list of <typeparamref name="TEntity"/> that match the
 		/// given expression.
 		/// </returns>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity>(this IRepository<TEntity> repository, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.FindAllAsync(new DynamicLinqFilter(expression), cancellationToken);
 
@@ -238,7 +238,7 @@ namespace Deveel.Data {
 		/// Returns a list of <typeparamref name="TEntity"/> that match the
 		/// given expression.
 		/// </returns>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.FindAllAsync(new DynamicLinqFilter(expression), cancellationToken);
 
@@ -270,7 +270,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the number of entities that match the given expression.
 		/// </returns>
-		public static Task<long> CountAsync<TEntity>(this IRepository<TEntity> repository, string paramName, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<long> CountAsync<TEntity>(this IRepository<TEntity> repository, string paramName, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.AsFilterable().CountAsync(new DynamicLinqFilter(paramName, expression), cancellationToken);
 
@@ -300,7 +300,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the number of entities that match the given expression.
 		/// </returns>
-		public static Task<long> CountAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string paramName, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<long> CountAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string paramName, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.AsFilterable().CountAsync(new DynamicLinqFilter(paramName, expression), cancellationToken);
 
@@ -325,7 +325,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the number of entities that match the given expression.
 		/// </returns>
-		public static Task<long> CountAsync<TEntity>(this IRepository<TEntity> repository, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<long> CountAsync<TEntity>(this IRepository<TEntity> repository, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.AsFilterable().CountAsync(new DynamicLinqFilter(expression), cancellationToken);
 
@@ -352,7 +352,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the number of entities that match the given expression.
 		/// </returns>
-		public static Task<long> CountAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<long> CountAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.AsFilterable().CountAsync(new DynamicLinqFilter(expression), cancellationToken);
 
@@ -387,7 +387,7 @@ namespace Deveel.Data {
 		/// Returns <c>true</c> if the repository contains at least one entity
 		/// that matches the given expression, otherwise <c>false</c>.
 		/// </returns>
-		public static Task<bool> ExistsAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string paramName, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<bool> ExistsAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string paramName, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.ExistsAsync<TEntity, TKey>(new DynamicLinqFilter(paramName, expression), cancellationToken);
 
@@ -418,7 +418,7 @@ namespace Deveel.Data {
 		/// Returns <c>true</c> if the repository contains at least one entity
 		/// that matches the given expression, otherwise <c>false</c>.
 		/// </returns>
-		public static Task<bool> ExistsAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string expression, CancellationToken cancellationToken = default)
+		public static ValueTask<bool> ExistsAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, string expression, CancellationToken cancellationToken = default)
 			where TEntity : class
 			=> repository.ExistsAsync<TEntity, TKey>(DynamicLinqFilter.DefaultParameterName, expression, cancellationToken);
 

--- a/src/Deveel.Repository.EntityFramework/Data/EntityRepository_T2.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/EntityRepository_T2.cs
@@ -185,7 +185,7 @@ namespace Deveel.Data
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task AddAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask AddAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 
 			ArgumentNullException.ThrowIfNull(entity, nameof(entity));
@@ -211,7 +211,7 @@ namespace Deveel.Data
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 
 			try {
@@ -227,7 +227,7 @@ namespace Deveel.Data
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 
 			ArgumentNullException.ThrowIfNull(entity, nameof(entity));
@@ -266,7 +266,7 @@ namespace Deveel.Data
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 
 			try {
@@ -302,12 +302,12 @@ namespace Deveel.Data
 		/// <param name="entity"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		protected virtual Task<TEntity> OnEntityFoundByKeyAsync(TKey key, TEntity entity, CancellationToken cancellationToken = default) {
-			return Task.FromResult(entity);
+		protected virtual ValueTask<TEntity> OnEntityFoundByKeyAsync(TKey key, TEntity entity, CancellationToken cancellationToken = default) {
+			return new ValueTask<TEntity>(entity);
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 
 			ArgumentNullException.ThrowIfNull(entity, nameof(entity));
@@ -364,7 +364,7 @@ namespace Deveel.Data
 		/// that matches the given filter, otherwise <c>false</c>.
 		/// </returns>
 		/// <exception cref="RepositoryException"></exception>
-		public virtual async Task<bool> ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<bool> ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 
 			try {
@@ -389,7 +389,7 @@ namespace Deveel.Data
 		/// A token used to cancel the operation.
 		/// </param>
 		/// <returns></returns>
-		public virtual async Task<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 
 			try {
@@ -404,7 +404,7 @@ namespace Deveel.Data
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task<TEntity?> FindFirstAsync(IQuery query, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<TEntity?> FindFirstAsync(IQuery query, CancellationToken cancellationToken = default) {
 			try {
 				var result = EfQueryNormalizer.Normalize(query.Apply(AsQueryable()));
 
@@ -416,7 +416,7 @@ namespace Deveel.Data
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 
 			try {
@@ -434,7 +434,7 @@ namespace Deveel.Data
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 
 			try {
@@ -455,7 +455,7 @@ namespace Deveel.Data
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default) {
 			try {
 				var result = EfQueryNormalizer.Normalize(query.Apply(AsQueryable()));
 				return await result.ToListAsync(cancellationToken);
@@ -504,7 +504,7 @@ namespace Deveel.Data
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> request, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> request, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 
 			try {

--- a/src/Deveel.Repository.EntityFramework/Data/EntityUserRepository_T3.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/EntityUserRepository_T3.cs
@@ -67,7 +67,7 @@ namespace Deveel.Data
 		protected TUserKey? UserId => UserAccessor.GetUserId();
 
 		/// <inheritdoc/>
-		public override async Task<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default)
+		public override async ValueTask<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default)
 		{
             var userId = UserAccessor.GetUserId();
 

--- a/src/Deveel.Repository.InMemory/Data/InMemoryRepository_T.cs
+++ b/src/Deveel.Repository.InMemory/Data/InMemoryRepository_T.cs
@@ -57,7 +57,7 @@ namespace Deveel.Data {
 			return GetEntityKey(entity);
 		}
 
-		Task<TEntity?> IRepository<TEntity, object>.FindAsync(object key, CancellationToken cancellationToken) {
+		ValueTask<TEntity?> IRepository<TEntity, object>.FindAsync(object key, CancellationToken cancellationToken) {
 			return FindAsync(NormalizeKey(key), cancellationToken);
 		}
 

--- a/src/Deveel.Repository.InMemory/Data/InMemoryRepository_T2.cs
+++ b/src/Deveel.Repository.InMemory/Data/InMemoryRepository_T2.cs
@@ -271,14 +271,14 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public Task<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
+		public ValueTask<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
 			cancellationToken.ThrowIfCancellationRequested();
 
 			try {
 				_lock.EnterReadLock();
 				try {
 					var result = GetEntityQueryable().LongCount(filter);
-					return Task.FromResult(result);
+					return new ValueTask<long>(result);
 				} finally {
 					_lock.ExitReadLock();
 				}
@@ -295,7 +295,7 @@ namespace Deveel.Data {
 		/// internal store, so it is safe to call concurrently from multiple threads.
 		/// </remarks>
 		/// <inheritdoc/>
-		public Task AddAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public ValueTask AddAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(entity, nameof(entity));
 
 			cancellationToken.ThrowIfCancellationRequested();
@@ -317,7 +317,7 @@ namespace Deveel.Data {
 					_lock.ExitWriteLock();
 				}
 
-				return Task.CompletedTask;
+				return ValueTask.CompletedTask;
 			} catch (RepositoryException) {
 				throw;
 			} catch (Exception ex) {
@@ -333,7 +333,7 @@ namespace Deveel.Data {
 		/// internal store, so it is safe to call concurrently from multiple threads.
 		/// </remarks>
 		/// <inheritdoc/>
-		public Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+		public ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(entities, nameof(entities));
 
 			cancellationToken.ThrowIfCancellationRequested();
@@ -360,7 +360,7 @@ namespace Deveel.Data {
 					_lock.ExitWriteLock();
 				}
 
-				return Task.CompletedTask;
+				return ValueTask.CompletedTask;
 			} catch (RepositoryException) {
 				throw;
 			} catch (Exception ex) {
@@ -376,7 +376,7 @@ namespace Deveel.Data {
 		/// internal store, so it is safe to call concurrently from multiple threads.
 		/// </remarks>
 		/// <inheritdoc/>
-		public Task<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(entity, nameof(entity));
 
 			cancellationToken.ThrowIfCancellationRequested();
@@ -384,13 +384,13 @@ namespace Deveel.Data {
 			try {
 				var entityId = GetEntityId(entity);
 				if (entityId == null)
-					return Task.FromResult(false);
+					return new ValueTask<bool>(false);
 
 				_lock.EnterWriteLock();
 				try {
 					var removed = this.entities.Remove(entityId);
 					if (removed) _version++;
-					return Task.FromResult(removed);
+					return new ValueTask<bool>(removed);
 				} finally {
 					_lock.ExitWriteLock();
 				}
@@ -409,7 +409,7 @@ namespace Deveel.Data {
 		/// internal store, so it is safe to call concurrently from multiple threads.
 		/// </remarks>
 		/// <inheritdoc/>
-		public Task RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+		public ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
 			cancellationToken.ThrowIfCancellationRequested();
 
 			ArgumentNullException.ThrowIfNull(entities, nameof(entities));
@@ -442,7 +442,7 @@ namespace Deveel.Data {
 					_lock.ExitWriteLock();
 				}
 
-				return Task.CompletedTask;
+				return ValueTask.CompletedTask;
 			} catch (RepositoryException) {
 				throw;
 			} catch (Exception ex) {
@@ -451,14 +451,14 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public Task<bool> ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
+		public ValueTask<bool> ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
 			cancellationToken.ThrowIfCancellationRequested();
 
 			try {
 				_lock.EnterReadLock();
 				try {
 					var result = GetEntityQueryable().Any(filter);
-					return Task.FromResult(result);
+					return new ValueTask<bool>(result);
 				} finally {
 					_lock.ExitReadLock();
 				}
@@ -469,14 +469,14 @@ namespace Deveel.Data {
 
 
 		/// <inheritdoc/>
-		public Task<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default) {
+		public ValueTask<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default) {
 			cancellationToken.ThrowIfCancellationRequested();
 
 			try {
 				_lock.EnterReadLock();
 				try {
 					var result = query.Apply(GetEntityQueryable()).ToList();
-					return Task.FromResult<IList<TEntity>>(result);
+					return new ValueTask<IList<TEntity>>(result);
 				} finally {
 					_lock.ExitReadLock();
 				}
@@ -486,14 +486,14 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public Task<TEntity?> FindFirstAsync(IQuery query, CancellationToken cancellationToken = default) {
+		public ValueTask<TEntity?> FindFirstAsync(IQuery query, CancellationToken cancellationToken = default) {
 			cancellationToken.ThrowIfCancellationRequested();
 
 			try {
 				_lock.EnterReadLock();
 				try {
 					var result = query.Apply(GetEntityQueryable()).FirstOrDefault();
-					return Task.FromResult(result);
+					return new ValueTask<TEntity?>(result);
 				} finally {
 					_lock.ExitReadLock();
 				}
@@ -503,7 +503,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public Task<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken = default) {
+		public ValueTask<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(key, nameof(key));
 			cancellationToken.ThrowIfCancellationRequested();
 
@@ -511,9 +511,9 @@ namespace Deveel.Data {
 				_lock.EnterReadLock();
 				try {
 					if (!entities.TryGetValue(key, out var entry))
-						return Task.FromResult<TEntity?>(null);
+						return new ValueTask<TEntity?>((TEntity?)null);
 
-					return Task.FromResult<TEntity?>(entry.Original);
+					return new ValueTask<TEntity?>(entry.Original);
 				} finally {
 					_lock.ExitReadLock();
 				}
@@ -523,7 +523,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public Task<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default) {
+		public ValueTask<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(key, nameof(key));
 
 			cancellationToken.ThrowIfCancellationRequested();
@@ -532,9 +532,9 @@ namespace Deveel.Data {
 				_lock.EnterReadLock();
 				try {
 					if (!entities.TryGetValue(key, out var entity))
-						return Task.FromResult<TEntity?>(null);
+						return new ValueTask<TEntity?>((TEntity?)null);
 
-					return Task.FromResult<TEntity?>(entity.Entity);
+					return new ValueTask<TEntity?>(entity.Entity);
 				} finally {
 					_lock.ExitReadLock();
 				}
@@ -564,7 +564,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public Task<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> request, CancellationToken cancellationToken = default) {
+		public ValueTask<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> request, CancellationToken cancellationToken = default) {
 			cancellationToken.ThrowIfCancellationRequested();
 
 			try {
@@ -578,7 +578,7 @@ namespace Deveel.Data {
 						.ToList();
 
 					var result = new PageResult<TEntity>(request, itemCount, items);
-					return Task.FromResult(result);
+					return new ValueTask<PageResult<TEntity>>(result);
 				} finally {
 					_lock.ExitReadLock();
 				}
@@ -595,7 +595,7 @@ namespace Deveel.Data {
 		/// internal store, so it is safe to call concurrently from multiple threads.
 		/// </remarks>
 		/// <inheritdoc/>
-		public Task<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			cancellationToken.ThrowIfCancellationRequested();
 
 			ArgumentNullException.ThrowIfNull(entity, nameof(entity));
@@ -603,16 +603,16 @@ namespace Deveel.Data {
 			try {
 				var entityId = GetEntityId(entity);
 				if (entityId == null)
-					return Task.FromResult(false);
+					return new ValueTask<bool>(false);
 
 				_lock.EnterWriteLock();
 				try {
 					if (!entities.TryGetValue(entityId, out var entry))
-						return Task.FromResult(false);
+						return new ValueTask<bool>(false);
 
 					entry.Update(entity);
 					_version++;
-					return Task.FromResult(true);
+					return new ValueTask<bool>(true);
 				} finally {
 					_lock.ExitWriteLock();
 				}

--- a/src/Deveel.Repository.Manager.DynamicLinq/Data/EntityManagerExtensions.cs
+++ b/src/Deveel.Repository.Manager.DynamicLinq/Data/EntityManagerExtensions.cs
@@ -36,10 +36,11 @@ namespace Deveel.Data {
 		/// A token to cancel the operation.
 		/// </param>
 		/// <returns>
-		/// Returns the first entity that matches the given expression, or
-		/// <c>null</c> if no entity was found.
+		/// Returns an instance of <see cref="OperationResult{TEntity}"/>
+		/// containing the first entity that matches the given expression,
+		/// or a failure result if no entity was found or an error occurred.
 		/// </returns>
-		public static ValueTask<TEntity?> FindFirstAsync<TEntity>(this EntityManager<TEntity> manager, string expression, CancellationToken? cancellationToken = null)
+		public static ValueTask<OperationResult<TEntity>> FindFirstAsync<TEntity>(this EntityManager<TEntity> manager, string expression, CancellationToken? cancellationToken = null)
 			where TEntity : class
 			=> manager.FindFirstAsync(new Query(new DynamicLinqFilter(expression)), cancellationToken);
 
@@ -63,10 +64,11 @@ namespace Deveel.Data {
 		/// A token to cancel the operation.
 		/// </param>
 		/// <returns>
-		/// Returns the first entity that matches the given expression, or
-		/// <c>null</c> if no entity was found.
+		/// Returns an instance of <see cref="OperationResult{TEntity}"/>
+		/// containing the first entity that matches the given expression,
+		/// or a failure result if no entity was found or an error occurred.
 		/// </returns>
-		public static ValueTask<TEntity?> FindFirstAsync<TEntity, TKey>(this EntityManager<TEntity, TKey> manager, string expression, CancellationToken? cancellationToken = null)
+		public static ValueTask<OperationResult<TEntity>> FindFirstAsync<TEntity, TKey>(this EntityManager<TEntity, TKey> manager, string expression, CancellationToken? cancellationToken = null)
 			where TEntity : class
 			where TKey : notnull
 			=> manager.FindFirstAsync(new Query(new DynamicLinqFilter(expression)), cancellationToken);

--- a/src/Deveel.Repository.Manager.DynamicLinq/Data/EntityManagerExtensions.cs
+++ b/src/Deveel.Repository.Manager.DynamicLinq/Data/EntityManagerExtensions.cs
@@ -39,7 +39,7 @@ namespace Deveel.Data {
 		/// Returns the first entity that matches the given expression, or
 		/// <c>null</c> if no entity was found.
 		/// </returns>
-		public static Task<TEntity?> FindFirstAsync<TEntity>(this EntityManager<TEntity> manager, string expression, CancellationToken? cancellationToken = null)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity>(this EntityManager<TEntity> manager, string expression, CancellationToken? cancellationToken = null)
 			where TEntity : class
 			=> manager.FindFirstAsync(new Query(new DynamicLinqFilter(expression)), cancellationToken);
 
@@ -66,7 +66,7 @@ namespace Deveel.Data {
 		/// Returns the first entity that matches the given expression, or
 		/// <c>null</c> if no entity was found.
 		/// </returns>
-		public static Task<TEntity?> FindFirstAsync<TEntity, TKey>(this EntityManager<TEntity, TKey> manager, string expression, CancellationToken? cancellationToken = null)
+		public static ValueTask<TEntity?> FindFirstAsync<TEntity, TKey>(this EntityManager<TEntity, TKey> manager, string expression, CancellationToken? cancellationToken = null)
 			where TEntity : class
 			where TKey : notnull
 			=> manager.FindFirstAsync(new Query(new DynamicLinqFilter(expression)), cancellationToken);
@@ -91,7 +91,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns a list of entities that matches the given expression.
 		/// </returns>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity>(this EntityManager<TEntity> manager, string expression, CancellationToken? cancellationToken = null)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity>(this EntityManager<TEntity> manager, string expression, CancellationToken? cancellationToken = null)
 			where TEntity : class
 			=> manager.FindAllAsync(new Query(new DynamicLinqFilter(expression)), cancellationToken);
 
@@ -117,7 +117,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns a list of entities that matches the given expression.
 		/// </returns>
-		public static Task<IList<TEntity>> FindAllAsync<TEntity, TKey>(this EntityManager<TEntity, TKey> manager, string expression, CancellationToken? cancellationToken = null)
+		public static ValueTask<IList<TEntity>> FindAllAsync<TEntity, TKey>(this EntityManager<TEntity, TKey> manager, string expression, CancellationToken? cancellationToken = null)
 			where TEntity : class
 			where TKey : notnull
 			=> manager.FindAllAsync(new Query(new DynamicLinqFilter(expression)), cancellationToken);
@@ -142,7 +142,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the number of entities that matches the given expression.
 		/// </returns>
-		public static Task<long> CountAsync<TEntity>(this EntityManager<TEntity> manager, string expression, CancellationToken? cancellationToken = null)
+		public static ValueTask<long> CountAsync<TEntity>(this EntityManager<TEntity> manager, string expression, CancellationToken? cancellationToken = null)
 			where TEntity : class
 			=> manager.CountAsync(new DynamicLinqFilter(expression), cancellationToken);
 
@@ -168,7 +168,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the number of entities that matches the given expression.
 		/// </returns>
-		public static Task<long> CountAsync<TEntity, TKey>(this EntityManager<TEntity, TKey> manager, string expression, CancellationToken? cancellationToken = null)
+		public static ValueTask<long> CountAsync<TEntity, TKey>(this EntityManager<TEntity, TKey> manager, string expression, CancellationToken? cancellationToken = null)
 			where TEntity : class
 			where TKey : notnull
 			=> manager.CountAsync(new DynamicLinqFilter(expression), cancellationToken);

--- a/src/Deveel.Repository.Manager.EasyCaching/Data/Caching/EntityEasyCache_2.cs
+++ b/src/Deveel.Repository.Manager.EasyCaching/Data/Caching/EntityEasyCache_2.cs
@@ -113,7 +113,7 @@ namespace Deveel.Data.Caching {
 			throw new NotSupportedException("The converter is not defined for this cache");
 		}
 
-		private Func<Task<TCached>> Factory(Func<Task<TEntity?>> valueFactory, CancellationToken cancellationToken) {
+		private Func<Task<TCached>> Factory(Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken) {
 			return async () => {
 				var entity = await valueFactory();
 				if (entity == null)
@@ -135,7 +135,7 @@ namespace Deveel.Data.Caching {
 		}
 
 		/// <inheritdoc/>
-		public async Task<TEntity?> GetOrSetAsync(string cacheKey, Func<Task<TEntity?>> valueFactory, CancellationToken cancellationToken = default) {
+		public async ValueTask<TEntity?> GetOrSetAsync(string cacheKey, Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken = default) {
 			try {
 				var factory = Factory(valueFactory, cancellationToken);
 
@@ -149,7 +149,7 @@ namespace Deveel.Data.Caching {
 		}
 
 		/// <inheritdoc/>
-		public async Task RemoveAsync(string[] cacheKeys, CancellationToken cancellationToken = default) {
+		public async ValueTask RemoveAsync(string[] cacheKeys, CancellationToken cancellationToken = default) {
 			try {
 				await cacheProvider.RemoveAllAsync(cacheKeys, cancellationToken);
 			} catch (Exception ex) {
@@ -158,7 +158,7 @@ namespace Deveel.Data.Caching {
 		}
 
 		/// <inheritdoc/>
-		public async Task SetAsync(string[] cacheKeys, TEntity entity, CancellationToken cancellationToken = default) {
+		public async ValueTask SetAsync(string[] cacheKeys, TEntity entity, CancellationToken cancellationToken = default) {
 			try {
 				var cached = ConvertToCached(entity);
 				var pairs = cacheKeys.ToDictionary(x => x, y => cached);

--- a/src/Deveel.Repository.Manager/Data/Caching/IEntityCache.cs
+++ b/src/Deveel.Repository.Manager/Data/Caching/IEntityCache.cs
@@ -53,7 +53,7 @@ namespace Deveel.Data.Caching {
 		/// <c>null</c> if the entity was not found in the cache
 		/// and the factory was not able to create it.
 		/// </returns>
-		Task<TEntity?> GetOrSetAsync(string cacheKey, Func<Task<TEntity?>> valueFactory, CancellationToken cancellationToken = default);
+		ValueTask<TEntity?> GetOrSetAsync(string cacheKey, Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Sets the given entity in the cache with the given key.
@@ -71,7 +71,7 @@ namespace Deveel.Data.Caching {
 		/// Returns a task that when completed will set the entity
 		/// in the cache.
 		/// </returns>
-		Task SetAsync(string[] cacheKeys, TEntity entity, CancellationToken cancellationToken = default);
+		ValueTask SetAsync(string[] cacheKeys, TEntity entity, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Removes a given entity from the cache with the given key.
@@ -86,6 +86,6 @@ namespace Deveel.Data.Caching {
 		/// Returns a task that when completed will remove the entity
 		/// from the cache.
 		/// </returns>
-		Task RemoveAsync(string[] cacheKeys, CancellationToken cancellationToken = default);
+		ValueTask RemoveAsync(string[] cacheKeys, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Deveel.Repository.Manager/Data/EntityErrorCodes.cs
+++ b/src/Deveel.Repository.Manager/Data/EntityErrorCodes.cs
@@ -34,6 +34,11 @@ namespace Deveel.Data {
 		public const string NotFound = "NOT_FOUND";
 
 		/// <summary>
+		/// The operation is not supported by the repository.
+		/// </summary>
+		public const string NotSupported = "NOT_SUPPORTED";
+
+		/// <summary>
 		/// An unknown error occurred during the operation.
 		/// </summary>
 		public const string UnknownError = "UNKNOWN_ERROR";

--- a/src/Deveel.Repository.Manager/Data/EntityManagerEventIds.cs
+++ b/src/Deveel.Repository.Manager/Data/EntityManagerEventIds.cs
@@ -147,5 +147,10 @@ namespace Deveel.Data {
 		/// An entity was found in the repository.
 		/// </summary>
 		public const int EntityFoundByKey = 2006;
+
+		/// <summary>
+		/// A first entity matching a query was found in the repository.
+		/// </summary>
+		public const int EntityFoundByQuery = 2007;
 	}
 }

--- a/src/Deveel.Repository.Manager/Data/EntityManager_T2.cs
+++ b/src/Deveel.Repository.Manager/Data/EntityManager_T2.cs
@@ -853,11 +853,12 @@ namespace Deveel.Data {
 			return EntityComparer.Equals(existing, other);
 		}
 
-		private ValueTask<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken) {
+		private async ValueTask<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken) {
 			if (SupportsTracking && IsTrackingChanges)
-				return TrackingRepository.FindOriginalAsync(key, cancellationToken);
+				return await TrackingRepository.FindOriginalAsync(key, cancellationToken);
 
-			return FindAsync(key, cancellationToken);
+			var result = await FindAsync(key, cancellationToken);
+			return result.IsSuccess() ? result.Value : null;
 		}
 
 		/// <summary>
@@ -977,13 +978,13 @@ namespace Deveel.Data {
 
 				Logger.LogRemovingEntity(typeof(TEntity), entityKey);
 
-				var found = await FindAsync(entityKey, token);
-				if (found == null) {
+				var foundResult = await FindAsync(entityKey, token);
+				if (!foundResult.IsSuccess()) {
 					LogEntityNotFound(entityKey);
 					return Fail(EntityErrorCodes.NotFound);
 				}
 
-				if (!await Repository.RemoveAsync(found, token)) {
+				if (!await Repository.RemoveAsync(foundResult.Value!, token)) {
 					Logger.LogEntityNotRemoved(typeof(TEntity), entityKey);
 					return NotChanged();
 				}
@@ -1036,7 +1037,7 @@ namespace Deveel.Data {
 		}
 
 		/// <summary>
-		/// Finds an entity in the repository with the given key.
+		/// Attempts to find an entity in the repository by its key.
 		/// </summary>
 		/// <param name="key">
 		/// The key of the entity to be found.
@@ -1045,16 +1046,11 @@ namespace Deveel.Data {
 		/// A token used to cancel the operation.
 		/// </param>
 		/// <returns>
-		/// Returns an instance of <typeparamref name="TEntity"/> that
-		/// is identified by the given key, or <c>null</c> if no entity
-		/// was found for the given key.
+		/// Returns an instance of <see cref="OperationResult{TEntity}"/> that
+		/// contains the entity identified by the given key, or a failure
+		/// result if no entity was found or an error occurred.
 		/// </returns>
-		/// <exception cref="OperationException">
-		/// Thrown when an unknown error occurs while looking for the entity.
-		/// </exception>
-		// TODO: Is there any use case for using OperationResult<TEntity> here
-		//       instead of returning an entity?
-		public virtual async ValueTask<TEntity?> FindAsync(TKey key, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<OperationResult<TEntity>> FindAsync(TKey key, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			ArgumentNullException.ThrowIfNull(key, nameof(key));
@@ -1067,14 +1063,14 @@ namespace Deveel.Data {
 
 				if (result == null) {
 					Logger.LogEntityNotFound(typeof(TEntity), key);
-				} else {
-					Logger.LogEntityFoundByKey(typeof(TEntity), key);
+					return OperationResult<TEntity>.Fail(OperationError(EntityErrorCodes.NotFound, "Entity was not found"));
 				}
 
-				return result;
+				Logger.LogEntityFoundByKey(typeof(TEntity), key);
+				return OperationResult<TEntity>.Success(result);
 			} catch (Exception ex) {
 				LogEntityUnknownError(key, ex);
-				throw new OperationException(EntityErrorCodes.UnknownError, Domain, "Could not look for the entity", ex);
+				return OperationResult<TEntity>.Fail(OperationError(EntityErrorCodes.UnknownError, "Could not look for the entity"));
 			}
 		}
 

--- a/src/Deveel.Repository.Manager/Data/EntityManager_T2.cs
+++ b/src/Deveel.Repository.Manager/Data/EntityManager_T2.cs
@@ -534,7 +534,7 @@ namespace Deveel.Data {
 		/// Returns a list of <see cref="ValidationResult"/> that
 		/// describe the validation errors.
 		/// </returns>
-		protected virtual async Task<IReadOnlyList<ValidationResult>> ValidateAsync(TEntity entity, CancellationToken cancellationToken) {
+		protected virtual async ValueTask<IReadOnlyList<ValidationResult>> ValidateAsync(TEntity entity, CancellationToken cancellationToken) {
 			if (EntityValidator == null)
 				return new List<ValidationResult>();
 
@@ -583,11 +583,11 @@ namespace Deveel.Data {
 		/// Returns the entity that is being added, after
 		/// any modification done by the callback.
 		/// </returns>
-		protected virtual Task<TEntity> OnAddingEntityAsync(TEntity entity) {
+		protected virtual ValueTask<TEntity> OnAddingEntityAsync(TEntity entity) {
 			if (entity is IHaveTimeStamp haveTimeStamp && Time != null)
 				haveTimeStamp.CreatedAtUtc = Time.UtcNow;
 
-			return Task.FromResult(entity);
+			return new ValueTask<TEntity>(entity);
 		}
 
 		/// <summary>
@@ -614,7 +614,7 @@ namespace Deveel.Data {
 			return EntityCache.GenerateKeys(entity);
 		}
 
-		private async Task SetToCacheAsync(TEntity entity, CancellationToken cancellationToken) {
+		private async ValueTask SetToCacheAsync(TEntity entity, CancellationToken cancellationToken) {
 			if (EntityCache == null)
 				return;
 
@@ -627,7 +627,7 @@ namespace Deveel.Data {
 			}
 		}
 
-		private async Task EvictAsync(TEntity entity, CancellationToken cancellationToken) {
+		private async ValueTask EvictAsync(TEntity entity, CancellationToken cancellationToken) {
 			if (EntityCache == null)
 				return;
 
@@ -665,7 +665,7 @@ namespace Deveel.Data {
 		/// it returns <c>null</c> if the entity was not found
 		/// in the cache and the factory was not able to create it.
 		/// </returns>
-		protected async Task<TEntity?> GetOrSetByKeyAsync(TKey key, Func<Task<TEntity?>> valueFactory, CancellationToken cancellationToken) {
+		protected async ValueTask<TEntity?> GetOrSetByKeyAsync(TKey key, Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken) {
 			return await GetOrSetAsync(GenerateCacheKey(key), valueFactory, cancellationToken);
 		}
 
@@ -691,7 +691,7 @@ namespace Deveel.Data {
 		/// </remarks>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		protected async Task<TEntity?> GetOrSetAsync(string cacheKey, Func<Task<TEntity?>> valueFactory, CancellationToken cancellationToken) {
+		protected async ValueTask<TEntity?> GetOrSetAsync(string cacheKey, Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken) {
 			if (EntityCache == null)
 				return await valueFactory();
 
@@ -716,7 +716,7 @@ namespace Deveel.Data {
 		/// Returns an instance of <see cref="OperationResult"/> that
 		/// describes the result of the operation.
 		/// </returns>
-		public virtual async Task<OperationResult> AddAsync(TEntity entity, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<OperationResult> AddAsync(TEntity entity, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			try {
@@ -765,7 +765,7 @@ namespace Deveel.Data {
 		/// operation.
 		/// </returns>
 		/// <seealso cref="IRepository{TEntity,TKey}.AddRangeAsync(IEnumerable{TEntity}, CancellationToken)"/>
-		public virtual async Task<OperationResult> AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<OperationResult> AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken? cancellationToken = null) {
 			try {
 				Logger.LogAddingEntityRange(typeof(TEntity));
 
@@ -807,11 +807,11 @@ namespace Deveel.Data {
 		/// Returns the entity that is being updated, after
 		/// the callback has modified it.
 		/// </returns>
-		protected virtual Task<TEntity> OnUpdatingEntityAsync(TEntity entity) {
+		protected virtual ValueTask<TEntity> OnUpdatingEntityAsync(TEntity entity) {
 			if (entity is IHaveTimeStamp haveTimeStamp && Time != null)
 				haveTimeStamp.UpdatedAtUtc = Time.UtcNow;
 
-			return Task.FromResult(entity);
+			return new ValueTask<TEntity>(entity);
 		}
 
 		/// <summary>
@@ -853,7 +853,7 @@ namespace Deveel.Data {
 			return EntityComparer.Equals(existing, other);
 		}
 
-		private Task<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken) {
+		private ValueTask<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken) {
 			if (SupportsTracking && IsTrackingChanges)
 				return TrackingRepository.FindOriginalAsync(key, cancellationToken);
 
@@ -890,7 +890,7 @@ namespace Deveel.Data {
 		/// Returns a result object that describes the result of the
 		/// update operation.
 		/// </returns>
-		public virtual async Task<OperationResult> UpdateAsync(TEntity entity, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<OperationResult> UpdateAsync(TEntity entity, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			var entityKey = GetEntityKey(entity);
@@ -964,7 +964,7 @@ namespace Deveel.Data {
 		/// Returns an instance of <see cref="OperationResult"/> that
 		/// describes the result of the operation.
 		/// </returns>
-		public virtual async Task<OperationResult> RemoveAsync(TEntity entity, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<OperationResult> RemoveAsync(TEntity entity, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			var entityKey = GetEntityKey(entity);
@@ -1010,7 +1010,7 @@ namespace Deveel.Data {
 		/// Returns an instance of <see cref="OperationResult"/> that
 		/// describes the result of the operation.
 		/// </returns>
-		public virtual async Task<OperationResult> RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<OperationResult> RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			try {
@@ -1054,7 +1054,7 @@ namespace Deveel.Data {
 		/// </exception>
 		// TODO: Is there any use case for using OperationResult<TEntity> here
 		//       instead of returning an entity?
-		public virtual async Task<TEntity?> FindAsync(TKey key, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<TEntity?> FindAsync(TKey key, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			ArgumentNullException.ThrowIfNull(key, nameof(key));
@@ -1103,7 +1103,7 @@ namespace Deveel.Data {
 		/// <seealso cref="IFilterableRepository{TEntity,TKey}.FindFirstAsync(IQuery, CancellationToken)"/>
 		// TODO: Is there any use case for using OperationResult<TEntity> here
 		//       instead of returning the entity?
-		public virtual async Task<TEntity?> FindFirstAsync(IQuery query, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<TEntity?> FindFirstAsync(IQuery query, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			if (!SupportsFilters)
@@ -1134,7 +1134,7 @@ namespace Deveel.Data {
 		/// mathces the given filter, or <c>null</c> if no entity was found.
 		/// </returns>
 		/// <seealso cref="FindFirstAsync(IQuery, CancellationToken?)"/>
-		public Task<TEntity?> FindFirstAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken? cancellationToken = null)
+		public ValueTask<TEntity?> FindFirstAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken? cancellationToken = null)
 			=> FindFirstAsync(filter == null ? Query.Empty : new QueryBuilder<TEntity>().Where(filter), cancellationToken);
 
 		/// <summary>
@@ -1158,7 +1158,7 @@ namespace Deveel.Data {
 		/// </exception>
 		// TODO: Is there any use case for using OperationResult<IList<TEntity>> here
 		//       instead of returning a list of entities?
-		public virtual async Task<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			if (!SupportsFilters)
@@ -1198,7 +1198,7 @@ namespace Deveel.Data {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support filters.
 		/// </exception>
-		public Task<IList<TEntity>> FindAllAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken? cancellationToken = null)
+		public ValueTask<IList<TEntity>> FindAllAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken? cancellationToken = null)
 			=> FindAllAsync(Query.Where(filter), cancellationToken);
 
 		/// <summary>
@@ -1220,7 +1220,7 @@ namespace Deveel.Data {
 		/// <exception cref="OperationException">
 		/// Thrown when an unknown error occurs while looking for the entities.
 		/// </exception>
-		public virtual Task<long> CountAsync(IQueryFilter filter, CancellationToken? cancellationToken = null) {
+		public virtual ValueTask<long> CountAsync(IQueryFilter filter, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			if (!SupportsFilters)
@@ -1263,7 +1263,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the number of entities that match the given filter.
 		/// </returns>
-		public Task<long> CountAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken? cancellationToken = null)
+		public ValueTask<long> CountAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken? cancellationToken = null)
 			=> CountAsync(filter == null ? QueryFilter.Empty : QueryFilter.Where(filter), cancellationToken);
 
 		/// <summary>
@@ -1274,7 +1274,7 @@ namespace Deveel.Data {
 		/// <returns></returns>
 		/// <exception cref="NotSupportedException"></exception>
 		/// <exception cref="OperationException"></exception>
-		public virtual async Task<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> query, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> query, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			if (!SupportsPaging)

--- a/src/Deveel.Repository.Manager/Data/EntityManager_T2.cs
+++ b/src/Deveel.Repository.Manager/Data/EntityManager_T2.cs
@@ -1097,26 +1097,32 @@ namespace Deveel.Data {
 		/// Thrown when the given filter is <c>null</c>.
 		/// </exception>
 		/// <seealso cref="IFilterableRepository{TEntity,TKey}.FindFirstAsync(IQuery, CancellationToken)"/>
-		// TODO: Is there any use case for using OperationResult<TEntity> here
-		//       instead of returning the entity?
-		public virtual async ValueTask<TEntity?> FindFirstAsync(IQuery query, CancellationToken? cancellationToken = null) {
+		public virtual async ValueTask<OperationResult<TEntity>> FindFirstAsync(IQuery query, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 
 			if (!SupportsFilters)
-				throw new NotSupportedException("The repository does not support filters");
+				return OperationResult<TEntity>.Fail(OperationError(EntityErrorCodes.NotSupported, "The repository does not support filters"));
 
 			try {
 				Logger.LogFindingFirstEntityByQuery(typeof(TEntity));
 
-				return await FilterableRepository.FindFirstAsync(query, GetCancellationToken(cancellationToken));
+				var result = await FilterableRepository.FindFirstAsync(query, GetCancellationToken(cancellationToken));
+
+				if (result == null) {
+					Logger.LogEntityNotFound(typeof(TEntity), query);
+					return OperationResult<TEntity>.Fail(OperationError(EntityErrorCodes.NotFound, "Entity was not found"));
+				}
+
+				Logger.LogEntityFoundByQuery(typeof(TEntity), query);
+				return OperationResult<TEntity>.Success(result);
 			} catch (Exception ex) {
 				LogUnknownError(ex);
-				throw new OperationException(EntityErrorCodes.UnknownError, Domain, "Could not look for the entity", ex);
+				return OperationResult<TEntity>.Fail(OperationError(EntityErrorCodes.UnknownError, "Could not look for the entity"));
 			}
 		}
 
 		/// <summary>
-		/// Finds the first entity in the repository that matches the 
+		/// Finds the first entity in the repository that matches the
 		/// given filter expression.
 		/// </summary>
 		/// <param name="filter">
@@ -1126,11 +1132,12 @@ namespace Deveel.Data {
 		/// A token used to cancel the operation.
 		/// </param>
 		/// <returns>
-		/// Returns the first instance of <typeparamref name="TEntity"/> that
-		/// mathces the given filter, or <c>null</c> if no entity was found.
+		/// Returns an instance of <see cref="OperationResult{TEntity}"/> that
+		/// contains the first entity matching the given filter, or a failure
+		/// result if no entity was found or an error occurred.
 		/// </returns>
 		/// <seealso cref="FindFirstAsync(IQuery, CancellationToken?)"/>
-		public ValueTask<TEntity?> FindFirstAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken? cancellationToken = null)
+		public ValueTask<OperationResult<TEntity>> FindFirstAsync(Expression<Func<TEntity, bool>>? filter = null, CancellationToken? cancellationToken = null)
 			=> FindFirstAsync(filter == null ? Query.Empty : new QueryBuilder<TEntity>().Where(filter), cancellationToken);
 
 		/// <summary>
@@ -1152,8 +1159,6 @@ namespace Deveel.Data {
 		/// <exception cref="OperationException">
 		/// Thrown when an unknown error occurs while looking for the entities.
 		/// </exception>
-		// TODO: Is there any use case for using OperationResult<IList<TEntity>> here
-		//       instead of returning a list of entities?
 		public virtual async ValueTask<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 

--- a/src/Deveel.Repository.Manager/Data/LoggerExtensions.cs
+++ b/src/Deveel.Repository.Manager/Data/LoggerExtensions.cs
@@ -76,6 +76,9 @@ namespace Deveel.Data {
 		[LoggerMessage(EntityManagerEventIds.EntityFoundByKey, LogLevel.Debug, "An entity of type {EntityType} identified by {EntityKey} has been found repository")]
 		public static partial void LogEntityFoundByKey(this ILogger logger, Type entityType, object? entityKey);
 
+		[LoggerMessage(EntityManagerEventIds.EntityFoundByQuery, LogLevel.Debug, "A first entity of type {EntityType} matching the query {Query} has been found in the repository")]
+		public static partial void LogEntityFoundByQuery(this ILogger logger, Type entityType, object? query);
+
         // Information
 
 		[LoggerMessage(EntityManagerEventIds.EntityAdded, LogLevel.Information, "The entity {EntityId} was added to the repository.")]

--- a/src/Deveel.Repository.Manager/Deveel.Repository.Manager.csproj
+++ b/src/Deveel.Repository.Manager/Deveel.Repository.Manager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Deveel.Results" Version="1.2.0" />
+        <PackageReference Include="Deveel.Results" Version="1.2.1" />
     </ItemGroup>
     
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Deveel.Repository.MongoFramework/Data/MongoRepository_T2.cs
+++ b/src/Deveel.Repository.MongoFramework/Data/MongoRepository_T2.cs
@@ -243,7 +243,7 @@ namespace Deveel.Data {
 
 		#region Controllable
 
-		Task<bool> IControllableRepository.ExistsAsync(CancellationToken cancellationToken)
+		ValueTask<bool> IControllableRepository.ExistsAsync(CancellationToken cancellationToken)
 			=> CollectionExistsAsync(cancellationToken);
 
 		/// <summary>
@@ -260,7 +260,7 @@ namespace Deveel.Data {
 		/// Thrown when an error occurs while verifying the existence of the
 		/// collection in the underlying database.
 		/// </exception>
-		public async Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default) {
+		public async ValueTask<bool> CollectionExistsAsync(CancellationToken cancellationToken = default) {
 			try {
 				var entityDef = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
 
@@ -278,7 +278,7 @@ namespace Deveel.Data {
 			}
 		}
 
-		async Task IControllableRepository.CreateAsync(CancellationToken cancellationToken) {
+		async ValueTask IControllableRepository.CreateAsync(CancellationToken cancellationToken) {
 			await CreateCollectionAsync(cancellationToken);
 			await CreateIndicesAsync(cancellationToken);
 		}
@@ -297,7 +297,7 @@ namespace Deveel.Data {
 		/// Thrown when an error occurs while creating the collection in the
 		/// database or if the collection already exists.
 		/// </exception>
-		public async Task CreateCollectionAsync(CancellationToken cancellationToken = default) {
+		public async ValueTask CreateCollectionAsync(CancellationToken cancellationToken = default) {
 			try {
 				var entityDef = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
 
@@ -322,7 +322,7 @@ namespace Deveel.Data {
 		/// of the repository.
 		/// </returns>
 		/// <exception cref="RepositoryException"></exception>
-		public async Task CreateIndicesAsync(CancellationToken cancellationToken = default) {
+		public async ValueTask CreateIndicesAsync(CancellationToken cancellationToken = default) {
 			try {
 				var entityDef = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
 
@@ -361,7 +361,7 @@ namespace Deveel.Data {
 			}
 		}
 
-		async Task IControllableRepository.DropAsync(CancellationToken cancellationToken) {
+		async ValueTask IControllableRepository.DropAsync(CancellationToken cancellationToken) {
 			await DropIndicesAsync(cancellationToken);
 			await DropCollectionAsync(cancellationToken);
 		}
@@ -380,7 +380,7 @@ namespace Deveel.Data {
 		/// <exception cref="RepositoryException">
 		/// Thrown when an error occurs while dropping the indices.
 		/// </exception>
-		public async Task DropIndicesAsync(CancellationToken cancellationToken = default) {
+		public async ValueTask DropIndicesAsync(CancellationToken cancellationToken = default) {
 			try {
 				await Collection.Indexes.DropAllAsync(cancellationToken);
 			} catch (Exception ex) {
@@ -400,7 +400,7 @@ namespace Deveel.Data {
 		/// Returns a task that, when completed, has dropped the collection.
 		/// </returns>
 		/// <exception cref="RepositoryException"></exception>
-		public async Task DropCollectionAsync(CancellationToken cancellationToken = default) {
+		public async ValueTask DropCollectionAsync(CancellationToken cancellationToken = default) {
 			try {
 				var entityDef = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
 
@@ -442,7 +442,7 @@ namespace Deveel.Data {
 		/// Thrown when an error occurs while creating the entity in the
 		/// underlying database.
 		/// </exception>
-		public virtual async Task AddAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask AddAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(entity, nameof(entity));
 
 			ThrowIfDisposed();
@@ -466,7 +466,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public async Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+		public async ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(entities, nameof(entities));
 
 			ThrowIfDisposed();
@@ -499,7 +499,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public virtual async Task<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(entity, nameof(entity));
 
 			ThrowIfDisposed();
@@ -538,7 +538,7 @@ namespace Deveel.Data {
 		#endregion
 
 		/// <inheritdoc/>
-		public virtual async Task<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {
+		public virtual async ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(entity, nameof(entity));
 
 			ThrowIfDisposed();
@@ -569,7 +569,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public async Task RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+		public async ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(entities, nameof(entities));
 
 			ThrowIfDisposed();
@@ -589,7 +589,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public async Task<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default) {
+		public async ValueTask<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default) {
 			ArgumentNullException.ThrowIfNull(key, nameof(key));
 
 			ThrowIfDisposed();
@@ -619,7 +619,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public async Task<TEntity?> FindFirstAsync(IQuery query, CancellationToken cancellationToken = default) {
+		public async ValueTask<TEntity?> FindFirstAsync(IQuery query, CancellationToken cancellationToken = default) {
 			try {
 				var entities = query.Apply(DbSet.AsQueryable());
 				return await entities.FirstOrDefaultAsync(cancellationToken);
@@ -629,7 +629,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public async Task<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default) {
+		public async ValueTask<IList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default) {
 			try {
 				var entities = query.Apply(DbSet.AsQueryable());
 				return await entities.ToListAsync(cancellationToken);
@@ -640,7 +640,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public async Task<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> query, CancellationToken cancellationToken = default) {
+		public async ValueTask<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> query, CancellationToken cancellationToken = default) {
 			try {
 				var entitySet = query.ApplyQuery(DbSet.AsQueryable());
 
@@ -657,14 +657,14 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public Task<bool> ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
+		public ValueTask<bool> ExistsAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
 			try {
 				var query = DbSet.AsQueryable();
 				if (filter != null) {
 					query = filter.Apply(query);
 				}
 
-				return query.AnyAsync(cancellationToken);
+				return new ValueTask<bool>(query.AnyAsync(cancellationToken));
 			} catch (Exception ex) {
 
 				throw new RepositoryException("Unable to execute the query", ex);
@@ -672,7 +672,7 @@ namespace Deveel.Data {
 		}
 
 		/// <inheritdoc/>
-		public async Task<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
+		public async ValueTask<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
 			try {
 				var query = DbSet.AsQueryable();
 				if (filter != null) {

--- a/src/Deveel.Repository.MongoFramework/Data/RepositoryExtensions.cs
+++ b/src/Deveel.Repository.MongoFramework/Data/RepositoryExtensions.cs
@@ -50,7 +50,7 @@ namespace Deveel.Data {
 		/// Thrown when the given repository is not a <see cref="MongoRepository{TEntity}"/>.
 		/// </exception>
 		/// <seealso cref="MongoGeoDistanceFilter{TEntity}"/>
-		public static Task<TEntity?> FindFirstByGeoDistanceAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, object>> field, GeoPoint point, double? maxDistance = null)
+		public static ValueTask<TEntity?> FindFirstByGeoDistanceAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, object>> field, GeoPoint point, double? maxDistance = null)
 			where TEntity : class {
 			ArgumentNullException.ThrowIfNull(repository, nameof(repository));
 
@@ -91,7 +91,7 @@ namespace Deveel.Data {
 		/// Thrown when the given repository is not a <see cref="MongoRepository{TEntity}"/>.
 		/// </exception>
 		/// <seealso cref="MongoGeoDistanceFilter{TEntity}"/>
-		public static Task<TEntity?> FindFirstByGeoDistanceAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, object>> field, GeoPoint point, double? maxDistance = null)
+		public static ValueTask<TEntity?> FindFirstByGeoDistanceAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, object>> field, GeoPoint point, double? maxDistance = null)
 			where TEntity : class {
 			ArgumentNullException.ThrowIfNull(repository, nameof(repository));
 
@@ -129,7 +129,7 @@ namespace Deveel.Data {
 		/// <exception cref="ArgumentException">
 		/// Thrown when the given repository is not a <see cref="MongoRepository{TEntity}"/>.
 		/// </exception>
-		public static Task<IList<TEntity>> FindAllByGeoDistanceAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, object>> field, GeoPoint point, double? maxDistance = null)
+		public static ValueTask<IList<TEntity>> FindAllByGeoDistanceAsync<TEntity>(this IRepository<TEntity> repository, Expression<Func<TEntity, object>> field, GeoPoint point, double? maxDistance = null)
 			where TEntity : class {
 			ArgumentNullException.ThrowIfNull(repository, nameof(repository));
 
@@ -167,7 +167,7 @@ namespace Deveel.Data {
 		/// is the result of the search.
 		/// </returns>
 		/// <exception cref="ArgumentException"></exception>
-		public static Task<IList<TEntity>> FindAllByGeoDistanceAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, object>> field, GeoPoint point, double? maxDistance = null)
+		public static ValueTask<IList<TEntity>> FindAllByGeoDistanceAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, object>> field, GeoPoint point, double? maxDistance = null)
 			where TEntity : class {
 			ArgumentNullException.ThrowIfNull(repository, nameof(repository));
 

--- a/test/Deveel.Repository.Core.XUnit/Unit/DependencyInjectionTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/DependencyInjectionTests.cs
@@ -37,7 +37,7 @@ public class DependencyInjectionTests
 
 interface IPersonRepository : IRepository<Person>
 {
-    Task<Person?> FindByNameAsync(string name, CancellationToken cancellationToken = default);
+    ValueTask<Person?> FindByNameAsync(string name, CancellationToken cancellationToken = default);
 }
 
 class MyRepository<TEntity> : IRepository<TEntity>
@@ -50,30 +50,30 @@ class MyRepository<TEntity> : IRepository<TEntity>
         Repository = new List<TEntity>(200).AsRepository();
     }
 
-    public Task AddAsync(TEntity entity, CancellationToken cancellationToken = default) =>
+    public ValueTask AddAsync(TEntity entity, CancellationToken cancellationToken = default) =>
         Repository.AddAsync(entity, cancellationToken);
 
-    public Task AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) =>
+    public ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) =>
         Repository.AddRangeAsync(entities, cancellationToken);
 
-    public Task<TEntity?> FindAsync(object key, CancellationToken cancellationToken = default) =>
+    public ValueTask<TEntity?> FindAsync(object key, CancellationToken cancellationToken = default) =>
         Repository.FindAsync(key, cancellationToken);
 
     public object? GetEntityKey(TEntity entity) =>
         Repository.GetEntityKey(entity);
 
-    public Task<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) =>
+    public ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) =>
         Repository.RemoveAsync(entity, cancellationToken);
 
-    public Task RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) =>
+    public ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) =>
         Repository.RemoveRangeAsync(entities, cancellationToken);
 
-    public Task<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) =>
+    public ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) =>
         Repository.UpdateAsync(entity, cancellationToken);
 }
 
 class MyPersonRepository : MyRepository<Person>, IPersonRepository
 {
-    public Task<Person?> FindByNameAsync(string name, CancellationToken cancellationToken = default) =>
+    public ValueTask<Person?> FindByNameAsync(string name, CancellationToken cancellationToken = default) =>
         Repository.FindFirstAsync(x => x.FirstName == name, cancellationToken);
 }

--- a/test/Deveel.Repository.Core.XUnit/Unit/ListAsRepositoryTests.cs
+++ b/test/Deveel.Repository.Core.XUnit/Unit/ListAsRepositoryTests.cs
@@ -29,7 +29,7 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
         var newPerson = _fixture.PersonFaker.Generate();
 
         // Act & Assert
-        await Assert.ThrowsAsync<NotSupportedException>(() => readOnly.AddAsync(newPerson, cancellationToken));
+        await Assert.ThrowsAsync<NotSupportedException>(async () => await readOnly.AddAsync(newPerson, cancellationToken));
     }
 
     [Fact]
@@ -49,39 +49,6 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
     }
 
     [Fact]
-    public async Task Should_AssignNewId_When_AddingPersonWithExistingId()
-    {
-        // Arrange
-        var cancellationToken = TestContext.Current.CancellationToken;
-        var initialCount = _people.Count;
-        var person = _fixture.PersonFaker.Generate();
-        var originalId = person.Id;
-
-        // Act
-        await _repository.AddAsync(person, cancellationToken);
-
-        // Assert
-        Assert.Equal(initialCount + 1, _repository.CountAll());
-        Assert.NotEqual(originalId, person.Id);
-    }
-
-    [Fact]
-    public async Task Should_IncrementCountByRange_When_AddingMultiplePersons()
-    {
-        // Arrange
-        var cancellationToken = TestContext.Current.CancellationToken;
-        var initialCount = _people.Count;
-        var newPeople = _fixture.PersonFaker.Generate(10);
-
-        // Act
-        await _repository.AddRangeAsync(newPeople, cancellationToken);
-
-        // Assert
-        Assert.Equal(initialCount + 10, _repository.CountAll());
-        Assert.All(newPeople, p => Assert.NotNull(p.Id));
-    }
-
-    [Fact]
     public async Task Should_ThrowNotSupportedException_When_AddingRangeToReadOnlyRepository()
     {
         // Arrange
@@ -90,7 +57,7 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
         var newPeople = _fixture.PersonFaker.Generate(10);
 
         // Act & Assert
-        await Assert.ThrowsAsync<NotSupportedException>(() => readOnly.AddRangeAsync(newPeople, cancellationToken));
+        await Assert.ThrowsAsync<NotSupportedException>(async () => await readOnly.AddRangeAsync(newPeople, cancellationToken));
     }
 
     #endregion
@@ -170,7 +137,7 @@ public class ListAsRepositoryTests : IClassFixture<PersonFixture>
         var target = RandomPerson();
 
         // Act & Assert
-        await Assert.ThrowsAsync<NotSupportedException>(() => readOnly.RemoveAsync(target, cancellationToken));
+        await Assert.ThrowsAsync<NotSupportedException>(async () => await readOnly.RemoveAsync(target, cancellationToken));
     }
 
     #endregion

--- a/test/Deveel.Repository.DynamicLinq.XUnit/Unit/FilterableRepositoryTests.cs
+++ b/test/Deveel.Repository.DynamicLinq.XUnit/Unit/FilterableRepositoryTests.cs
@@ -56,7 +56,7 @@ public class FilterableRepositoryTests {
     public async Task Should_ThrowInvalidOperationException_When_CountExpressionInvalid() {
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _repository.CountAsync("x.FirstName", TestContext.Current.CancellationToken));
+            async () => await _repository.CountAsync("x.FirstName", TestContext.Current.CancellationToken));
     }
 
     #endregion
@@ -95,7 +95,7 @@ public class FilterableRepositoryTests {
     public async Task Should_ThrowInvalidOperationException_When_ExistsExpressionInvalid() {
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _repository.ExistsAsync("x.FirstName", TestContext.Current.CancellationToken));
+            async () => await _repository.ExistsAsync("x.FirstName", TestContext.Current.CancellationToken));
     }
 
     #endregion
@@ -134,7 +134,7 @@ public class FilterableRepositoryTests {
     public async Task Should_ThrowInvalidOperationException_When_FindFirstExpressionInvalid() {
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _repository.FindFirstAsync<Person>("x.FirstName", TestContext.Current.CancellationToken));
+            async () => await _repository.FindFirstAsync<Person>("x.FirstName", TestContext.Current.CancellationToken));
     }
 
     #endregion
@@ -173,7 +173,7 @@ public class FilterableRepositoryTests {
     public async Task Should_ThrowInvalidOperationException_When_FindAllExpressionInvalid() {
         // Act & Assert
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => _repository.FindAllAsync("x.FirstName", TestContext.Current.CancellationToken));
+            async () => await _repository.FindAllAsync("x.FirstName", TestContext.Current.CancellationToken));
     }
 
     #endregion

--- a/test/Deveel.Repository.EntityFramework.XUnit/Fixtures/Entities/DbPersonRepository.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Fixtures/Entities/DbPersonRepository.cs
@@ -9,7 +9,7 @@ namespace Deveel.Data.Entities {
 
 		public override IQueryable<DbPerson> AsQueryable() => base.Entities.Include(x => x.Relationships);
 
-		protected override async Task<DbPerson> OnEntityFoundByKeyAsync(Guid key, DbPerson entity, CancellationToken cancellationToken = default) {
+		protected override async ValueTask<DbPerson> OnEntityFoundByKeyAsync(Guid key, DbPerson entity, CancellationToken cancellationToken = default) {
 			await Context.Entry(entity).Collection(x => x.Relationships).LoadAsync(cancellationToken);
 
 			return entity;

--- a/test/Deveel.Repository.InMemory.XUnit/Integration/InMemoryRepositoryConcurrencyTests.cs
+++ b/test/Deveel.Repository.InMemory.XUnit/Integration/InMemoryRepositoryConcurrencyTests.cs
@@ -49,7 +49,7 @@ public class InMemoryRepositoryConcurrencyTests {
         var people = PersonFaker.Generate(ThreadCount);
 
         // Act — fire all AddAsync calls simultaneously
-        var tasks = people.Select(p => repository.AddAsync(p, cancellationToken));
+        var tasks = people.Select(p => repository.AddAsync(p, cancellationToken).AsTask());
         await Task.WhenAll(tasks);
 
         // Assert — every entity must be retrievable; no writes may have been lost
@@ -195,7 +195,7 @@ public class InMemoryRepositoryConcurrencyTests {
             await repository.AddAsync(p, cancellationToken);
 
         // Act — every task removes its own distinct entity
-        var tasks = people.Select(p => repository.RemoveAsync(p, cancellationToken));
+        var tasks = people.Select(p => repository.RemoveAsync(p, cancellationToken).AsTask());
         var results = await Task.WhenAll(tasks);
 
         // Assert — every removal must have returned true and the store must be empty
@@ -305,7 +305,7 @@ public class InMemoryRepositoryConcurrencyTests {
         var extra = PersonFaker.Generate(extraCount);
 
         // Act — take snapshot while writers are running
-        var writeTask = Task.WhenAll(extra.Select(p => repository.AddAsync(p, cancellationToken)));
+        var writeTask = Task.WhenAll(extra.Select(p => repository.AddAsync(p, cancellationToken).AsTask()));
         var snapshot = repository.Entities; // taken while writes may still be in-flight
 
         await writeTask;

--- a/test/Deveel.Repository.Management.Testing.TUnit/Suites/EntityManagerTestSuite_2.cs
+++ b/test/Deveel.Repository.Management.Testing.TUnit/Suites/EntityManagerTestSuite_2.cs
@@ -251,8 +251,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson> : IAsyncInitiali
 
 		var found = await Manager.FindAsync(person.Id!);
 
-		await Assert.That(found).IsNotNull();
-		await Assert.That(found!.Id).IsEqualTo(person.Id);
+		await Assert.That(found.IsSuccess()).IsTrue();
+		await Assert.That(found.Value!.Id).IsEqualTo(person.Id);
 	}
 
 	[Test]
@@ -263,7 +263,7 @@ public abstract class EntityManagerTestSuite<TManager, TPerson> : IAsyncInitiali
 
 		var found = await Manager.FindAsync(personId);
 
-		await Assert.That(found).IsNull();
+		await Assert.That(found.IsError()).IsTrue();
 	}
 
 	[Test]

--- a/test/Deveel.Repository.Management.Testing.TUnit/Suites/EntityManagerTestSuite_2.cs
+++ b/test/Deveel.Repository.Management.Testing.TUnit/Suites/EntityManagerTestSuite_2.cs
@@ -275,8 +275,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson> : IAsyncInitiali
 
 		var found = await Manager.FindFirstAsync(x => x.FirstName.StartsWith("A"));
 
-		await Assert.That(found).IsNotNull();
-		await Assert.That(found!.Id).IsEqualTo(person!.Id);
+		await Assert.That(found.IsSuccess()).IsTrue();
+		await Assert.That(found.Value!.Id).IsEqualTo(person!.Id);
 	}
 
 	[Test]

--- a/test/Deveel.Repository.Management.Testing.TUnit/Suites/EntityManagerTestSuite_3.cs
+++ b/test/Deveel.Repository.Management.Testing.TUnit/Suites/EntityManagerTestSuite_3.cs
@@ -303,8 +303,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncIn
 
 		var found = await Manager.FindFirstAsync(x => x.FirstName.StartsWith("A"));
 
-		await Assert.That(found).IsNotNull();
-		await Assert.That(found!.Id).IsEqualTo(person!.Id);
+		await Assert.That(found.IsSuccess()).IsTrue();
+		await Assert.That(found.Value!.Id).IsEqualTo(person!.Id);
 	}
 
 	[Test]
@@ -316,8 +316,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncIn
 
 		var found = await Manager.FindFirstAsync("FirstName.StartsWith(\"A\")");
 
-		await Assert.That(found).IsNotNull();
-		await Assert.That(found!.Id).IsEqualTo(person!.Id);
+		await Assert.That(found.IsSuccess()).IsTrue();
+		await Assert.That(found.Value!.Id).IsEqualTo(person!.Id);
 	}
 
 	[Test]
@@ -329,8 +329,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncIn
 
 		var found = await Manager.FindFirstAsync();
 
-		await Assert.That(found).IsNotNull();
-		await Assert.That(found!.Id).IsEqualTo(person!.Id);
+		await Assert.That(found.IsSuccess()).IsTrue();
+		await Assert.That(found.Value!.Id).IsEqualTo(person!.Id);
 	}
 
 	[Test]

--- a/test/Deveel.Repository.Management.Testing.TUnit/Suites/EntityManagerTestSuite_3.cs
+++ b/test/Deveel.Repository.Management.Testing.TUnit/Suites/EntityManagerTestSuite_3.cs
@@ -279,8 +279,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncIn
 
 		var found = await Manager.FindAsync(person.Id!);
 
-		await Assert.That(found).IsNotNull();
-		await Assert.That(found!.Id).IsEqualTo(person.Id);
+		await Assert.That(found.IsSuccess()).IsTrue();
+		await Assert.That(found.Value!.Id).IsEqualTo(person.Id);
 	}
 
 	[Test]
@@ -291,7 +291,7 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncIn
 
 		var found = await Manager.FindAsync(personId);
 
-		await Assert.That(found).IsNull();
+		await Assert.That(found.IsError()).IsTrue();
 	}
 
 	[Test]

--- a/test/Deveel.Repository.Management.Testing/Suites/EntityManagerTestSuite_2.cs
+++ b/test/Deveel.Repository.Management.Testing/Suites/EntityManagerTestSuite_2.cs
@@ -380,8 +380,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson> : IAsyncLifetime
 		var found = await Manager.FindFirstAsync(x => x.FirstName.StartsWith("A"));
 
 		// Assert
-		Assert.NotNull(found);
-		Assert.Equal(person.Id, found.Id);
+		Assert.True(found.IsSuccess());
+		Assert.Equal(person.Id, found.Value!.Id);
 	}
 
 	[Fact]
@@ -401,8 +401,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson> : IAsyncLifetime
 		var found = await Manager.FindFirstAsync("FirstName.StartsWith(\"A\")");
 
 		// Assert
-		Assert.NotNull(found);
-		Assert.Equal(person.Id, found.Id);
+		Assert.True(found.IsSuccess());
+		Assert.Equal(person.Id, found.Value!.Id);
 	}
 
 	[Fact]
@@ -421,8 +421,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson> : IAsyncLifetime
 		var found = await Manager.FindFirstAsync();
 
 		// Assert
-		Assert.NotNull(found);
-		Assert.Equal(person.Id, found.Id);
+		Assert.True(found.IsSuccess());
+		Assert.Equal(person.Id, found.Value!.Id);
 	}
 
 	[Fact]

--- a/test/Deveel.Repository.Management.Testing/Suites/EntityManagerTestSuite_2.cs
+++ b/test/Deveel.Repository.Management.Testing/Suites/EntityManagerTestSuite_2.cs
@@ -343,7 +343,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson> : IAsyncLifetime
 
 		// Assert
 		Assert.NotNull(found);
-		Assert.Equal(person.Id, found.Id);
+		Assert.True(found.IsSuccess());
+		Assert.Equal(person.Id, found.Value!.Id);
 	}
 
 	[Fact]
@@ -358,7 +359,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson> : IAsyncLifetime
 		var found = await Manager.FindAsync(personId);
 
 		// Assert
-		Assert.Null(found);
+		Assert.NotNull(found);
+		Assert.True(found.IsError());
 	}
 
 	[Fact]

--- a/test/Deveel.Repository.Management.Testing/Suites/EntityManagerTestSuite_3.cs
+++ b/test/Deveel.Repository.Management.Testing/Suites/EntityManagerTestSuite_3.cs
@@ -346,7 +346,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncLi
 
 		// Assert
 		Assert.NotNull(found);
-		Assert.Equal(person.Id, found.Id);
+		Assert.True(found.IsSuccess());
+		Assert.Equal(person.Id, found.Value!.Id);
 	}
 
 	[Fact]
@@ -361,7 +362,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncLi
 		var found = await Manager.FindAsync(personId);
 
 		// Assert
-		Assert.Null(found);
+		Assert.NotNull(found);
+		Assert.True(found.IsError());
 	}
 
 	[Fact]

--- a/test/Deveel.Repository.Management.Testing/Suites/EntityManagerTestSuite_3.cs
+++ b/test/Deveel.Repository.Management.Testing/Suites/EntityManagerTestSuite_3.cs
@@ -383,8 +383,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncLi
 		var found = await Manager.FindFirstAsync(x => x.FirstName.StartsWith("A"));
 
 		// Assert
-		Assert.NotNull(found);
-		Assert.Contains(found.Id, matchingIds);
+		Assert.True(found.IsSuccess());
+		Assert.Contains(found.Value!.Id, matchingIds);
 	}
 
 	[Fact]
@@ -404,8 +404,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncLi
 		var found = await Manager.FindFirstAsync("FirstName.StartsWith(\"A\")");
 
 		// Assert
-		Assert.NotNull(found);
-		Assert.Contains(found.Id, matchingIds);
+		Assert.True(found.IsSuccess());
+		Assert.Contains(found.Value!.Id, matchingIds);
 	}
 
 	[Fact]
@@ -424,8 +424,8 @@ public abstract class EntityManagerTestSuite<TManager, TPerson, TKey> : IAsyncLi
 		var found = await Manager.FindFirstAsync();
 
 		// Assert
-		Assert.NotNull(found);
-		Assert.Contains(found.Id, allIds);
+		Assert.True(found.IsSuccess());
+		Assert.Contains(found.Value!.Id, allIds);
 	}
 
 	[Fact]

--- a/test/Deveel.Repository.Manager.EasyCaching.XUnit/Fixtures/PersonManager.cs
+++ b/test/Deveel.Repository.Manager.EasyCaching.XUnit/Fixtures/PersonManager.cs
@@ -17,7 +17,10 @@ namespace Deveel.Data {
 		public async Task<Person?> FindByEmailAsync(string email, CancellationToken? cancellationToken = null) {
 			var token = GetCancellationToken(cancellationToken);
 
-			return await GetOrSetAsync($"person:{email}", () => FindFirstAsync(x => x.Email == email, token), token);
+			return await GetOrSetAsync($"person:{email}", async () => {
+				var result = await FindFirstAsync(x => x.Email == email, token);
+				return result.IsSuccess() ? result.Value : null;
+			}, token);
 		}
 	}
 }

--- a/test/Deveel.Repository.Manager.XUnit/Fixtures/MyPersonManager.cs
+++ b/test/Deveel.Repository.Manager.XUnit/Fixtures/MyPersonManager.cs
@@ -15,7 +15,8 @@ namespace Deveel.Data {
 		}
 
 		public async Task<Person?> FindByEmailAsync(string email, CancellationToken? cancellationToken = null) {
-			return await FindFirstAsync(x => x.Email == email, cancellationToken);
+			var result = await FindFirstAsync(x => x.Email == email, cancellationToken);
+			return result.IsSuccess() ? result.Value : null;
 		}
 	}
 }

--- a/test/Deveel.Repository.Testing/Suites/RepositoryTestSuite_T2.cs
+++ b/test/Deveel.Repository.Testing/Suites/RepositoryTestSuite_T2.cs
@@ -188,7 +188,7 @@ public abstract class RepositoryTestSuite<TPerson, TRelationship> : IAsyncLifeti
 	[Trait("Feature", "Repository")]
 	public async Task Should_ThrowArgumentNullException_When_AddNullPerson() {
 		// Act & Assert
-		await Assert.ThrowsAsync<ArgumentNullException>(() => Repository.AddAsync(null!, TestContext.Current.CancellationToken));
+		await Assert.ThrowsAsync<ArgumentNullException>(async () => await Repository.AddAsync(null!, TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -197,7 +197,7 @@ public abstract class RepositoryTestSuite<TPerson, TRelationship> : IAsyncLifeti
 	[Trait("Feature", "Repository")]
 	public async Task Should_ThrowArgumentNullException_When_AddRangeNullList() {
 		// Act & Assert
-		await Assert.ThrowsAsync<ArgumentNullException>(() => Repository.AddRangeAsync(null!, TestContext.Current.CancellationToken));
+		await Assert.ThrowsAsync<ArgumentNullException>(async () => await Repository.AddRangeAsync(null!, TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -206,7 +206,7 @@ public abstract class RepositoryTestSuite<TPerson, TRelationship> : IAsyncLifeti
 	[Trait("Feature", "Repository")]
 	public async Task Should_ThrowArgumentNullException_When_RemoveNullPerson() {
 		// Act & Assert
-		await Assert.ThrowsAsync<ArgumentNullException>(() => Repository.RemoveAsync(null!, TestContext.Current.CancellationToken));
+		await Assert.ThrowsAsync<ArgumentNullException>(async () => await Repository.RemoveAsync(null!, TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -215,7 +215,7 @@ public abstract class RepositoryTestSuite<TPerson, TRelationship> : IAsyncLifeti
 	[Trait("Feature", "Repository")]
 	public async Task Should_ThrowArgumentNullException_When_RemoveRangeNullList() {
 		// Act & Assert
-		await Assert.ThrowsAsync<ArgumentNullException>(() => Repository.RemoveRangeAsync(null!, TestContext.Current.CancellationToken));
+		await Assert.ThrowsAsync<ArgumentNullException>(async () => await Repository.RemoveRangeAsync(null!, TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -224,7 +224,7 @@ public abstract class RepositoryTestSuite<TPerson, TRelationship> : IAsyncLifeti
 	[Trait("Feature", "Repository")]
 	public async Task Should_ThrowArgumentNullException_When_FindWithNullKey() {
 		// Act & Assert
-		await Assert.ThrowsAsync<ArgumentNullException>(() => Repository.FindAsync(default!, TestContext.Current.CancellationToken));
+		await Assert.ThrowsAsync<ArgumentNullException>(async () => await Repository.FindAsync(default!, TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -237,7 +237,7 @@ public abstract class RepositoryTestSuite<TPerson, TRelationship> : IAsyncLifeti
 		await Repository.AddAsync(person, TestContext.Current.CancellationToken);
 
 		// Act & Assert
-		await Assert.ThrowsAsync<RepositoryException>(() => Repository.AddAsync(person, TestContext.Current.CancellationToken));
+		await Assert.ThrowsAsync<RepositoryException>(async () => await Repository.AddAsync(person, TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -368,7 +368,7 @@ public abstract class RepositoryTestSuite<TPerson, TRelationship> : IAsyncLifeti
 		people.Add(entity);
 
 		// Act & Assert
-		await Assert.ThrowsAsync<RepositoryException>(() => Repository.RemoveRangeAsync(people, TestContext.Current.CancellationToken));
+		await Assert.ThrowsAsync<RepositoryException>(async () => await Repository.RemoveRangeAsync(people, TestContext.Current.CancellationToken));
 
 		var result = await Repository.FindAllAsync(TestContext.Current.CancellationToken);
 		Assert.NotNull(result);
@@ -728,7 +728,7 @@ public abstract class RepositoryTestSuite<TPerson, TRelationship> : IAsyncLifeti
 
 		// Act & Assert
 		await Assert.ThrowsAsync<RepositoryException>(
-			() => Repository.FindAllAsync(QueryFilter.Where<MailAddress>(m => m.Address == null), TestContext.Current.CancellationToken));
+			async () => await Repository.FindAllAsync(QueryFilter.Where<MailAddress>(m => m.Address == null), TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -1023,7 +1023,7 @@ public abstract class RepositoryTestSuite<TPerson, TRelationship> : IAsyncLifeti
 	[Trait("Feature", "Repository")]
 	public async Task Should_ThrowArgumentNullException_When_UpdateNullPerson() {
 		// Act & Assert
-		await Assert.ThrowsAsync<ArgumentNullException>(() => Repository.UpdateAsync(null!, TestContext.Current.CancellationToken));
+		await Assert.ThrowsAsync<ArgumentNullException>(async () => await Repository.UpdateAsync(null!, TestContext.Current.CancellationToken));
 	}
 
 	[Fact]
@@ -1037,7 +1037,7 @@ public abstract class RepositoryTestSuite<TPerson, TRelationship> : IAsyncLifeti
 		cts.Cancel();
 
 		// Act & Assert
-		await Assert.ThrowsAsync<OperationCanceledException>(() => Repository.UpdateAsync(person, cts.Token));
+		await Assert.ThrowsAsync<OperationCanceledException>(async () => await Repository.UpdateAsync(person, cts.Token));
 	}
 
 	[Fact]

--- a/test/Deveel.Repository.Testing/Suites/RepositoryTestSuite_T3.cs
+++ b/test/Deveel.Repository.Testing/Suites/RepositoryTestSuite_T3.cs
@@ -311,7 +311,7 @@ public abstract class RepositoryTestSuite<TPerson, TKey, TRelationship> : IAsync
 		people.Add(entity);
 
 		// Act & Assert
-		await Assert.ThrowsAsync<RepositoryException>(() => Repository.RemoveRangeAsync(people, TestContext.Current.CancellationToken));
+		await Assert.ThrowsAsync<RepositoryException>(async () => await Repository.RemoveRangeAsync(people, TestContext.Current.CancellationToken));
 
 		var result = await Repository.FindAllAsync();
 		Assert.NotNull(result);
@@ -674,7 +674,7 @@ public abstract class RepositoryTestSuite<TPerson, TKey, TRelationship> : IAsync
 
 		// Act & Assert
 		await Assert.ThrowsAsync<RepositoryException>(
-			() => Repository.FindAllAsync(QueryFilter.Where<MailAddress>(m => m.Address == null), 
+			async () => await Repository.FindAllAsync(QueryFilter.Where<MailAddress>(m => m.Address == null), 
 				TestContext.Current.CancellationToken));
 	}
 


### PR DESCRIPTION
This pull request primarily updates the repository interfaces and related implementations to use `ValueTask` instead of `Task` for asynchronous methods, which can improve performance in certain scenarios. Additionally, it updates guard clauses to use standard .NET exceptions and makes minor code cleanup changes.

**Async API modernization:**

* All asynchronous methods in the main repository interfaces (`IRepository`, `IFilterableRepository`, `IPageableRepository`, `ITrackingRepository`, `IControllableRepository`, and `IRepositoryController`) have been updated to return `ValueTask` instead of `Task`, affecting methods such as `AddAsync`, `FindAsync`, `ExistsAsync`, `CreateAsync`, `DropAsync`, and others. This change also propagates to their implementations and usages. [[1]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dL56-R56) [[2]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dL80-R80) [[3]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dL98-R98) [[4]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dL115-R115) [[5]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dL133-R133) [[6]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dL148-R148) [[7]](diffhunk://#diff-ab569d70e11836703180957eed3e774cb333d0a6a927f1b3c9c1558148e09ef5L31-R31) [[8]](diffhunk://#diff-ab569d70e11836703180957eed3e774cb333d0a6a927f1b3c9c1558148e09ef5L43-R43) [[9]](diffhunk://#diff-ab569d70e11836703180957eed3e774cb333d0a6a927f1b3c9c1558148e09ef5L55-R55) [[10]](diffhunk://#diff-a941b05ff64859905963402b2720f5ecbb77027bd4d5b6035aa99eab8d8efb55L45-R45) [[11]](diffhunk://#diff-a941b05ff64859905963402b2720f5ecbb77027bd4d5b6035aa99eab8d8efb55L67-R67) [[12]](diffhunk://#diff-a941b05ff64859905963402b2720f5ecbb77027bd4d5b6035aa99eab8d8efb55L90-R90) [[13]](diffhunk://#diff-a941b05ff64859905963402b2720f5ecbb77027bd4d5b6035aa99eab8d8efb55L106-R106) [[14]](diffhunk://#diff-245a280ebbcfc5c0ac9713837aa5b09834adb7ce2db5f6d61104ea34bd0362f3L48-R48) [[15]](diffhunk://#diff-f26951bad2701954b850e4f0cd91fb10b18697bb2e296b253c679fd975d1dd2aL54-R54) [[16]](diffhunk://#diff-6c9ecdd1defaef7b102e6429b930de168af259dd2feca40ce36a2943c3e202bfL34-R34) [[17]](diffhunk://#diff-6c9ecdd1defaef7b102e6429b930de168af259dd2feca40ce36a2943c3e202bfL50-R52) [[18]](diffhunk://#diff-6c9ecdd1defaef7b102e6429b930de168af259dd2feca40ce36a2943c3e202bfL65-R67) [[19]](diffhunk://#diff-6c9ecdd1defaef7b102e6429b930de168af259dd2feca40ce36a2943c3e202bfL83-R85) [[20]](diffhunk://#diff-eeb727c10c6a9315601d6cbc11558f41b4c3be385868fcccdc32c626664bb5c8L106-R106) [[21]](diffhunk://#diff-eeb727c10c6a9315601d6cbc11558f41b4c3be385868fcccdc32c626664bb5c8L146-R146) [[22]](diffhunk://#diff-eeb727c10c6a9315601d6cbc11558f41b4c3be385868fcccdc32c626664bb5c8L176-R176) [[23]](diffhunk://#diff-eeb727c10c6a9315601d6cbc11558f41b4c3be385868fcccdc32c626664bb5c8L188-R188) [[24]](diffhunk://#diff-eeb727c10c6a9315601d6cbc11558f41b4c3be385868fcccdc32c626664bb5c8L201-R201) [[25]](diffhunk://#diff-eeb727c10c6a9315601d6cbc11558f41b4c3be385868fcccdc32c626664bb5c8L212-R212)

**Benchmark updates:**

* Benchmark methods in `RepositoryCoreBenchmarksBase.cs` have been updated to use `async`/`await` syntax, aligning with the interface changes and ensuring accurate benchmarking of asynchronous workflows.

**Guard clause modernization:**

* Replaces usage of `CommunityToolkit.Diagnostics.Guard` with standard .NET guard clauses such as `ArgumentNullException.ThrowIfNull` and `ArgumentOutOfRangeException.ThrowIfLessThanOrEqual` in `CombinedQueryFilter`. [[1]](diffhunk://#diff-6aa5b5b1115f72fc56a046da2b27ebab52117ae21a46579f11467e70315bf67aL18-L19) [[2]](diffhunk://#diff-6aa5b5b1115f72fc56a046da2b27ebab52117ae21a46579f11467e70315bf67aL41-R40) [[3]](diffhunk://#diff-6aa5b5b1115f72fc56a046da2b27ebab52117ae21a46579f11467e70315bf67aL66-R64)

These changes modernize the asynchronous programming model and improve code consistency and maintainability across the repository codebase.