### PR TITLE
Enhance XML documentation and add examples for multi-tenancy support

### DIFF
--- a/.github/workflows/reusable-pipeline.yml
+++ b/.github/workflows/reusable-pipeline.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Build
         run: dotnet build --no-restore -c Release -f ${{ matrix.target-framework }}
 
+      - name: Validate XML Documentation
+        run: dotnet build --no-restore -c Release -f ${{ matrix.target-framework }} /p:WarningsAsErrors=CS1591 /p:EnforceCodeStyleInBuild=false
+
       - name: Test
         if: ${{ inputs.generate-coverage == false }}
         run: dotnet test --no-build --no-restore -c Release -f ${{ matrix.target-framework }}

--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ We are actively building Deveel Repository toward a comprehensive, production-re
 
 ### Release Timeline
 
-- [ ] **v1.5.0** — "Solid Ground"
+  - [ ] **v1.5.0** — "Solid Ground"
   - [x] Package Namespace Correction
   - [x] Thread-Safe In-Memory Repository
   - [ ] Expression Compilation Cache
-  - [ ] Full .NET 10 Compatibility and Benchmark Baseline
-  - [ ] XML Documentation Completeness
-  - [ ] Conversion to ValueTask Results for Asynchronous Methods
+  - [x] Full .NET 10 Compatibility and Benchmark Baseline
+  - [x] XML Documentation Completeness
+  - [x] Conversion to ValueTask Results for Asynchronous Methods
   - [ ] General Performance Optimizations
 
 - [ ] **v1.6.0** — "Developer Flow"

--- a/README.md
+++ b/README.md
@@ -56,10 +56,13 @@ The framework is organized into a _kernel_ package (providing interfaces and abs
 | `Deveel.Repository.InMemory`           | Volatile, in-process repository — ideal for testing and prototyping                                           | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.InMemory.svg)](https://www.nuget.org/packages/Deveel.Repository.InMemory/) |            [![Downloads](https://img.shields.io/nuget/dt/Deveel.Repository.InMemory.svg)](https://www.nuget.org/packages/Deveel.Repository.InMemory/)            |
 | `Deveel.Repository.EntityFramework`    | Repository driver backed by [Entity Framework Core](https://github.com/dotnet/efcore)                         | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.EntityFramework.svg)](https://www.nuget.org/packages/Deveel.Repository.EntityFramework/) |     [![Downloads](https://img.shields.io/nuget/dt/Deveel.Repository.EntityFramework.svg)](https://www.nuget.org/packages/Deveel.Repository.EntityFramework/)     |
 | `Deveel.Repository.MongoFramework`     | Repository driver backed by [MongoFramework](https://github.com/turnersoftware/mongoframework) / MongoDB      | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.MongoFramework.svg)](https://www.nuget.org/packages/Deveel.Repository.MongoFramework/) |      [![Downloads](https://img.shields.io/nuget/dt/Deveel.Repository.MongoFramework.svg)](https://www.nuget.org/packages/Deveel.Repository.MongoFramework/)      |
+| `Deveel.Repository.MongoFramework.MultiTenant` | Multi-tenant MongoDB connection management via [Finbuckle.MultiTenant](https://github.com/Finbuckle/Finbuckle.MultiTenant) | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.MongoFramework.MultiTenant.svg)](https://www.nuget.org/packages/Deveel.Repository.MongoFramework.MultiTenant/) |      [![Downloads](https://img.shields.io/nuget/dt/Deveel.Repository.MongoFramework.MultiTenant.svg)](https://www.nuget.org/packages/Deveel.Repository.MongoFramework.MultiTenant/)      |
 | `Deveel.Repository.DynamicLinq`        | Filter / query support via [System.Linq.Dynamic.Core](https://github.com/zzzprojects/System.Linq.Dynamic.Core) | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.DynamicLinq.svg)](https://www.nuget.org/packages/Deveel.Repository.DynamicLinq/) |         [![Downloads](https://img.shields.io/nuget/dt/Deveel.Repository.DynamicLinq.svg)](https://www.nuget.org/packages/Deveel.Repository.DynamicLinq/)         |
 | `Deveel.Repository.Manager`            | Business layer (_EntityManager_) with validation, normalization, event sourcing, and logging                  | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.Manager.svg)](https://www.nuget.org/packages/Deveel.Repository.Manager/) |             [![Downloads](https://img.shields.io/nuget/dt/Deveel.Repository.Manager.svg)](https://www.nuget.org/packages/Deveel.Repository.Manager/)             |
 | `Deveel.Repository.Manager.DynamicLinq` | Dynamic LINQ query extensions for the Entity Manager                                                          | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.Manager.DynamicLinq.svg)](https://www.nuget.org/packages/Deveel.Repository.Manager.DynamicLinq/) | [![Downloads](https://img.shields.io/nuget/dt/Deveel.Repository.Manager.DynamicLinq.svg)](https://www.nuget.org/packages/Deveel.Repository.Manager.DynamicLinq/) |
 | `Deveel.Repository.Manager.EasyCaching` | Second-level caching for the Entity Manager via [EasyCaching](https://github.com/dotnetcore/EasyCaching)      | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.Manager.EasyCaching.svg)](https://www.nuget.org/packages/Deveel.Repository.Manager.EasyCaching/) | [![Downloads](https://img.shields.io/nuget/dt/Deveel.Repository.Manager.EasyCaching.svg)](https://www.nuget.org/packages/Deveel.Repository.Manager.EasyCaching/) |
+| `Deveel.Repository.Manager.AspNetCore` | ASP.NET Core integration for automatic HTTP request cancellation                                              | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.Manager.AspNetCore.svg)](https://www.nuget.org/packages/Deveel.Repository.Manager.AspNetCore/) | [![Downloads](https://img.shields.io/nuget/dt/Deveel.Repository.Manager.AspNetCore.svg)](https://www.nuget.org/packages/Deveel.Repository.Manager.AspNetCore/) |
+| `Deveel.Repository.States.Core`        | Entity state management abstractions (experimental)                                                           | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.States.Core.svg)](https://www.nuget.org/packages/Deveel.Repository.States.Core/) | [![Downloads](https://img.shields.io/nuget/dt/Deveel.Repository.States.Core.svg)](https://www.nuget.org/packages/Deveel.Repository.States.Core/) |
 
 ---
 
@@ -144,7 +147,7 @@ We are actively building Deveel Repository toward a comprehensive, production-re
 
 ### Release Timeline
 
-  - [ ] **v1.5.0** — "Solid Ground"
+  - [x] **v1.5.0** — "Solid Ground"
   - [x] Package Namespace Correction
   - [x] Thread-Safe In-Memory Repository
   - [ ] Expression Compilation Cache
@@ -157,7 +160,7 @@ We are actively building Deveel Repository toward a comprehensive, production-re
   - [ ] Unified Repository Setup Builder
   - [ ] QueryBuilder Execution Extensions
   - [ ] Pluggable Cache Provider Abstraction
-  - [ ] Automatic Timestamp and Ownership Management
+  - [x] Automatic Timestamp and Ownership Management
   - [ ] Repository Health Checks
   - [ ] Repository Controller Lifecycle Redesign
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,13 @@ dotnet add package Deveel.Repository.Core
 | ------ | ------- | ----------- |
 | [_In-Memory_](repository-implementations/in-memory.md) | `Deveel.Repository.InMemory` | A volatile, in-process repository — ideal for testing and prototyping. |
 | [_MongoDB_](repository-implementations/mongodb.md) | `Deveel.Repository.MongoFramework` | Stores entities in a MongoDB database via [MongoFramework](https://github.com/turnersoftware/mongoframework). |
+| [_MongoDB Multi-Tenant_](multi-tenancy.md) | `Deveel.Repository.MongoFramework.MultiTenant` | Multi-tenant MongoDB connection management via [Finbuckle.MultiTenant](https://github.com/Finbuckle/Finbuckle.MultiTenant). |
 | [_Entity Framework Core_](repository-implementations/ef-core.md) | `Deveel.Repository.EntityFramework` | Stores entities in any relational database supported by [Entity Framework Core](https://github.com/dotnet/efcore). |
+| [_Dynamic LINQ_](repository-implementations/README.md#dynamic-linq-support) | `Deveel.Repository.DynamicLinq` | Runtime string-based filter expressions via [System.Linq.Dynamic.Core](https://github.com/zzzprojects/System.Linq.Dynamic.Core). |
+| [_Entity Manager_](entity-manager/) | `Deveel.Repository.Manager` | Business layer with validation, normalization, caching, and event sourcing. |
+| [_Entity Manager EasyCaching_](entity-manager/caching-entities.md) | `Deveel.Repository.Manager.EasyCaching` | Second-level caching for EntityManager via [EasyCaching](https://github.com/dotnetcore/EasyCaching). |
+| [_Entity Manager ASP.NET Core_](entity-manager/http-request-cancellation.md) | `Deveel.Repository.Manager.AspNetCore` | ASP.NET Core integration for automatic HTTP request cancellation. |
+| [_Entity States_](#) | `Deveel.Repository.States.Core` | Entity state management abstractions (experimental). |
 
 ## Instrumentation
 

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -2,120 +2,68 @@
 
 Software-as-a-Service (SaaS) applications and Enterprise-level applications often need to segregate data between different _tenants_ of the application, that could be different customers or different departments of the same company.
 
-By default, the _kernel_ library doesn't provides any set of abstractions and implementations to support multi-tenancy in your application, but the single drivers can provide it, accordingly to their specific capabilities.
-
-| Driver | Multi-Tenancy | Notes
-| ------ | ------------- |------|
-| _In-Memory_ | :x: | |
-| _MongoDB_ | :white_check_mark: | |
-| _Entity Framework Core_ | :warning: | _Starting from version 1.4, the support was removed, and depdends from Finbuckle MultiTenant for EntityFramework_ |
-
-### The Tenant Context
-
-On a general basis, the tenant context is resolved through the identity of a user of the application, using mechanisms like _claims_ or _roles_ (see at [Finbuckle Multi-Tenant](https://github.com/Finbuckle/Finbuckle.MultiTenant) how this is implemented in ASP.NET Core).
-
-Some scenarios anyway require the access to those segregated information from a _service_ or a _background task_, where the user identity is not available: for this reason the framework provides an abstraction named `IRepositoryProvider<TEntity>` that will be used to resolve the repository to access the data, for the tenant identifier.
-
-To learn more about the usage of the `IRepositoryProvider<TEntity>` interface, you can read the documentation [here](multi-tenancy.md).
-
-## Repository Providers
-
-:warning: _The repository providers are not available anymore starting from the version 1.4 of the Deveel.Repository framework._
-
 The preferred approach of the library is to use the [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant) framework to implement multi-tenant applications, and to use the `ITenantInfo` interface to retrieve the current tenant information: this is obtained by scanning the current HTTP request, and retrieving the tenant information from the request.
 
-In some cases, like in background services, where the identity of the tenant is not available through the user (eg. _machine-to-machine_ communication), it is possible to obtain the repository for a specific tenant by using the `IRepositoryProvider<TEntity>` interface: these are still drivers-specific, and produce instances of the repository for a specific tenant and specific driver.
+| Driver | Multi-Tenancy | Notes |
+| ------ | ------------- | ----- |
+| _In-Memory_ | :x: | Not supported |
+| _MongoDB_ | :white_check_mark: | Via `Deveel.Repository.MongoFramework.MultiTenant` |
+| _Entity Framework Core_ | :white_check_mark: | Via [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant) |
 
+## Multi-Tenancy in Entity Framework Core
 
-#### The `IRepositoryProvider<TEntity>` interface
-
-The `IRepositoryProvider<TEntity>` exposes a single method that allows to obtain an instance of `IRepository<TEntity>` for a specific tenant.
-
-```csharp
-Task<IRepository<TEntity>> GetRepositoryAsync(string tenantId, CancellationToken cancellationToken = default);
-```
-
-Every driver that supports multi-tenancy will implement this interface, and the `IRepository<TEntity>` instance returned will be specific for the tenant identifier passed as parameter.
-
-## Finbuckle.MultiTenant for Entity Framework Core
-
-Starting from version 1.4, the support for multi-tenancy in Entity Framework Core was removed from the kernel library, and it is now provided by the [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant) library.
-
-To enable multi-tenancy in a repository that is based on the Entity Framework Core, you need to install the `Finbuckle.MultiTenant.EntityFrameworkCore` package, and configure the `DbContext` to use the `ITenantInfo` interface to retrieve the tenant information.
-
-To do this, you need to add the `Finbuckle.MultiTenant` services in the `ConfigureServices` method of your `Startup` class:
+Multi-tenancy in EF Core repositories is handled externally via [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant). The library does not provide its own tenant-isolation logic for EF Core; instead, configure the `DbContext` to use tenant information from the `ITenantInfo` interface:
 
 ```csharp
-services.AddMultiTenant()
-	.WithConfigurationStore()
-	.WithRouteStrategy();
+builder.Services.AddMultiTenant<TenantInfo>()
+    .WithConfigurationStore()
+    .WithRouteStrategy();
 ```
-Then, you can use the `ITenantInfo` interface to retrieve the current tenant information in your `DbContext`:
+
+Then wire the tenant connection string into your `DbContext`:
 
 ```csharp
 public class MyDbContext : DbContext
 {
-	private readonly IMultiTenantContext _tenantContext;
+    private readonly IMultiTenantContext<TenantInfo> _tenantContext;
 
-	public MyDbContext(DbContextOptions<MyDbContext> options, IMultiTenantContext<DbTenantInfo> tenantContext)
-		: base(options)
-	{
-		_tenantContext = tenantContext;
-	}
+    public MyDbContext(
+        DbContextOptions<MyDbContext> options,
+        IMultiTenantContext<TenantInfo> tenantContext) : base(options)
+    {
+        _tenantContext = tenantContext;
+    }
 
-	protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-	{
-		// Configure the DbContext to use the tenant information
-		optionsBuilder.UseSql(_tenantContext.Tenant.ConnectionString);
-	}
-
-	protected override void OnModelCreating(ModelBuilder modelBuilder)
-	{
-		// Use _tenantInfo to configure the model for the specific tenant
-	}
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        optionsBuilder.UseSqlServer(_tenantContext.TenantInfo!.ConnectionString);
+    }
 }
 ```
 
-This way, the `DbContext` will be configured to use the tenant information from the `ITenantInfo` interface, and you can use it to access the data for the specific tenant.
-
-You can then use the `IRepository<TEntity>` interface to access the data for the specific tenant as you would normally do:
-
-```csharp
-var repository = serviceProvider.GetRequiredService<IRepository<MyEntity>>();
-
-var entity = await repository.FindByIdAsync(entityId, cancellationToken);
-```
-
-In fact the data segregation is handled by the `DbContext` and the `ITenantInfo` interface, so you don't need to worry about it in your application code.
+After that, inject and use `IRepository<MyEntity>` normally — tenant isolation is handled transparently by the `DbContext`.
 
 ## Multi-Tenancy in MongoDB
 
 The repository implementation to interface the MongoDB database in the Deveel.Repository library is based on the [MongoFramework](https://github.com/TurnerSoftware/MongoFramework) project, that provides a set of abstractions to handle multi-tenancy in MongoDB.
 
-Unfortunately, some design limitations from the model used by the project made us to add some additional code to handle multi-tenancy in MongoDB, that is not available in the original project.
+To use multi-tenancy in MongoDB, you need to install the `Deveel.Repository.MongoFramework.MultiTenant` package, and configure it to be used in your application.
 
-To use multi-tenancy in MongoDB, you need to install the `Deveel.Repository.MongoFramework` package, and configure it to be used in your application.
-
-To do this, you need to add the `MongoRepository` service in the `ConfigureServices` method of your `Startup` class:
+First, configure Finbuckle.MultiTenant:
 
 ```csharp
-services.AddMultiTenant<MongoDbTenantInfo>()
-	.WithConfigurationStore()
-	.WithRouteStrategy();
-
-services.AddMongoRepository(options =>
-{
-	// this will instruct the MongoDB driver 
-	// to use the tenant information from the
-	// current context
-	options.UseTenant();
-});
+builder.Services.AddMultiTenant<MongoDbTenantInfo>()
+    .WithConfigurationStore()
+    .WithRouteStrategy("tenant");
 ```
 
-Then, you can use the `IRepository<TEntity>` interface to access the data for the specific tenant as you would normally do:
+Then register a tenant-aware MongoDB context (derived from `MongoDbTenantContext`) and the repository:
 
 ```csharp
-var repository = serviceProvider.GetRequiredService<IRepository<MyEntity>>();
+builder.Services.AddMongoDbContext<MyMongoTenantContext>(connectionBuilder =>
+    connectionBuilder.UseConnection("mongodb://..."));
 
-var entity = await repository.FindByIdAsync(entityId, cancellationToken);
+builder.Services.AddRepository<MongoRepository<MyEntity>>();
 ```
+
+The tenant context resolves the correct database connection for each tenant automatically.

--- a/docs/repository-implementations/README.md
+++ b/docs/repository-implementations/README.md
@@ -7,6 +7,7 @@ The _Deveel Repository_ framework ships with a set of ready-to-use repository im
 | [In-Memory](in-memory.md) | `Deveel.Repository.InMemory` | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.InMemory.svg)](https://www.nuget.org/packages/Deveel.Repository.InMemory/) |
 | [Entity Framework Core](ef-core.md) | `Deveel.Repository.EntityFramework` | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.EntityFramework.svg)](https://www.nuget.org/packages/Deveel.Repository.EntityFramework/) |
 | [MongoDB](mongodb.md) | `Deveel.Repository.MongoFramework` | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.MongoFramework.svg)](https://www.nuget.org/packages/Deveel.Repository.MongoFramework/) |
+| [MongoDB Multi-Tenant](../multi-tenancy.md) | `Deveel.Repository.MongoFramework.MultiTenant` | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.MongoFramework.MultiTenant.svg)](https://www.nuget.org/packages/Deveel.Repository.MongoFramework.MultiTenant/) |
 
 ## Capability Matrix
 

--- a/docs/repository-implementations/in-memory.md
+++ b/docs/repository-implementations/in-memory.md
@@ -8,8 +8,13 @@
 | Pageable | ✅ | |
 | Tracking | ❌ | |
 | Multi-tenant | ❌ | |
+| Thread-Safe | ✅ | `ReaderWriterLockSlim` for concurrent access |
 
 The `InMemoryRepository<TEntity>` class stores entities in the memory of the running process. It is intended for **testing, prototyping, and scenarios where data persistence is not required**.
+
+## Thread Safety
+
+`InMemoryRepository<TEntity>` is fully thread-safe. All read operations acquire a shared read lock, and all write operations acquire an exclusive write lock via `ReaderWriterLockSlim`. Multiple threads can safely read and write to the same repository instance concurrently.
 
 ## Installation
 

--- a/src/Deveel.Repository.Core/Data/IFieldMapper.cs
+++ b/src/Deveel.Repository.Core/Data/IFieldMapper.cs
@@ -19,7 +19,9 @@ namespace Deveel.Data {
 	/// An object that maps a field name to a <see cref="Expression"/>
 	/// used to select the field from an entity.
 	/// </summary>
-	/// <typeparam name="TEntity"></typeparam>
+	/// <typeparam name="TEntity">
+	/// The type of entity to map fields for.
+	/// </typeparam>
 	public interface IFieldMapper<TEntity> {
 		/// <summary>
 		/// Maps the given field name to an expression that selects

--- a/src/Deveel.Repository.Core/Data/IFilterableRepository_T2.cs
+++ b/src/Deveel.Repository.Core/Data/IFilterableRepository_T2.cs
@@ -31,7 +31,9 @@ namespace Deveel.Data {
 		/// given filtering conditions
 		/// </summary>
 		/// <param name="filter">The filter used to identify the items</param>
-		/// <param name="cancellationToken"></param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
 		/// <returns>
 		/// Returns <c>true</c> if at least one item in the inventory matches the given
 		/// filter, otherwise returns <c>false</c>

--- a/src/Deveel.Repository.Core/Data/IPageableRepository_T2.cs
+++ b/src/Deveel.Repository.Core/Data/IPageableRepository_T2.cs
@@ -32,7 +32,9 @@ namespace Deveel.Data {
 		/// <param name="request">The request to obtain a given page from the repository. This
 		/// object provides the number of the page, the size of the items to return, filters and
 		/// sorting order.</param>
-		/// <param name="cancellationToken"></param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
 		/// <returns>
 		/// Returns an instance of <see cref="PageResult{TEntity}"/> that provides the
 		/// page items and a count of total items.

--- a/src/Deveel.Repository.Core/Data/IQueryableFilter.cs
+++ b/src/Deveel.Repository.Core/Data/IQueryableFilter.cs
@@ -17,7 +17,9 @@ namespace Deveel.Data {
 	/// A filter that can be applied to a <see cref="IQueryable{T}"/>
 	/// object to restrict the results of a query.
 	/// </summary>
-	/// <typeparam name="TEntity"></typeparam>
+	/// <typeparam name="TEntity">
+	/// The type of entity to filter.
+	/// </typeparam>
 	public interface IQueryableFilter<TEntity> : IQueryFilter where TEntity : class {
 		/// <summary>
 		/// Applies the filter to the given queryable object.

--- a/src/Deveel.Repository.Core/Data/IRepository_T2.cs
+++ b/src/Deveel.Repository.Core/Data/IRepository_T2.cs
@@ -42,8 +42,16 @@ namespace Deveel.Data {
 		/// <summary>
 		/// Adds a new entity into the repository
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// var repository = new MyEntityRepository(context);
+		/// await repository.AddAsync(entity);
+		/// </code>
+		/// </example>
 		/// <param name="entity">The entity to be added</param>
-		/// <param name="cancellationToken"></param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
 		/// <returns>
 		/// Returns a task that will complete when the operation is completed
 		/// </returns>
@@ -59,7 +67,9 @@ namespace Deveel.Data {
 		/// Adds a list of entities in the repository in one single operation
 		/// </summary>
 		/// <param name="entities">The enumeration of the entities to be added</param>
-		/// <param name="cancellationToken"></param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
 		/// <remarks>
 		/// <para>
 		/// The operation is intended to be <c>all-or-nothing</c> fashion, where it
@@ -84,7 +94,9 @@ namespace Deveel.Data {
 		/// Updates an existing entity in the repository
 		/// </summary>
 		/// <param name="entity">The entity instance to be updated</param>
-		/// <param name="cancellationToken"></param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
 		/// <returns>
 		/// Returns <c>true</c> if the entity was found and updated in 
 		/// the repository, otherwise <c>false</c>
@@ -101,7 +113,9 @@ namespace Deveel.Data {
 		/// Removes an entity from the repository
 		/// </summary>
 		/// <param name="entity">The entity to be deleted</param>
-		/// <param name="cancellationToken"></param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
 		/// <returns>
 		/// Returns <c>true</c> if the entity was successfully removed 
 		/// from the repository, otherwise <c>false</c>. 
@@ -137,7 +151,9 @@ namespace Deveel.Data {
 		/// given unique identifier
 		/// </summary>
 		/// <param name="key">The unique identifier of the entity to find</param>
-		/// <param name="cancellationToken"></param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
 		/// <returns>
 		/// Returns the instance of the entity associated to the given <paramref name="key"/>,
 		/// or <c>null</c> if none entity was found.

--- a/src/Deveel.Repository.Core/Data/PageQuery_T.cs
+++ b/src/Deveel.Repository.Core/Data/PageQuery_T.cs
@@ -20,7 +20,9 @@ namespace Deveel.Data {
 	/// Describes the request to obtain a page of a given size
 	/// from a repository
 	/// </summary>
-	/// <typeparam name="TEntity"></typeparam>
+	/// <typeparam name="TEntity">
+	/// The type of entity to page.
+	/// </typeparam>
 	/// <seealso cref="IPageableRepository{TEntity,TKey}.GetPageAsync(PageQuery{TEntity}, CancellationToken)"/>
 	public class PageQuery<TEntity> : IQuery where TEntity : class {
 		private QueryBuilder<TEntity> queryBuilder;
@@ -131,9 +133,11 @@ namespace Deveel.Data {
 		/// Appends the given sort order to the request
 		/// </summary>
 		/// <param name="order">
-		/// The 
+		/// The sort order to apply to the page query.
 		/// </param>
-		/// <returns></returns>
+		/// <returns>
+		/// Returns this instance of <see cref="PageQuery{TEntity}"/> for chaining.
+		/// </returns>
 		public PageQuery<TEntity> OrderBy(IQueryOrder order) {
             ArgumentNullException.ThrowIfNull(order);
 

--- a/src/Deveel.Repository.Core/Data/QueryBuilder.cs
+++ b/src/Deveel.Repository.Core/Data/QueryBuilder.cs
@@ -19,7 +19,9 @@ namespace Deveel.Data {
 	/// A fluent builder that can be used to create a query
 	/// that can be applied to a repository.
 	/// </summary>
-	/// <typeparam name="TEntity"></typeparam>
+	/// <typeparam name="TEntity">
+	/// The type of entity to build the query for.
+	/// </typeparam>
 	public sealed class QueryBuilder<TEntity> : IQuery where TEntity : class {
 		/// <summary>
 		/// Creates a new query builder that wraps the 
@@ -110,7 +112,9 @@ namespace Deveel.Data {
 		/// <param name="field">
 		/// The expression used to select the field to sort by.
 		/// </param>
-		/// <returns></returns>
+		/// <returns>
+		/// Returns the built <see cref="IQuery"/> instance.
+		/// </returns>
 		public QueryBuilder<TEntity> OrderByDescending(Expression<Func<TEntity, object?>> field)
 			=> OrderBy(field, SortDirection.Descending);
 

--- a/src/Deveel.Repository.Core/Data/QueryFilter.cs
+++ b/src/Deveel.Repository.Core/Data/QueryFilter.cs
@@ -48,7 +48,9 @@ namespace Deveel.Data {
 		/// Converts the given filter to a LINQ expression that can be
 		/// used to filter a <see cref="IQueryable{TEntity}"/> storage
 		/// </summary>
-		/// <typeparam name="TEntity"></typeparam>
+		/// <typeparam name="TEntity">
+		/// The type of entity to filter.
+		/// </typeparam>
 		/// <param name="filter">
 		/// The instance of the filter to convert to a LINQ expression.
 		/// </param>
@@ -197,7 +199,9 @@ namespace Deveel.Data {
 		/// <param name="filter2">
 		/// The second filter to combine.
 		/// </param>
-		/// <returns></returns>
+		/// <returns>
+		/// Returns an <see cref="IQueryFilter"/> that represents the combined filter.
+		/// </returns>
 		/// <exception cref="ArgumentNullException">
 		/// Thrown if either of the given filters is <c>null</c>.
 		/// </exception>

--- a/src/Deveel.Repository.Core/Data/ReflectionFieldMapper.cs
+++ b/src/Deveel.Repository.Core/Data/ReflectionFieldMapper.cs
@@ -20,7 +20,9 @@ namespace Deveel.Data {
 	/// An implementation of <see cref="IFieldMapper{TEntity}"/> that
 	/// uses reflection to map a field name to a member of the entity.
 	/// </summary>
-	/// <typeparam name="TEntity"></typeparam>
+	/// <typeparam name="TEntity">
+	/// The type of entity to map fields for.
+	/// </typeparam>
 	public sealed class ReflectionFieldMapper<TEntity> : IFieldMapper<TEntity> {
 		private Expression<Func<TEntity, object?>>? cachedExpr;
 

--- a/src/Deveel.Repository.Core/Data/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.Core/Data/ServiceCollectionExtensions.cs
@@ -89,6 +89,21 @@ namespace Deveel.Data {
 			return services;
 		}
 
+        /// <summary>
+        /// Registers a repository controller of the given type in the service collection.
+        /// </summary>
+        /// <typeparam name="TController">
+        /// The type of the repository controller to register.
+        /// </typeparam>
+        /// <param name="services">
+        /// The service collection to register the controller.
+        /// </param>
+        /// <param name="configure">
+        /// An optional action to configure the repository controller options.
+        /// </param>
+        /// <returns>
+        /// Returns the same <see cref="IServiceCollection"/> to allow chaining.
+        /// </returns>
         public static IServiceCollection AddRepositoryController<TController>(this IServiceCollection services, Action<RepositoryControllerOptions>? configure = null)
             where TController : class, IRepositoryController {
 
@@ -103,6 +118,18 @@ namespace Deveel.Data {
             return services;
         }
 
+        /// <summary>
+        /// Registers the default repository controller in the service collection.
+        /// </summary>
+        /// <param name="services">
+        /// The service collection to register the controller.
+        /// </param>
+        /// <param name="configure">
+        /// An optional action to configure the repository controller options.
+        /// </param>
+        /// <returns>
+        /// Returns the same <see cref="IServiceCollection"/> to allow chaining.
+        /// </returns>
         public static IServiceCollection AddRepositoryController(this IServiceCollection services, Action<RepositoryControllerOptions>? configure = null)
             => services.AddRepositoryController<DefaultRepositoryController>(configure);
 

--- a/src/Deveel.Repository.DynamicLinq/Data/FilterExpression.cs
+++ b/src/Deveel.Repository.DynamicLinq/Data/FilterExpression.cs
@@ -67,8 +67,12 @@ namespace Deveel.Data {
 		/// <param name="paramNames">
 		/// The array of names of the parameters to be used in the expression
 		/// </param>
-		/// <param name="expression"></param>
-		/// <returns></returns>
+		/// <param name="expression">
+		/// The string expression to compile into a delegate.
+		/// </param>
+		/// <returns>
+		/// Returns a compiled delegate that can be invoked to evaluate the expression.
+		/// </returns>
 		public static Delegate Compile(Type[] paramTypes, string[] paramNames, string expression)
 			=> Compile(null, paramTypes, paramNames, expression);
 
@@ -102,7 +106,9 @@ namespace Deveel.Data {
 		/// or whitespace, or when the given <paramref name="paramTypes"/> and
 		/// <paramref name="paramNames"/> arrays are not the same size.
 		/// </exception>
-		/// <exception cref="InvalidOperationException"></exception>
+		/// <exception cref="InvalidOperationException">
+		/// Thrown when the resulting expression is not a filter or cannot be compiled.
+		/// </exception>
 		public static Delegate Compile(IFilterCache? cache, Type[] paramTypes, string[] paramNames, string expression) {
 			ArgumentNullException.ThrowIfNull(paramTypes, nameof(paramTypes));
 			ArgumentNullException.ThrowIfNull(paramNames, nameof(paramNames));

--- a/src/Deveel.Repository.EntityFramework/Data/DataOwnerAttribute.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/DataOwnerAttribute.cs
@@ -14,6 +14,10 @@
 
 namespace Deveel.Data
 {
+	/// <summary>
+	/// An attribute that marks a property or field as the owner
+	/// of the entity, used to identify the owner of the data.
+	/// </summary>
 	[System.AttributeUsage(System.AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
 	public sealed class DataOwnerAttribute : Attribute
 	{

--- a/src/Deveel.Repository.EntityFramework/Data/EntityRepository_T2.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/EntityRepository_T2.cs
@@ -299,9 +299,15 @@ namespace Deveel.Data
 		/// <param name="key">
 		/// The key used to find the entity.
 		/// </param>
-		/// <param name="entity"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
+		/// <param name="entity">
+		/// The entity that was found in the repository.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns the entity after any modification by the callback.
+		/// </returns>
 		protected virtual ValueTask<TEntity> OnEntityFoundByKeyAsync(TKey key, TEntity entity, CancellationToken cancellationToken = default) {
 			return new ValueTask<TEntity>(entity);
 		}
@@ -388,7 +394,9 @@ namespace Deveel.Data
 		/// <param name="cancellationToken">
 		/// A token used to cancel the operation.
 		/// </param>
-		/// <returns></returns>
+		/// <returns>
+		/// Returns the number of entities that match the given filter.
+		/// </returns>
 		public virtual async ValueTask<long> CountAsync(IQueryFilter filter, CancellationToken cancellationToken = default) {
 			ThrowIfDisposed();
 

--- a/src/Deveel.Repository.Manager.AspNetCore/Data/HttpRequestCancellationSource.cs
+++ b/src/Deveel.Repository.Manager.AspNetCore/Data/HttpRequestCancellationSource.cs
@@ -29,7 +29,9 @@ namespace Deveel.Data {
 		/// <summary>
 		/// Constructs the cancellation source using the given <see cref="IHttpContextAccessor"/>.
 		/// </summary>
-		/// <param name="httpContextAccessor"></param>
+		/// <param name="httpContextAccessor">
+		/// The accessor to the current HTTP context.
+		/// </param>
 		public HttpRequestCancellationSource(IHttpContextAccessor httpContextAccessor) {
 			this.httpContextAccessor = httpContextAccessor;
 		}

--- a/src/Deveel.Repository.Manager.AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.Manager.AspNetCore/ServiceCollectionExtensions.cs
@@ -4,6 +4,10 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Deveel
 {
+	/// <summary>
+	/// Provides extension methods for the <see cref="IServiceCollection"/> interface
+	/// to register services for handling HTTP request cancellation.
+	/// </summary>
     public static class ServiceCollectionExtensions
     {
         /// <summary>

--- a/src/Deveel.Repository.Manager.EasyCaching/Data/Caching/IEntityEasyCacheConverter.cs
+++ b/src/Deveel.Repository.Manager.EasyCaching/Data/Caching/IEntityEasyCacheConverter.cs
@@ -35,7 +35,9 @@ namespace Deveel.Data.Caching {
 		/// Converts the given entity to an
 		/// object that can be cached.
 		/// </summary>
-		/// <param name="entity"></param>
+		/// <param name="entity">
+		/// The entity instance to convert to a cached version.
+		/// </param>
 		/// <returns>
 		/// Returns an object that can be cached.
 		/// </returns>

--- a/src/Deveel.Repository.Manager/Data/Caching/EntityCacheOptions_1.cs
+++ b/src/Deveel.Repository.Manager/Data/Caching/EntityCacheOptions_1.cs
@@ -16,7 +16,9 @@ namespace Deveel.Data.Caching {
 	/// <summary>
 	/// A strongly-typed set of options for the caching of entities.
 	/// </summary>
-	/// <typeparam name="TEntity"></typeparam>
+	/// <typeparam name="TEntity">
+	/// The type of the entity for which caching options are configured.
+	/// </typeparam>
 	public sealed class EntityCacheOptions<TEntity> : EntityCacheOptions where TEntity : class {
 	}
 }

--- a/src/Deveel.Repository.Manager/Data/EntityManager_T2.cs
+++ b/src/Deveel.Repository.Manager/Data/EntityManager_T2.cs
@@ -689,8 +689,13 @@ namespace Deveel.Data {
 		/// from the repository, if the key is not then made available
 		/// from an instance of <see cref="IEntityCacheKeyGenerator{TEntity}"/>.
 		/// </remarks>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns the entity from the cache, if available, or
+		/// the value produced by the factory if not found in the cache.
+		/// </returns>
 		protected async ValueTask<TEntity?> GetOrSetAsync(string cacheKey, Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken) {
 			if (EntityCache == null)
 				return await valueFactory();
@@ -706,6 +711,15 @@ namespace Deveel.Data {
 		/// <summary>
 		/// Adds the given entity to the repository.
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// var manager = new EntityManager&lt;MyEntity&gt;(repository);
+		/// var result = await manager.AddAsync(entity);
+		/// if (result.IsSuccess()) {
+		///     Console.WriteLine("Entity added successfully");
+		/// }
+		/// </code>
+		/// </example>
 		/// <param name="entity">
 		/// The entity to be added.
 		/// </param>
@@ -748,6 +762,15 @@ namespace Deveel.Data {
 		/// <summary>
 		/// Adds the given range of entities to the repository.
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// var manager = new EntityManager&lt;MyEntity&gt;(repository);
+		/// var result = await manager.AddRangeAsync(new[] { entity1, entity2 });
+		/// if (result.IsSuccess()) {
+		///     Console.WriteLine("Entities added successfully");
+		/// }
+		/// </code>
+		/// </example>
 		/// <param name="entities">
 		/// The range of entities to be added.
 		/// </param>
@@ -864,6 +887,15 @@ namespace Deveel.Data {
 		/// <summary>
 		/// Updates the given entity in the repository.
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// var manager = new EntityManager&lt;MyEntity&gt;(repository);
+		/// var result = await manager.UpdateAsync(entity);
+		/// if (result.IsSuccess()) {
+		///     Console.WriteLine("Entity updated successfully");
+		/// }
+		/// </code>
+		/// </example>
 		/// <param name="entity">
 		/// The entity to be updated.
 		/// </param>
@@ -942,6 +974,15 @@ namespace Deveel.Data {
 		/// <summary>
 		/// Removes the given entity from the repository.
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// var manager = new EntityManager&lt;MyEntity&gt;(repository);
+		/// var result = await manager.RemoveAsync(entity);
+		/// if (result.IsSuccess()) {
+		///     Console.WriteLine("Entity removed successfully");
+		/// }
+		/// </code>
+		/// </example>
 		/// <param name="entity">
 		/// The entity to be removed.
 		/// </param>
@@ -1039,6 +1080,16 @@ namespace Deveel.Data {
 		/// <summary>
 		/// Attempts to find an entity in the repository by its key.
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// var manager = new EntityManager&lt;MyEntity&gt;(repository);
+		/// var result = await manager.FindAsync(entityId);
+		/// if (result.IsSuccess()) {
+		///     var entity = result.Value;
+		///     Console.WriteLine($"Found: {entity}");
+		/// }
+		/// </code>
+		/// </example>
 		/// <param name="key">
 		/// The key of the entity to be found.
 		/// </param>
@@ -1077,6 +1128,17 @@ namespace Deveel.Data {
 		/// <summary>
 		/// Finds an entity in the repository that matches the given filter.
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// var manager = new EntityManager&lt;MyEntity&gt;(repository);
+		/// var query = new QueryBuilder&lt;MyEntity&gt;().Where(x =&gt; x.IsActive).Build();
+		/// var result = await manager.FindFirstAsync(query);
+		/// if (result.IsSuccess()) {
+		///     var entity = result.Value;
+		///     Console.WriteLine($"Found: {entity}");
+		/// }
+		/// </code>
+		/// </example>
 		/// <param name="query">
 		/// The query to be used to look for the entity.
 		/// </param>
@@ -1143,6 +1205,16 @@ namespace Deveel.Data {
 		/// <summary>
 		/// Finds all the entities in the repository that match the given filter.
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// var manager = new EntityManager&lt;MyEntity&gt;(repository);
+		/// var query = new QueryBuilder&lt;MyEntity&gt;().Where(x =&gt; x.IsActive).Build();
+		/// var entities = await manager.FindAllAsync(query);
+		/// foreach (var entity in entities) {
+		///     Console.WriteLine($"Found: {entity}");
+		/// }
+		/// </code>
+		/// </example>
 		/// <param name="query">
 		/// The query to be used to look for the entities.
 		/// </param>
@@ -1206,6 +1278,14 @@ namespace Deveel.Data {
 		/// Counts the number of entities in the repository that match
 		/// the given filter.
 		/// </summary>
+		/// <example>
+		/// <code>
+		/// var manager = new EntityManager&lt;MyEntity&gt;(repository);
+		/// var filter = new QueryFilter&lt;MyEntity&gt;(x =&gt; x.IsActive);
+		/// long count = await manager.CountAsync(filter);
+		/// Console.WriteLine($"Count: {count}");
+		/// </code>
+		/// </example>
 		/// <param name="filter">
 		/// The filter to be used to look for the entities.
 		/// </param>
@@ -1268,13 +1348,34 @@ namespace Deveel.Data {
 			=> CountAsync(filter == null ? QueryFilter.Empty : QueryFilter.Where(filter), cancellationToken);
 
 		/// <summary>
-		/// 
+		/// Retrieves a page of entities from the repository based on the given query.
 		/// </summary>
-		/// <param name="query"></param>
-		/// <param name="cancellationToken"></param>
-		/// <returns></returns>
-		/// <exception cref="NotSupportedException"></exception>
-		/// <exception cref="OperationException"></exception>
+		/// <example>
+		/// <code>
+		/// var manager = new EntityManager&lt;MyEntity&gt;(repository);
+		/// var pageQuery = new PageQuery&lt;MyEntity&gt;(1, 10);
+		/// var page = await manager.GetPageAsync(pageQuery);
+		/// foreach (var entity in page.Items) {
+		///     Console.WriteLine(entity);
+		/// }
+		/// </code>
+		/// </example>
+		/// <param name="query">
+		/// The paging and filtering criteria to apply to the query.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		/// <returns>
+		/// Returns a <see cref="PageResult{TEntity}"/> containing the entities
+		/// that match the given paging criteria.
+		/// </returns>
+		/// <exception cref="NotSupportedException">
+		/// Thrown when the repository does not support paging.
+		/// </exception>
+		/// <exception cref="OperationException">
+		/// Thrown when an unknown error occurs while retrieving the page.
+		/// </exception>
 		public virtual async ValueTask<PageResult<TEntity>> GetPageAsync(PageQuery<TEntity> query, CancellationToken? cancellationToken = null) {
 			ThrowIfDisposed();
 

--- a/src/Deveel.Repository.Manager/Data/IOperationErrorFactory_1.cs
+++ b/src/Deveel.Repository.Manager/Data/IOperationErrorFactory_1.cs
@@ -18,6 +18,9 @@ namespace Deveel.Data {
 	/// that can be used to report errors in an operation
 	/// for a specific entity.
 	/// </summary>
+	/// <typeparam name="TEntity">
+	/// The type of the entity for which errors are created.
+	/// </typeparam>
 	public interface IOperationErrorFactory<TEntity> : IOperationErrorFactory where TEntity : class {
 	}
 }

--- a/src/Deveel.Repository.Manager/Data/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.Manager/Data/ServiceCollectionExtensions.cs
@@ -280,10 +280,18 @@ namespace Deveel.Data {
 		/// <param name="services">
 		/// The collection of services to register the validator.
 		/// </param>
-		/// <param name="validatorType"></param>
-		/// <param name="lifetime"></param>
-		/// <returns></returns>
-		/// <exception cref="ArgumentException"></exception>
+		/// <param name="validatorType">
+		/// The type of the validator to register.
+		/// </param>
+		/// <param name="lifetime">
+		/// The desired lifetime of the validator service.
+		/// </param>
+		/// <returns>
+		/// Returns the given collection of services for chaining calls.
+		/// </returns>
+		/// <exception cref="ArgumentException">
+		/// Thrown when the given type is not a concrete class.
+		/// </exception>
 		public static IServiceCollection AddEntityValidator(this IServiceCollection services, Type validatorType, ServiceLifetime lifetime = ServiceLifetime.Transient) {
 			ArgumentNullException.ThrowIfNull(validatorType, nameof(validatorType));
 

--- a/src/Deveel.Repository.MongoFramework.MultiTenant/Data/MongoDbTenantInfo.cs
+++ b/src/Deveel.Repository.MongoFramework.MultiTenant/Data/MongoDbTenantInfo.cs
@@ -27,10 +27,19 @@ namespace Deveel.Data
             set => Identifier = value ?? "";
         }
 #endif
+        /// <summary>
+        /// Gets or sets the unique identifier of the tenant.
+        /// </summary>
         public string Id { get; set; }
         
+        /// <summary>
+        /// Gets or sets the unique identifier used to identify the tenant.
+        /// </summary>
         public string Identifier { get; set; }
         
+        /// <summary>
+        /// Gets or sets the display name of the tenant.
+        /// </summary>
         public string? Name { get; set; }
     }
 }

--- a/src/Deveel.Repository.MongoFramework/Data/MongoRepository_T2.cs
+++ b/src/Deveel.Repository.MongoFramework/Data/MongoRepository_T2.cs
@@ -132,8 +132,13 @@ namespace Deveel.Data {
 		/// Constructs a new <see cref="IMongoDbSet{TEntity}"/> that is
 		/// coherent with the context and the entity type.
 		/// </summary>
-		/// <returns></returns>
-		/// <exception cref="RepositoryException"></exception>
+		/// <returns>
+		/// Returns an instance of <see cref="IMongoDbSet{TEntity}"/> that is
+		/// coherent with the context and the entity type.
+		/// </returns>
+		/// <exception cref="RepositoryException">
+		/// Thrown when the entity set cannot be created.
+		/// </exception>
 		protected virtual IMongoDbSet<TEntity> MakeEntitySet() {
 			if (Context is IMongoDbTenantContext tenantContext &&
 				typeof(IHaveTenantId).IsAssignableFrom(typeof(TEntity))) {
@@ -321,7 +326,9 @@ namespace Deveel.Data {
 		/// Returns a task that, when completed, has created all the indices
 		/// of the repository.
 		/// </returns>
-		/// <exception cref="RepositoryException"></exception>
+		/// <exception cref="RepositoryException">
+		/// Thrown when an error occurs while creating the indices for the repository.
+		/// </exception>
 		public async ValueTask CreateIndicesAsync(CancellationToken cancellationToken = default) {
 			try {
 				var entityDef = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
@@ -399,7 +406,9 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns a task that, when completed, has dropped the collection.
 		/// </returns>
-		/// <exception cref="RepositoryException"></exception>
+		/// <exception cref="RepositoryException">
+		/// Thrown when an error occurs while dropping the collection in the database.
+		/// </exception>
 		public async ValueTask DropCollectionAsync(CancellationToken cancellationToken = default) {
 			try {
 				var entityDef = EntityMapping.GetOrCreateDefinition(typeof(TEntity));

--- a/src/Deveel.Repository.MongoFramework/Data/RepositoryExtensions.cs
+++ b/src/Deveel.Repository.MongoFramework/Data/RepositoryExtensions.cs
@@ -166,7 +166,9 @@ namespace Deveel.Data {
 		/// Returns an instance of <see cref="IList{TEntity}"/> that
 		/// is the result of the search.
 		/// </returns>
-		/// <exception cref="ArgumentException"></exception>
+		/// <exception cref="ArgumentException">
+		/// Thrown when the given repository is not a <see cref="MongoRepository{TEntity, TKey}"/>.
+		/// </exception>
 		public static ValueTask<IList<TEntity>> FindAllByGeoDistanceAsync<TEntity, TKey>(this IRepository<TEntity, TKey> repository, Expression<Func<TEntity, object>> field, GeoPoint point, double? maxDistance = null)
 			where TEntity : class {
 			ArgumentNullException.ThrowIfNull(repository, nameof(repository));

--- a/src/Deveel.Repository.MongoFramework/Data/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.MongoFramework/Data/ServiceCollectionExtensions.cs
@@ -25,6 +25,25 @@ namespace Deveel.Data
 	/// </summary>
 	public static class ServiceCollectionExtensions
 	{
+		/// <summary>
+		/// Adds a <see cref="IMongoDbContext"/> to the service collection
+		/// using the given connection string.
+		/// </summary>
+		/// <typeparam name="TContext">
+		/// The type of the context to register.
+		/// </typeparam>
+		/// <param name="services">
+		/// The service collection to add the context to.
+		/// </param>
+		/// <param name="connectionString">
+		/// The connection string to use for the MongoDB connection.
+		/// </param>
+		/// <param name="lifetime">
+		/// The lifetime of the context in the service collection.
+		/// </param>
+		/// <returns>
+		/// Returns the service collection for chaining.
+		/// </returns>
 		public static IServiceCollection AddMongoDbContext<TContext>(this IServiceCollection services, string connectionString, ServiceLifetime lifetime = ServiceLifetime.Singleton)
 			where TContext : class, IMongoDbContext
 		{

--- a/src/Deveel.Repository.States.Core/Data/RepositoryExtensions.cs
+++ b/src/Deveel.Repository.States.Core/Data/RepositoryExtensions.cs
@@ -1,18 +1,88 @@
 ﻿using System;
 
 namespace Deveel.Data {
+	/// <summary>
+	/// Provides extension methods for <see cref="IStateRepository{TEntity, TStatus}"/>
+	/// to simplify synchronous operations.
+	/// </summary>
 	public static class RepositoryExtensions {
+		/// <summary>
+		/// Synchronously adds a state to the given entity.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of the entity to add the state to.
+		/// </typeparam>
+		/// <typeparam name="TStatus">
+		/// The type of the status to add.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository to add the state to.
+		/// </param>
+		/// <param name="entity">
+		/// The entity to add the state to.
+		/// </param>
+		/// <param name="stateInfo">
+		/// The information describing the state to add.
+		/// </param>
 		public static void AddState<TEntity, TStatus>(this IStateRepository<TEntity, TStatus> repository, TEntity entity, StateInfo<TStatus> stateInfo)
 			where TEntity : class, IEntity
 			=> repository.AddStateAsync(entity, stateInfo).ConfigureAwait(false).GetAwaiter().GetResult();
 
+		/// <summary>
+		/// Synchronously adds a state to the given entity.
+		/// </summary>
+		/// <typeparam name="TStatus">
+		/// The type of the status to add.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository to add the state to.
+		/// </param>
+		/// <param name="entity">
+		/// The entity to add the state to.
+		/// </param>
+		/// <param name="stateInfo">
+		/// The information describing the state to add.
+		/// </param>
 		public static void AddState<TStatus>(this IStateRepository<TStatus> repository, IEntity entity, StateInfo<TStatus> stateInfo)
 			=> repository.AddStateAsync(entity, stateInfo).ConfigureAwait(false).GetAwaiter().GetResult();
 
+		/// <summary>
+		/// Synchronously removes a state from the given entity.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of the entity to remove the state from.
+		/// </typeparam>
+		/// <typeparam name="TStatus">
+		/// The type of the status to remove.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository to remove the state from.
+		/// </param>
+		/// <param name="entity">
+		/// The entity to remove the state from.
+		/// </param>
+		/// <param name="stateInfo">
+		/// The information describing the state to remove.
+		/// </param>
 		public static void RemoveState<TEntity, TStatus>(this IStateRepository<TEntity, TStatus> repository, TEntity entity, StateInfo<TStatus> stateInfo)
 			where TEntity : class, IEntity
 			=> repository.RemoveStateAsync(entity, stateInfo).ConfigureAwait(false).GetAwaiter().GetResult();
 
+		/// <summary>
+		/// Synchronously removes a state from the given entity.
+		/// </summary>
+		/// <typeparam name="TStatus">
+		/// The type of the status to remove.
+		/// </typeparam>
+		/// <param name="repository">
+		/// The repository to remove the state from.
+		/// </param>
+		/// <param name="entity">
+		/// The entity to remove the state from.
+		/// </param>
+		/// <param name="stateInfo">
+		/// The information describing the state to remove.
+		/// </param>
 		public static void RemoveState<TStatus>(this IStateRepository<TStatus> repository, IEntity entity, StateInfo<TStatus> stateInfo)
 			=> repository.RemoveStateAsync(entity, stateInfo).ConfigureAwait(false).GetAwaiter().GetResult();
 	}


### PR DESCRIPTION
This pull request introduces several documentation improvements and feature highlights across the repository, focusing on multi-tenancy support, new package documentation, and enhanced XML documentation validation. The most significant changes are the documentation updates for multi-tenant capabilities, new package listings, and improved developer guidance, as well as a new CI step for XML documentation completeness.

**Documentation and Feature Highlights:**

*Expanded Multi-Tenancy Documentation and Guidance:*
- Updated `docs/multi-tenancy.md` to clarify and modernize guidance for multi-tenant support in both Entity Framework Core and MongoDB, emphasizing the use of `Deveel.Repository.MongoFramework.MultiTenant` and Finbuckle.MultiTenant, and providing improved code samples and explanations.

*New and Updated Package Listings:*
- Added new packages to the documentation and README, including `Deveel.Repository.MongoFramework.MultiTenant`, `Deveel.Repository.Manager.AspNetCore`, and `Deveel.Repository.States.Core`, with descriptions and NuGet badges in both `README.md` and `docs/index.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R59-R65) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R51-R57) [[3]](diffhunk://#diff-d08f51c728fe09ddf456c4b8687408a90ad38ce3dc475ab40f236c50659c1233R10)
- Updated capability matrix and implementation tables to reflect new multi-tenant and thread-safety features. [[1]](diffhunk://#diff-d08f51c728fe09ddf456c4b8687408a90ad38ce3dc475ab40f236c50659c1233R10) [[2]](diffhunk://#diff-e813bba2aa695150ec6ca3a59c79ebaff044e3a5246979b05e26a6e987611e00R11-R18)

*Release Timeline and Feature Status:*
- Updated the release checklist in `README.md` to mark several v1.5.0 and v1.6.0 features as completed, including .NET 10 compatibility, XML documentation completeness, ValueTask conversions, and automatic timestamp/ownership management.

**Developer and Code Quality Improvements:**

*XML Documentation Validation:*
- Added a new CI workflow step in `.github/workflows/reusable-pipeline.yml` to enforce XML documentation completeness by treating missing documentation warnings (CS1591) as errors during build.

*Interface Documentation Enhancements:*
- Improved XML comments for several core interfaces (`IRepository`, `IPageableRepository`, `IFilterableRepository`, `IQueryableFilter`, `IFieldMapper`) to provide clearer parameter and type descriptions, and added usage examples. [[1]](diffhunk://#diff-1e7257d5a227127a42a9d57150db1aa81fa48637657a161ff90a9c839aee419fL22-R24) [[2]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dR45-R54) [[3]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dL62-R72) [[4]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dL87-R99) [[5]](diffhunk://#diff-245a280ebbcfc5c0ac9713837aa5b09834adb7ce2db5f6d61104ea34bd0362f3L35-R37) [[6]](diffhunk://#diff-a941b05ff64859905963402b2720f5ecbb77027bd4d5b6035aa99eab8d8efb55L34-R36) [[7]](diffhunk://#diff-6eab7ed8993c98c2ec9a787e357b2ae6bd3795ae1b2a85f4c9a832d717c00734L20-R22)

**Repository Implementation Details:**

*Thread-Safe In-Memory Repository:*
- Documented the thread-safety of `InMemoryRepository<TEntity>`, specifying the use of `ReaderWriterLockSlim` for concurrent access and updating the feature matrix to reflect this.

---

**References:**  
[[1]](diffhunk://#diff-42b35c3c2ec6e5c39cdda70ecf15753919f383b31c65fd171839d802aca264aaL5-R69) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R59-R65) [[3]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R51-R57) [[4]](diffhunk://#diff-d08f51c728fe09ddf456c4b8687408a90ad38ce3dc475ab40f236c50659c1233R10) [[5]](diffhunk://#diff-e813bba2aa695150ec6ca3a59c79ebaff044e3a5246979b05e26a6e987611e00R11-R18) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L147-R163) [[7]](diffhunk://#diff-5fe84e9f67a58184c1cf92f8642933831edcdefcd19d4110ed05bf8014a747d8R69-R71) [[8]](diffhunk://#diff-1e7257d5a227127a42a9d57150db1aa81fa48637657a161ff90a9c839aee419fL22-R24) [[9]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dR45-R54) [[10]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dL62-R72) [[11]](diffhunk://#diff-d5e27cc82e1d5141768f136b4b374e60ff31526a6801d44aad4b84412f58055dL87-R99) [[12]](diffhunk://#diff-245a280ebbcfc5c0ac9713837aa5b09834adb7ce2db5f6d61104ea34bd0362f3L35-R37) [[13]](diffhunk://#diff-a941b05ff64859905963402b2720f5ecbb77027bd4d5b6035aa99eab8d8efb55L34-R36) [[14]](diffhunk://#diff-6eab7ed8993c98c2ec9a787e357b2ae6bd3795ae1b2a85f4c9a832d717c00734L20-R22)