### PR TITLE
Add multi-tenancy support and repository context builder

### DIFF
--- a/Deveel.Repository.sln
+++ b/Deveel.Repository.sln
@@ -72,6 +72,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Repository.Testing.T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "repobench", "benchmarks\repobench\repobench.csproj", "{A88D555E-4301-4844-A40D-DB852337CAA9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Repository.Context.XUnit", "test\Deveel.Repository.Context.XUnit\Deveel.Repository.Context.XUnit.csproj", "{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Repository.EntityFramework.MultiTenant", "src\Deveel.Repository.EntityFramework.MultiTenant\Deveel.Repository.EntityFramework.MultiTenant.csproj", "{C4CE594C-71F8-4052-98CA-99B027DA9A8E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -370,6 +374,30 @@ Global
 		{A88D555E-4301-4844-A40D-DB852337CAA9}.Release|x64.Build.0 = Release|Any CPU
 		{A88D555E-4301-4844-A40D-DB852337CAA9}.Release|x86.ActiveCfg = Release|Any CPU
 		{A88D555E-4301-4844-A40D-DB852337CAA9}.Release|x86.Build.0 = Release|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Debug|x64.Build.0 = Debug|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Debug|x86.Build.0 = Debug|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Release|x64.ActiveCfg = Release|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Release|x64.Build.0 = Release|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Release|x86.ActiveCfg = Release|Any CPU
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD}.Release|x86.Build.0 = Release|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Debug|x64.Build.0 = Debug|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Debug|x86.Build.0 = Debug|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Release|x64.ActiveCfg = Release|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Release|x64.Build.0 = Release|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Release|x86.ActiveCfg = Release|Any CPU
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -401,6 +429,8 @@ Global
 		{BB76E99D-06A8-474E-A3F6-3B6990DCEE08} = {85200FA4-CC68-4758-B6E5-287E8AFA79FE}
 		{2591DA8C-2B1F-4DA4-A320-F0444C5BA52C} = {6EAA2746-39E4-4C63-9D86-117248B1C2A3}
 		{A88D555E-4301-4844-A40D-DB852337CAA9} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{F93FCA96-83F3-4B18-A5A7-9E9D5F0AF0FD} = {50434E05-0F21-4871-AFB3-A483CEE4A300}
+		{C4CE594C-71F8-4052-98CA-99B027DA9A8E} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01FD9B16-84B3-4D99-80C1-11B2F3D65B56}

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ dotnet add package Deveel.Repository.Core
 | [_MongoDB_](repository-implementations/mongodb.md) | `Deveel.Repository.MongoFramework` | Stores entities in a MongoDB database via [MongoFramework](https://github.com/turnersoftware/mongoframework). |
 | [_MongoDB Multi-Tenant_](multi-tenancy.md) | `Deveel.Repository.MongoFramework.MultiTenant` | Multi-tenant MongoDB connection management via [Finbuckle.MultiTenant](https://github.com/Finbuckle/Finbuckle.MultiTenant). |
 | [_Entity Framework Core_](repository-implementations/ef-core.md) | `Deveel.Repository.EntityFramework` | Stores entities in any relational database supported by [Entity Framework Core](https://github.com/dotnet/efcore). |
+| [_EF Core Multi-Tenant_](repository-implementations/ef-core.md#multi-tenant-support) | `Deveel.Repository.EntityFramework.MultiTenant` | Multi-tenant EF Core with database-per-tenant or shared-database strategies. |
 | [_Dynamic LINQ_](repository-implementations/README.md#dynamic-linq-support) | `Deveel.Repository.DynamicLinq` | Runtime string-based filter expressions via [System.Linq.Dynamic.Core](https://github.com/zzzprojects/System.Linq.Dynamic.Core). |
 | [_Entity Manager_](entity-manager/) | `Deveel.Repository.Manager` | Business layer with validation, normalization, caching, and event sourcing. |
 | [_Entity Manager EasyCaching_](entity-manager/caching-entities.md) | `Deveel.Repository.Manager.EasyCaching` | Second-level caching for EntityManager via [EasyCaching](https://github.com/dotnetcore/EasyCaching). |
@@ -60,24 +61,63 @@ dotnet add package Deveel.Repository.Core
 
 ## Instrumentation
 
-The library provides extension methods on `IServiceCollection` to register repositories in the dependency injection container.
+The library provides a fluent builder API via `AddRepositoryContext()` to configure repositories, drivers, and cross-cutting concerns in a unified way.
 
-Use `AddRepository<TRepository>` to register a concrete repository type. The method uses reflection to discover all `IRepository<TEntity>` interface implementations on the given type and registers them automatically.
+### Using the Fluent Builder
 
 ```csharp
 // Program.cs
+
+// In-Memory driver
+builder.Services.AddRepositoryContext()
+    .UseInMemory();
+
+// Entity Framework Core driver
+builder.Services.AddRepositoryContext()
+    .UseEntityFramework<MyDbContext>(b => b
+        .ConfigureDbContext(opts => opts.UseSqlServer("...")));
+
+// MongoDB driver
+builder.Services.AddRepositoryContext()
+    .UseMongoDB<MyMongoContext>(b => b
+        .WithConnectionString("mongodb://..."));
+```
+
+Each driver call returns to the parent builder, allowing you to chain multiple concerns:
+
+```csharp
+builder.Services.AddRepositoryContext()
+    .UseEntityFramework<AppDbContext>(b => b
+        .ConfigureDbContext(opts => opts.UseSqlServer("...")))
+    .WithManagement()
+    .WithEasyCaching();
+```
+
+### Assembly Scanning
+
+Use `ScanRepositories()` to automatically discover and register repository types from one or more assemblies:
+
+```csharp
+builder.Services.AddRepositoryContext()
+    .UseInMemory()
+    .ScanRepositories(typeof(MyEntityRepository).Assembly);
+```
+
+Open generic repositories are registered as open generics; closed repositories are registered via their service interfaces.
+
+### Legacy Registration
+
+The older `AddRepository<T>` extension method is still available for backward compatibility:
+
+```csharp
 builder.Services.AddRepository<InMemoryRepository<MyEntity>>();
 ```
 
-For custom repositories:
-
-```csharp
-builder.Services.AddRepository<MyCustomRepository>();
-```
+> **Note:** `AddRepository<T>` is marked `[Obsolete]` but not as an error. It will continue to work. Prefer `AddRepositoryContext()` for new code.
 
 ### Consuming the Repository
 
-After calling `AddRepository<TRepository>`, the following service types become available in the DI container (availability depends on which interfaces the concrete repository implements):
+After registration, the following service types become available in the DI container (availability depends on which interfaces the concrete repository implements):
 
 | Service | Description |
 | ------- | ----------- |

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -8,40 +8,97 @@ The preferred approach of the library is to use the [Finbuckle.MultiTenant](http
 | ------ | ------------- | ----- |
 | _In-Memory_ | :x: | Not supported |
 | _MongoDB_ | :white_check_mark: | Via `Deveel.Repository.MongoFramework.MultiTenant` |
-| _Entity Framework Core_ | :white_check_mark: | Via [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant) |
+| _Entity Framework Core_ | :white_check_mark: | Via `Deveel.Repository.EntityFramework.MultiTenant` |
 
 ## Multi-Tenancy in Entity Framework Core
 
-Multi-tenancy in EF Core repositories is handled externally via [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant). The library does not provide its own tenant-isolation logic for EF Core; instead, configure the `DbContext` to use tenant information from the `ITenantInfo` interface:
+The `Deveel.Repository.EntityFramework.MultiTenant` package provides two multi-tenancy strategies, both built on [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant).
+
+### Strategy 1: Database-per-Tenant
+
+Each tenant connects to its own database. Your `ITenantInfo` implementation must have a `ConnectionString` property.
 
 ```csharp
-builder.Services.AddMultiTenant<TenantInfo>()
-    .WithConfigurationStore()
+builder.Services.AddMultiTenant<AppTenantInfo>()
+    .WithInMemoryStore()
     .WithRouteStrategy();
+
+builder.Services.AddRepositoryContext()
+    .UseEntityFramework<AppDbContext>()
+    .WithDatabasePerTenant<AppTenantInfo>(defaultConnection: "Data Source=default.db")
+    .Build();
 ```
 
-Then wire the tenant connection string into your `DbContext`:
+The `DbContext` resolves the connection string in `OnConfiguring`:
 
 ```csharp
-public class MyDbContext : DbContext
+public class AppDbContext : DbContext
 {
-    private readonly IMultiTenantContext<TenantInfo> _tenantContext;
+    private readonly IMultiTenantContextAccessor<AppTenantInfo> _tenantAccessor;
+    private readonly IOptions<EntityFrameworkTenantConnectionOptions> _options;
 
-    public MyDbContext(
-        DbContextOptions<MyDbContext> options,
-        IMultiTenantContext<TenantInfo> tenantContext) : base(options)
+    public AppDbContext(
+        DbContextOptions<AppDbContext> options,
+        IMultiTenantContextAccessor<AppTenantInfo> tenantAccessor,
+        IOptions<EntityFrameworkTenantConnectionOptions> options) : base(options)
     {
-        _tenantContext = tenantContext;
+        _tenantAccessor = tenantAccessor;
+        _options = options;
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        optionsBuilder.UseSqlServer(_tenantContext.TenantInfo!.ConnectionString);
+        var connectionString = _tenantAccessor.MultiTenantContext?.TenantInfo?.ConnectionString
+            ?? _options.Value.DefaultConnectionString;
+
+        if (string.IsNullOrEmpty(connectionString))
+            throw new InvalidOperationException("No connection string available.");
+
+        optionsBuilder.UseSqlServer(connectionString);
     }
 }
 ```
 
-After that, inject and use `IRepository<MyEntity>` normally — tenant isolation is handled transparently by the `DbContext`.
+### Strategy 2: Shared Database
+
+All tenants share a single database. Data isolation is achieved by filtering queries based on the current tenant's ID. The `DbContext` must derive from `Finbuckle.MultiTenant.EntityFrameworkCore.MultiTenantDbContext` and entities must be configured with `IsMultiTenant()`.
+
+```csharp
+builder.Services.AddMultiTenant<AppTenantInfo>()
+    .WithInMemoryStore()
+    .WithRouteStrategy();
+
+builder.Services.AddRepositoryContext()
+    .UseEntityFramework<AppDbContext>(b => b
+        .ConfigureDbContext(opts => opts.UseSqlServer("..."))
+        .WithSharedTenantDatabase());
+```
+
+```csharp
+public class AppDbContext : MultiTenantDbContext
+{
+    public AppDbContext(
+        IMultiTenantContextAccessor multiTenantContextAccessor,
+        DbContextOptions<AppDbContext> options) : base(multiTenantContextAccessor, options) { }
+
+    public DbSet<Order> Orders { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Order>().IsMultiTenant();
+    }
+}
+```
+
+### Choosing a Strategy
+
+| Aspect | Database-per-Tenant | Shared Database |
+| ------ | ------------------- | --------------- |
+| **Data isolation** | Complete (separate databases) | Logical (TenantId column) |
+| **Schema management** | Per-database migrations needed | Single schema for all tenants |
+| **Cost** | Higher (one DB per tenant) | Lower (shared infrastructure) |
+| **Tenant onboarding** | Create new database | Add tenant record |
+| **Compliance** | Easier for data residency | Requires careful query filtering |
 
 ## Multi-Tenancy in MongoDB
 

--- a/docs/repository-implementations/README.md
+++ b/docs/repository-implementations/README.md
@@ -6,6 +6,7 @@ The _Deveel Repository_ framework ships with a set of ready-to-use repository im
 | ----------- | ------- | ------- |
 | [In-Memory](in-memory.md) | `Deveel.Repository.InMemory` | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.InMemory.svg)](https://www.nuget.org/packages/Deveel.Repository.InMemory/) |
 | [Entity Framework Core](ef-core.md) | `Deveel.Repository.EntityFramework` | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.EntityFramework.svg)](https://www.nuget.org/packages/Deveel.Repository.EntityFramework/) |
+| [EF Core Multi-Tenant](ef-core.md#multi-tenant-support) | `Deveel.Repository.EntityFramework.MultiTenant` | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.EntityFramework.MultiTenant.svg)](https://www.nuget.org/packages/Deveel.Repository.EntityFramework.MultiTenant/) |
 | [MongoDB](mongodb.md) | `Deveel.Repository.MongoFramework` | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.MongoFramework.svg)](https://www.nuget.org/packages/Deveel.Repository.MongoFramework/) |
 | [MongoDB Multi-Tenant](../multi-tenancy.md) | `Deveel.Repository.MongoFramework.MultiTenant` | [![NuGet](https://img.shields.io/nuget/v/Deveel.Repository.MongoFramework.MultiTenant.svg)](https://www.nuget.org/packages/Deveel.Repository.MongoFramework.MultiTenant/) |
 

--- a/docs/repository-implementations/ef-core.md
+++ b/docs/repository-implementations/ef-core.md
@@ -7,7 +7,7 @@
 | Queryable | ✅ | Native EF Core `IQueryable` |
 | Pageable | ✅ | |
 | Tracking | ✅ | EF Core change tracking |
-| Multi-tenant | ✅ | Via [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant) |
+| Multi-tenant | ✅ | Via `Deveel.Repository.EntityFramework.MultiTenant` |
 
 The _Deveel Repository_ `Deveel.Repository.EntityFramework` package provides an implementation of the repository pattern that uses [Entity Framework Core](https://github.com/dotnet/efcore), enabling access to any relational database that EF Core supports (SQL Server, PostgreSQL, SQLite, MySQL, and others).
 
@@ -21,58 +21,117 @@ dotnet add package Deveel.Repository.EntityFramework
 
 ## Registration
 
-You need to register a `DbContext` yourself (using the standard EF Core methods), and then register the repository on top of it. The library does not manage the `DbContext` registration.
+Use the fluent builder API to register the EF Core driver. The builder handles both `DbContext` and repository registration in a single call:
 
 ```csharp
 // Program.cs
-builder.Services.AddDbContext<MyDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("Default")));
-
-// Generic form — registers EntityRepository<MyEntity> and all its interface projections
-builder.Services.AddRepository<EntityRepository<MyEntity>>();
-
-// Shortcut form provided by this package
-builder.Services.AddEntityRepository<MyEntity>();
+builder.Services.AddRepositoryContext()
+    .UseEntityFramework<MyDbContext>(b => b
+        .ConfigureDbContext(opts =>
+            opts.UseSqlServer(builder.Configuration.GetConnectionString("Default"))));
 ```
 
 For a custom repository that derives from `EntityRepository<TEntity>`:
 
 ```csharp
-builder.Services.AddRepository<MyEntityRepository>();
+builder.Services.AddRepositoryContext()
+    .UseEntityFramework<MyDbContext>(b => b
+        .ConfigureDbContext(opts => opts.UseSqlServer("...")))
+    .AddRepository<MyEntityRepository>();
 ```
+
+### Configuration Options
+
+| Method | Description |
+| ------ | ----------- |
+| `ConfigureDbContext(Action<DbContextOptionsBuilder>)` | Configures the `DbContext` options (provider, connection string, etc.) |
+| `WithLifetime(ServiceLifetime)` | Sets the service lifetime for the `DbContext` and repositories (default: `Scoped`) |
 
 ## Multi-tenant Support
 
-Starting from version 1.4, multi-tenancy in EF Core repositories is handled externally via [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant). The library does not provide its own tenant-isolation logic for EF Core; instead, configure the `DbContext` to use tenant information from the `ITenantInfo` interface:
+Install the `Deveel.Repository.EntityFramework.MultiTenant` package:
 
-```csharp
-builder.Services.AddMultiTenant<TenantInfo>()
-    .WithConfigurationStore()
-    .WithRouteStrategy();
+```bash
+dotnet add package Deveel.Repository.EntityFramework.MultiTenant
 ```
 
-Then wire the tenant connection string into your `DbContext`:
+Two multi-tenancy strategies are supported, both built on [Finbuckle.MultiTenant](https://www.finbuckle.com/MultiTenant):
+
+### Strategy 1: Database-per-Tenant (`WithDatabasePerTenant`)
+
+Each tenant connects to its own database. Your `ITenantInfo` implementation must have a `ConnectionString` property.
 
 ```csharp
-public class MyDbContext : DbContext
-{
-    private readonly IMultiTenantContext<TenantInfo> _tenantContext;
+builder.Services.AddMultiTenant<AppTenantInfo>()
+    .WithInMemoryStore()
+    .WithRouteStrategy();
 
-    public MyDbContext(
-        DbContextOptions<MyDbContext> options,
-        IMultiTenantContext<TenantInfo> tenantContext) : base(options)
+builder.Services.AddRepositoryContext()
+    .UseEntityFramework<AppDbContext>()
+    .WithDatabasePerTenant<AppTenantInfo>(defaultConnection: "Data Source=default.db")
+    .Build();
+```
+
+Your `DbContext` resolves the connection string in `OnConfiguring`:
+
+```csharp
+public class AppDbContext : DbContext
+{
+    private readonly IMultiTenantContextAccessor<AppTenantInfo> _tenantAccessor;
+    private readonly IOptions<EntityFrameworkTenantConnectionOptions> _options;
+
+    public AppDbContext(
+        DbContextOptions<AppDbContext> options,
+        IMultiTenantContextAccessor<AppTenantInfo> tenantAccessor,
+        IOptions<EntityFrameworkTenantConnectionOptions> options) : base(options)
     {
-        _tenantContext = tenantContext;
+        _tenantAccessor = tenantAccessor;
+        _options = options;
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
-        optionsBuilder.UseSqlServer(_tenantContext.TenantInfo!.ConnectionString);
+        var connectionString = _tenantAccessor.MultiTenantContext?.TenantInfo?.ConnectionString
+            ?? _options.Value.DefaultConnectionString;
+
+        if (string.IsNullOrEmpty(connectionString))
+            throw new InvalidOperationException("No connection string available.");
+
+        optionsBuilder.UseSqlServer(connectionString);
     }
 }
 ```
 
-After that, inject and use `IRepository<MyEntity>` normally — tenant isolation is handled transparently by the `DbContext`.
+### Strategy 2: Shared Database (`WithSharedTenantDatabase`)
+
+All tenants share a single database. Data isolation is achieved by filtering queries based on the current tenant's ID. Your `DbContext` must derive from `Finbuckle.MultiTenant.EntityFrameworkCore.MultiTenantDbContext` and entities must be configured with `IsMultiTenant()`.
+
+```csharp
+builder.Services.AddMultiTenant<AppTenantInfo>()
+    .WithInMemoryStore()
+    .WithRouteStrategy();
+
+builder.Services.AddRepositoryContext()
+    .UseEntityFramework<AppDbContext>(b => b
+        .ConfigureDbContext(opts => opts.UseSqlServer("..."))
+        .WithSharedTenantDatabase());
+```
+
+```csharp
+public class AppDbContext : MultiTenantDbContext
+{
+    public AppDbContext(
+        IMultiTenantContextAccessor multiTenantContextAccessor,
+        DbContextOptions<AppDbContext> options) : base(multiTenantContextAccessor, options) { }
+
+    public DbSet<Order> Orders { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Order>().IsMultiTenant();
+    }
+}
+```
 
 ## Querying
 
@@ -96,6 +155,6 @@ var entities = await repository.FindAllAsync(query);
 
 ## Notes
 
-- Register your `DbContext` using the standard EF Core `AddDbContext` extension — the repository package does not wrap or replace that registration.
+- The `UseEntityFramework<TDbContext>()` builder method handles `DbContext` registration — you do not need to call `AddDbContext` separately.
 - Refer to the [Entity Framework Core documentation](https://learn.microsoft.com/en-us/ef/core/) for migration and schema configuration details.
-- Refer to the [Finbuckle.MultiTenant documentation](https://www.finbuckle.com/MultiTenant) for multi-tenant EF Core configuration.
+- Refer to the [Finbuckle.MultiTenant documentation](https://www.finbuckle.com/MultiTenant) for multi-tenant configuration.

--- a/docs/repository-implementations/in-memory.md
+++ b/docs/repository-implementations/in-memory.md
@@ -24,18 +24,34 @@ dotnet add package Deveel.Repository.InMemory
 
 ## Registration
 
-Register the repository in the DI container using the generic `AddRepository<T>` method from the kernel package:
+Use the fluent builder API to register the In-Memory driver:
 
 ```csharp
 // Program.cs
-builder.Services.AddRepository<InMemoryRepository<MyEntity>>();
+builder.Services.AddRepositoryContext()
+    .UseInMemory();
 ```
 
-The library does not provide a type-specific shortcut method for the in-memory driver. Use the generic `AddRepository<T>` form shown above, or register your own concrete sub-class if you have one.
+You can also configure field mappers and initial data:
 
-## Pre-seeding Data
+```csharp
+builder.Services.AddRepositoryContext()
+    .UseInMemory(b => b
+        .WithFieldMapper<MyEntity, MyFieldMapper>()
+        .WithInitialData(new[] { new MyEntity { /* ... */ } }));
+```
 
-The `InMemoryRepository<TEntity>` constructor accepts an optional initial list of entities:
+### Pre-seeding Data
+
+You can seed initial data using the `WithInitialData` method:
+
+```csharp
+var seeded = new List<MyEntity> { /* ... */ };
+builder.Services.AddRepositoryContext()
+    .UseInMemory(b => b.WithInitialData(seeded));
+```
+
+Or register the repository directly with pre-seeded data:
 
 ```csharp
 var seeded = new List<MyEntity> { /* ... */ };

--- a/docs/repository-implementations/mongodb.md
+++ b/docs/repository-implementations/mongodb.md
@@ -7,7 +7,7 @@
 | Queryable | ✅ | Via MongoFramework `IQueryable` |
 | Pageable | ✅ | |
 | Tracking | ✅ | MongoFramework change tracking |
-| Multi-tenant | ✅ | Via [Finbuckle.MultiTenant](https://github.com/Finbuckle/Finbuckle.MultiTenant) |
+| Multi-tenant | ✅ | Via `Deveel.Repository.MongoFramework.MultiTenant` |
 
 The `MongoRepository<TEntity>` class is an implementation of the repository pattern that stores entities in a [MongoDB](https://www.mongodb.com) database, built on top of [MongoFramework](https://github.com/TurnerSoftware/MongoFramework).
 
@@ -21,40 +21,39 @@ dotnet add package Deveel.Repository.MongoFramework
 
 ## Registration
 
-The package provides `AddMongoDbContext<TContext>` to register the MongoDB context, followed by the standard `AddRepository<T>` to register the repository:
+Use the fluent builder API to register the MongoDB driver:
 
 ```csharp
 // Program.cs
-
-// 1. Register the MongoDB context
-builder.Services.AddMongoDbContext<MongoDbContext>(
-    "mongodb://localhost:27017/my_database");
-
-// 2. Register the repository
-builder.Services.AddRepository<MongoRepository<MyEntity>>();
+builder.Services.AddRepositoryContext()
+    .UseMongoDB<MyMongoContext>(b => b
+        .WithConnectionString("mongodb://localhost:27017/my_database"));
 ```
 
 You can also use a builder delegate to configure the connection:
 
 ```csharp
-builder.Services.AddMongoDbContext<MongoDbContext>(builder =>
-    builder.UseConnection("mongodb://localhost:27017/my_database"));
+builder.Services.AddRepositoryContext()
+    .UseMongoDB<MyMongoContext>(b => b
+        .WithConnection(conn => conn.UseConnection("mongodb://localhost:27017/my_database")));
 ```
 
-The following context registration methods are available:
+The following configuration methods are available on the MongoDB driver builder:
 
 | Method | Description |
 | ------ | ----------- |
-| `AddMongoDbContext<TContext>(string, ServiceLifetime)` | Registers a context using a connection string. |
-| `AddMongoDbContext<TContext>(Action<MongoConnectionBuilder>, ServiceLifetime)` | Registers a context using a connection builder delegate. |
+| `WithConnectionString(string)` | Sets the MongoDB connection string. |
+| `WithConnection(Action<MongoConnectionBuilder>)` | Configures the connection using a builder delegate. |
+| `WithLifetime(ServiceLifetime)` | Sets the service lifetime (default: `Scoped`). |
 
 ### Custom Context Type
 
 If you derive from `MongoDbContext` (or `MongoDbTenantContext` for multi-tenant scenarios), register your concrete type:
 
 ```csharp
-builder.Services.AddMongoDbContext<MyMongoDbContext>("mongodb://...");
-builder.Services.AddRepository<MongoRepository<MyEntity>>();
+builder.Services.AddRepositoryContext()
+    .UseMongoDB<MyMongoDbContext>(b => b
+        .WithConnectionString("mongodb://..."));
 ```
 
 ## Multi-tenant Support
@@ -70,10 +69,10 @@ builder.Services.AddMultiTenant<MongoDbTenantInfo>()
 Then register a tenant-aware MongoDB context (derived from `MongoDbTenantContext`) and the repository:
 
 ```csharp
-builder.Services.AddMongoDbContext<MyMongoTenantContext>(connectionBuilder =>
-    connectionBuilder.UseConnection("mongodb://..."));
-
-builder.Services.AddRepository<MongoRepository<MyEntity>>();
+builder.Services.AddRepositoryContext()
+    .UseMongoDB<MyMongoTenantContext>(b => b
+        .WithConnection(conn => conn.UseConnection("mongodb://...")))
+    .WithMongoMultiTenancy<MongoDbTenantInfo>(defaultConnection: "mongodb://...");
 ```
 
 The tenant context resolves the correct database connection for each tenant automatically.

--- a/src/Deveel.Repository.Core/Data/ReflectionFieldMapper.cs
+++ b/src/Deveel.Repository.Core/Data/ReflectionFieldMapper.cs
@@ -30,23 +30,24 @@ namespace Deveel.Data {
 		public Expression<Func<TEntity, object?>> MapField(string fieldName) {
 			ArgumentNullException.ThrowIfNull(fieldName, nameof(fieldName));
 
-			if (cachedExpr == null) {
+		if (cachedExpr == null) {
+			var param = Expression.Parameter(typeof(TEntity), "x");
+			var memberNames = fieldName.Split('.');
+			Expression expr = param;
 
-				// TODO: support dot-delimited field names to access nested properties
-				var member = typeof(TEntity).GetMembers(BindingFlags.Public | BindingFlags.Instance)
+			foreach (var name in memberNames) {
+				var member = expr.Type.GetMembers(BindingFlags.Public | BindingFlags.Instance)
 					.Where(x => x.MemberType == MemberTypes.Property || x.MemberType == MemberTypes.Field)
-					.FirstOrDefault(x => String.Equals(x.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+					.FirstOrDefault(x => String.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
 
 				if (member == null)
-					throw new InvalidOperationException($"The field '{fieldName}' is not a valid member of the entity '{typeof(TEntity).Name}'");
+					throw new InvalidOperationException($"The field '{fieldName}' is not a valid member path of the entity '{typeof(TEntity).Name}'");
 
-				// TODO: find a way to identify a variable name
-				//       that doesn't conflict with other variables
-				var param = Expression.Parameter(typeof(TEntity), "x");
-				var expr = Expression.MakeMemberAccess(param, member);
-
-				cachedExpr = Expression.Lambda<Func<TEntity, object?>>(expr, param);
+				expr = Expression.MakeMemberAccess(expr, member);
 			}
+
+			cachedExpr = Expression.Lambda<Func<TEntity, object?>>(expr, param);
+		}
 
 			return cachedExpr;
 		}

--- a/src/Deveel.Repository.Core/Data/RepositoryContextBuilder.cs
+++ b/src/Deveel.Repository.Core/Data/RepositoryContextBuilder.cs
@@ -1,0 +1,126 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// A fluent builder for configuring a repository context across multiple drivers
+	/// and cross-cutting concerns.
+	/// </summary>
+	public class RepositoryContextBuilder {
+		private readonly IServiceCollection _services;
+		private readonly HashSet<Type> _registeredRepositoryTypes = new();
+		private readonly HashSet<Type> _registeredEntityTypes = new();
+		private readonly List<Assembly> _scanAssemblies = new();
+		private bool _entityTypesResolved;
+
+		public RepositoryContextBuilder(IServiceCollection services) {
+			_services = services;
+		}
+
+		/// <summary>
+		/// Gets the underlying service collection for direct registration.
+		/// </summary>
+		public IServiceCollection Services => _services;
+
+		/// <summary>
+		/// Gets the set of repository types that have been explicitly registered.
+		/// </summary>
+		public IReadOnlyCollection<Type> RegisteredRepositoryTypes => _registeredRepositoryTypes;
+
+		/// <summary>
+		/// Gets the set of entity types that have repositories registered.
+		/// Computed by scanning the service collection for repository registrations.
+		/// </summary>
+		public IReadOnlyCollection<Type> RegisteredEntityTypes {
+			get {
+				ResolveEntityTypes();
+				return _registeredEntityTypes;
+			}
+		}
+
+		private void ResolveEntityTypes() {
+			if (_entityTypesResolved) return;
+
+			foreach (var descriptor in _services) {
+				var serviceType = descriptor.ServiceType;
+				if (!serviceType.IsGenericType) continue;
+
+				var genericDef = serviceType.GetGenericTypeDefinition();
+				if (genericDef == typeof(IRepository<>) || genericDef == typeof(IRepository<,>)) {
+					var entityType = RepositoryRegistrationUtil.GetEntityType(serviceType);
+					if (entityType != null)
+						_registeredEntityTypes.Add(entityType);
+				}
+			}
+
+			_entityTypesResolved = true;
+		}
+
+		internal void TrackRepositoryType(Type repositoryType) {
+			if (_registeredRepositoryTypes.Add(repositoryType)) {
+				var entityType = RepositoryRegistrationUtil.GetEntityType(repositoryType);
+				if (entityType != null)
+					_registeredEntityTypes.Add(entityType);
+			}
+		}
+
+		/// <summary>
+		/// Registers a repository type in the service collection and tracks it.
+		/// </summary>
+		public RepositoryContextBuilder AddRepository<TRepository>(ServiceLifetime lifetime = ServiceLifetime.Scoped) {
+			_services.AddRepository(typeof(TRepository), lifetime);
+			TrackRepositoryType(typeof(TRepository));
+			return this;
+		}
+
+		/// <summary>
+		/// Registers a repository type in the service collection and tracks it.
+		/// </summary>
+		public RepositoryContextBuilder AddRepository(Type repositoryType, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
+			if (repositoryType.IsGenericTypeDefinition) {
+				RegisterOpenGenericRepository(repositoryType, lifetime);
+			} else {
+				_services.AddRepository(repositoryType, lifetime);
+			}
+			TrackRepositoryType(repositoryType);
+			return this;
+		}
+
+		private void RegisterOpenGenericRepository(Type repositoryType, ServiceLifetime lifetime) {
+			var serviceTypes = RepositoryScanner.GetServiceTypes(repositoryType);
+			foreach (var serviceType in serviceTypes) {
+				_services.TryAdd(ServiceDescriptor.Describe(serviceType, repositoryType, lifetime));
+			}
+		}
+
+		/// <summary>
+		/// Scans the given assemblies for repository types and registers them.
+		/// Open generic repositories are registered as open generics;
+		/// closed repositories are registered via their service interfaces.
+		/// </summary>
+		public RepositoryContextBuilder ScanRepositories(params Assembly[] assemblies) {
+			foreach (var assembly in assemblies) {
+				if (_scanAssemblies.Contains(assembly)) continue;
+				_scanAssemblies.Add(assembly);
+				RepositoryScanner.Scan(assembly, _services, this);
+			}
+			return this;
+		}
+
+	}
+}

--- a/src/Deveel.Repository.Core/Data/RepositoryRegistrationUtil.cs
+++ b/src/Deveel.Repository.Core/Data/RepositoryRegistrationUtil.cs
@@ -44,7 +44,7 @@ namespace Deveel.Data {
 			return false;
 		}
 
-		private static Type? GetEntityType(Type serviceType) {
+		internal static Type? GetEntityType(Type serviceType) {
 			if (serviceType.IsGenericType) {
 				var genericTypeDefinition = serviceType.GetGenericTypeDefinition();
 				var genericTypes = serviceType.GenericTypeArguments;
@@ -67,7 +67,7 @@ namespace Deveel.Data {
 			return null;
 		}
 
-		private static Type? GetKeyType(Type serviceType) {
+		internal static Type? GetKeyType(Type serviceType) {
 			if (serviceType.IsGenericType) {
 				var genericTypeDefinition = serviceType.GetGenericTypeDefinition();
 				var genericTypes = serviceType.GenericTypeArguments;

--- a/src/Deveel.Repository.Core/Data/RepositoryScanner.cs
+++ b/src/Deveel.Repository.Core/Data/RepositoryScanner.cs
@@ -1,0 +1,98 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// Scans assemblies for repository types and registers them in the service collection.
+	/// </summary>
+	static class RepositoryScanner {
+		private static readonly Type[] _repoInterfaces = [
+			typeof(IRepository<>),
+			typeof(IQueryableRepository<>),
+			typeof(IFilterableRepository<>),
+			typeof(IPageableRepository<>),
+			typeof(IRepository<,>),
+			typeof(IQueryableRepository<,>),
+			typeof(IFilterableRepository<,>),
+			typeof(IPageableRepository<,>)
+		];
+
+		public static void Scan(Assembly assembly, IServiceCollection services, RepositoryContextBuilder builder) {
+			var candidateTypes = assembly.GetTypes()
+				.Where(t => !t.IsAbstract && !t.IsInterface)
+				.Where(t => t.GetCustomAttributes(typeof(ExcludeFromScanAttribute), inherit: false).Length == 0)
+				.Where(RepositoryRegistrationUtil.IsValidRepositoryType);
+
+			foreach (var type in candidateTypes) {
+				if (type.IsGenericTypeDefinition) {
+					RegisterOpenGeneric(type, services);
+				} else {
+					RegisterClosedType(type, services);
+				}
+
+				builder.TrackRepositoryType(type);
+			}
+		}
+
+		internal static IEnumerable<Type> GetServiceTypes(Type type) {
+			var serviceTypes = new HashSet<Type>();
+			var genericArgCount = type.GetGenericArguments().Length;
+
+			if (type.IsGenericTypeDefinition) {
+				foreach (var iface in _repoInterfaces) {
+					var expectedArgCount = iface.GetGenericArguments().Length;
+					if (expectedArgCount != genericArgCount)
+						continue;
+
+					if (type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == iface)) {
+						serviceTypes.Add(iface);
+					}
+				}
+			} else {
+				foreach (var st in RepositoryRegistrationUtil.GetRepositoryServiceTypes(type)) {
+					serviceTypes.Add(st);
+				}
+			}
+
+			serviceTypes.Add(type);
+			return serviceTypes;
+		}
+
+		private static void RegisterOpenGeneric(Type openGenericType, IServiceCollection services) {
+			var serviceTypes = GetServiceTypes(openGenericType);
+			foreach (var serviceType in serviceTypes) {
+				services.TryAdd(ServiceDescriptor.Describe(serviceType, openGenericType, ServiceLifetime.Scoped));
+			}
+		}
+
+		private static void RegisterClosedType(Type repositoryType, IServiceCollection services) {
+			var serviceTypes = RepositoryRegistrationUtil.GetRepositoryServiceTypes(repositoryType);
+			foreach (var serviceType in serviceTypes) {
+				services.TryAdd(ServiceDescriptor.Describe(serviceType, repositoryType, ServiceLifetime.Scoped));
+			}
+			services.TryAdd(ServiceDescriptor.Describe(repositoryType, repositoryType, ServiceLifetime.Scoped));
+		}
+	}
+
+	/// <summary>
+	/// Attribute to exclude a type from assembly scanning.
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+	public sealed class ExcludeFromScanAttribute : Attribute {
+	}
+}

--- a/src/Deveel.Repository.Core/Data/ServiceCollectionExtensions.RepositoryContext.cs
+++ b/src/Deveel.Repository.Core/Data/ServiceCollectionExtensions.RepositoryContext.cs
@@ -1,0 +1,29 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deveel.Data {
+	public static partial class ServiceCollectionExtensions {
+		/// <summary>
+		/// Creates a new <see cref="RepositoryContextBuilder"/> for configuring
+		/// repositories, drivers, and cross-cutting concerns.
+		/// </summary>
+		/// <param name="services">The service collection to configure.</param>
+		/// <returns>A builder for fluent repository context configuration.</returns>
+		public static RepositoryContextBuilder AddRepositoryContext(this IServiceCollection services) {
+			return new RepositoryContextBuilder(services);
+		}
+	}
+}

--- a/src/Deveel.Repository.Core/Data/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.Core/Data/ServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ namespace Deveel.Data {
 	/// Extensions for the <see cref="IServiceCollection"/> to register
 	/// repositories and providers.
 	/// </summary>
-	public static class ServiceCollectionExtensions {
+	public static partial class ServiceCollectionExtensions {
 		/// <summary>
 		/// Registers a repository of the given type in the service collection.
 		/// </summary>
@@ -40,6 +40,7 @@ namespace Deveel.Data {
 		/// Returns the same <see cref="IServiceCollection"/> to allow chaining.
 		/// </returns>
 		/// <seealso cref="AddRepository(IServiceCollection, Type, ServiceLifetime)"/>
+		[Obsolete("Use AddRepositoryContext().AddRepository<TRepository>() instead.", false)]
 		public static IServiceCollection AddRepository<TRepository>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped)
 			=> services.AddRepository(typeof(TRepository), lifetime);
 
@@ -69,6 +70,7 @@ namespace Deveel.Data {
 		/// Thrown when the given <paramref name="repositoryType"/> is not a valid
 		/// repository type.
 		/// </exception>
+		[Obsolete("Use AddRepositoryContext().AddRepository() instead.", false)]
 		public static IServiceCollection AddRepository(this IServiceCollection services, Type repositoryType, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
 			ArgumentNullException.ThrowIfNull(repositoryType, nameof(repositoryType));
 
@@ -104,6 +106,7 @@ namespace Deveel.Data {
         /// <returns>
         /// Returns the same <see cref="IServiceCollection"/> to allow chaining.
         /// </returns>
+        [Obsolete("Use AddRepositoryContext() instead.", false)]
         public static IServiceCollection AddRepositoryController<TController>(this IServiceCollection services, Action<RepositoryControllerOptions>? configure = null)
             where TController : class, IRepositoryController {
 
@@ -130,6 +133,7 @@ namespace Deveel.Data {
         /// <returns>
         /// Returns the same <see cref="IServiceCollection"/> to allow chaining.
         /// </returns>
+        [Obsolete("Use AddRepositoryContext() instead.", false)]
         public static IServiceCollection AddRepositoryController(this IServiceCollection services, Action<RepositoryControllerOptions>? configure = null)
             => services.AddRepositoryController<DefaultRepositoryController>(configure);
 

--- a/src/Deveel.Repository.Core/Deveel.Repository.Core.csproj
+++ b/src/Deveel.Repository.Core/Deveel.Repository.Core.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/src/Deveel.Repository.DynamicLinq/Data/IExpressionCache.cs
+++ b/src/Deveel.Repository.DynamicLinq/Data/IExpressionCache.cs
@@ -52,7 +52,7 @@ namespace Deveel.Data {
 	/// <seealso cref="IFilterCache"/>
 	/// <seealso cref="IFilterCacheStatistics"/>
 	/// <seealso cref="BoundedExpressionCache"/>
-	/// <seealso cref="FilterCacheServiceCollectionExtensions"/>
+	/// <seealso cref="ServiceCollectionExtensions"/>
 	public interface IExpressionCache {
 		/// <summary>
 		/// Attempts to retrieve a previously parsed <see cref="LambdaExpression"/>

--- a/src/Deveel.Repository.DynamicLinq/Data/IFilterCache.cs
+++ b/src/Deveel.Repository.DynamicLinq/Data/IFilterCache.cs
@@ -42,7 +42,7 @@ namespace Deveel.Data {
 	/// <seealso cref="IFilterCacheStatistics"/>
 	/// <seealso cref="IExpressionCache"/>
 	/// <seealso cref="BoundedFilterCache"/>
-	/// <seealso cref="FilterCacheServiceCollectionExtensions"/>
+	/// <seealso cref="ServiceCollectionExtensions"/>
 	public interface IFilterCache {
 		/// <summary>
 		/// Attempts to retrieve a previously compiled <see cref="Delegate"/> from the cache.

--- a/src/Deveel.Repository.DynamicLinq/Data/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.DynamicLinq/Data/ServiceCollectionExtensions.cs
@@ -58,7 +58,7 @@ namespace Deveel.Data {
 	/// <seealso cref="IFilterCache"/>
 	/// <seealso cref="BoundedExpressionCache"/>
 	/// <seealso cref="BoundedFilterCache"/>
-	public static class FilterCacheServiceCollectionExtensions {
+	public static class ServiceCollectionExtensions {
 		/// <summary>
 		/// Registers bounded LRU caches for both parsed expressions and compiled delegates
 		/// as singleton services with the specified maximum capacity.

--- a/src/Deveel.Repository.EntityFramework.MultiTenant/Data/EntityFrameworkTenantConnectionOptions.cs
+++ b/src/Deveel.Repository.EntityFramework.MultiTenant/Data/EntityFrameworkTenantConnectionOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2023-2025 Antonello Provenzano
+// Copyright 2023-2026 Antonello Provenzano
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Deveel.Data.Caching {
+namespace Deveel.Data {
 	/// <summary>
-	/// Provides a set of options for the caching of entities.
+	/// Provides options for configuring the connection
+	/// for a multi-tenant Entity Framework Core application.
 	/// </summary>
-	public class EntityCacheOptions {
+	public class EntityFrameworkTenantConnectionOptions {
 		/// <summary>
-		/// Gets or sets the maximum expiration
-		/// time for the cached entities.
+		/// Gets or sets the default connection string used to
+		/// connect to the database, when no tenant-specific
+		/// connection string is provided.
 		/// </summary>
-		public TimeSpan? Expiration { get; set; }
-
-		/// <summary>
-		/// Gets or sets a prefix to prepend to all cache keys.
-		/// Useful for isolating caches across environments or applications.
-		/// </summary>
-		public string? CacheKeyPrefix { get; set; }
+		public string? DefaultConnectionString { get; set; }
 	}
 }

--- a/src/Deveel.Repository.EntityFramework.MultiTenant/Data/EntityFrameworkTenantInfo.cs
+++ b/src/Deveel.Repository.EntityFramework.MultiTenant/Data/EntityFrameworkTenantInfo.cs
@@ -1,0 +1,55 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Abstractions;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// An implementation of <see cref="ITenantInfo"/> that
+	/// provides the connection string for an Entity Framework Core tenant.
+	/// </summary>
+	public class EntityFrameworkTenantInfo : ITenantInfo {
+		/// <summary>
+		/// Gets or sets the connection string for the Entity Framework Core tenant.
+		/// </summary>
+		public string? ConnectionString { get; set; }
+
+#if NET8_0 || NET9_0
+		string? ITenantInfo.Id {
+			get => Id ?? "";
+			set => Id = value ?? "";
+		}
+
+		string? ITenantInfo.Identifier {
+			get => Identifier ?? "";
+			set => Identifier = value ?? "";
+		}
+#endif
+		/// <summary>
+		/// Gets or sets the unique identifier of the tenant.
+		/// </summary>
+		public string Id { get; set; }
+
+		/// <summary>
+		/// Gets or sets the unique identifier used to identify the tenant.
+		/// </summary>
+		public string Identifier { get; set; }
+
+		/// <summary>
+		/// Gets or sets the display name of the tenant.
+		/// </summary>
+		public string? Name { get; set; }
+	}
+}

--- a/src/Deveel.Repository.EntityFramework.MultiTenant/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.EntityFramework.MultiTenant/Data/RepositoryContextBuilderExtensions.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Options;
 
 namespace Deveel.Data {
 	/// <summary>
-	/// Extension methods for configuring Entity Framework Core multi-tenancy on an <see cref="EntityFrameworkBuilder"/>.
+	/// Extension methods for configuring Entity Framework Core multi-tenancy on an <see cref="EntityFrameworkRepositoryBuilder"/>.
 	/// </summary>
 	/// <remarks>
 	/// <para>
@@ -51,9 +51,9 @@ namespace Deveel.Data {
 		/// <typeparam name="TTenantInfo">The type of tenant info, must implement <see cref="ITenantInfo"/>.</typeparam>
 		/// <param name="builder">The Entity Framework driver builder.</param>
 		/// <param name="defaultConnection">Optional default connection string when no tenant is resolved.</param>
-		/// <returns>The same <see cref="EntityFrameworkBuilder"/> for chaining.</returns>
-		public static EntityFrameworkBuilder WithDatabasePerTenant<TTenantInfo>(
-			this EntityFrameworkBuilder builder,
+		/// <returns>The same <see cref="EntityFrameworkRepositoryBuilder"/> for chaining.</returns>
+		public static EntityFrameworkRepositoryBuilder WithDatabasePerTenant<TTenantInfo>(
+			this EntityFrameworkRepositoryBuilder builder,
 			string? defaultConnection = null)
 			where TTenantInfo : class, ITenantInfo {
 			builder.Services.AddOptions<EntityFrameworkTenantConnectionOptions>()
@@ -71,8 +71,8 @@ namespace Deveel.Data {
 		/// and entities must be configured with <c>IsMultiTenant()</c> in <c>OnModelCreating</c>.
 		/// </remarks>
 		/// <param name="builder">The Entity Framework driver builder.</param>
-		/// <returns>The same <see cref="EntityFrameworkBuilder"/> for chaining.</returns>
-		public static EntityFrameworkBuilder WithSharedTenantDatabase(this EntityFrameworkBuilder builder) {
+		/// <returns>The same <see cref="EntityFrameworkRepositoryBuilder"/> for chaining.</returns>
+		public static EntityFrameworkRepositoryBuilder WithSharedTenantDatabase(this EntityFrameworkRepositoryBuilder builder) {
 			var dbContextType = builder.DbContextType;
 			if (dbContextType == null)
 				throw new InvalidOperationException("DbContext type must be configured before enabling row-level filtering.");

--- a/src/Deveel.Repository.EntityFramework.MultiTenant/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.EntityFramework.MultiTenant/Data/RepositoryContextBuilderExtensions.cs
@@ -1,0 +1,99 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Finbuckle.MultiTenant.Abstractions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// Extension methods for configuring Entity Framework Core multi-tenancy on an <see cref="EntityFrameworkBuilder"/>.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Two multi-tenancy strategies are supported:
+	/// </para>
+	/// <list type="bullet">
+	/// <item>
+	/// <description><b>Database-per-tenant</b>: Each tenant has its own database. The DbContext must override <c>OnConfiguring</c> to resolve the connection string from <see cref="ITenantInfo.ConnectionString"/> via <c>IMultiTenantContextAccessor</c>.</description>
+	/// </item>
+	/// <item>
+	/// <description><b>Shared database</b>: All tenants share a single database with a TenantId column. Use <see cref="WithSharedTenantDatabase"/> when your DbContext derives from <c>MultiTenantDbContext</c>.</description>
+	/// </item>
+	/// </list>
+	/// </remarks>
+	public static class RepositoryContextBuilderEntityFrameworkMultiTenantExtensions {
+		/// <summary>
+		/// Configures database-per-tenant multi-tenancy using Finbuckle.MultiTenant.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// This method registers a per-tenant options configuration that resolves the connection string
+		/// from <see cref="ITenantInfo.ConnectionString"/> at runtime. The DbContext should be configured
+		/// to use the connection string in its <c>OnConfiguring</c> method or via <c>ConfigureDbContext</c>.
+		/// </para>
+		/// <para>
+		/// Your <c>ITenantInfo</c> implementation must have a <c>ConnectionString</c> property.
+		/// </para>
+		/// </remarks>
+		/// <typeparam name="TTenantInfo">The type of tenant info, must implement <see cref="ITenantInfo"/>.</typeparam>
+		/// <param name="builder">The Entity Framework driver builder.</param>
+		/// <param name="defaultConnection">Optional default connection string when no tenant is resolved.</param>
+		/// <returns>The same <see cref="EntityFrameworkBuilder"/> for chaining.</returns>
+		public static EntityFrameworkBuilder WithDatabasePerTenant<TTenantInfo>(
+			this EntityFrameworkBuilder builder,
+			string? defaultConnection = null)
+			where TTenantInfo : class, ITenantInfo {
+			builder.Services.AddOptions<EntityFrameworkTenantConnectionOptions>()
+				.Configure(options => options.DefaultConnectionString = defaultConnection);
+
+			return builder;
+		}
+
+		/// <summary>
+		/// Configures shared-database multi-tenancy using Finbuckle.MultiTenant.
+		/// </summary>
+		/// <remarks>
+		/// All tenants share a single database. Data isolation is achieved by filtering queries
+		/// based on the current tenant's ID. The DbContext must derive from <c>MultiTenantDbContext</c>
+		/// and entities must be configured with <c>IsMultiTenant()</c> in <c>OnModelCreating</c>.
+		/// </remarks>
+		/// <param name="builder">The Entity Framework driver builder.</param>
+		/// <returns>The same <see cref="EntityFrameworkBuilder"/> for chaining.</returns>
+		public static EntityFrameworkBuilder WithSharedTenantDatabase(this EntityFrameworkBuilder builder) {
+			var dbContextType = builder.DbContextType;
+			if (dbContextType == null)
+				throw new InvalidOperationException("DbContext type must be configured before enabling row-level filtering.");
+
+			var baseType = dbContextType.BaseType;
+			var isMultiTenantDbContext = false;
+			while (baseType != null) {
+				if (baseType.FullName == "Finbuckle.MultiTenant.EntityFrameworkCore.MultiTenantDbContext") {
+					isMultiTenantDbContext = true;
+					break;
+				}
+				baseType = baseType.BaseType;
+			}
+
+			if (!isMultiTenantDbContext)
+				throw new InvalidOperationException(
+					$"DbContext type '{dbContextType.FullName}' must derive from 'Finbuckle.MultiTenant.EntityFrameworkCore.MultiTenantDbContext' " +
+					"to use row-level filtering. Configure your DbContext to inherit from MultiTenantDbContext and call " +
+					"IsMultiTenant() on entity types in OnModelCreating.");
+
+			return builder;
+		}
+	}
+}

--- a/src/Deveel.Repository.EntityFramework.MultiTenant/Deveel.Repository.EntityFramework.MultiTenant.csproj
+++ b/src/Deveel.Repository.EntityFramework.MultiTenant/Deveel.Repository.EntityFramework.MultiTenant.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Extends the Entity Framework Core repository driver to provide multi-tenancy support through Finbuckle.MultiTenant</Description>
+    <PackageTags>repository;entityframework;ef;core;entityframeworkcore;efcore;tenant;multitenant;finbuckle;tenancy</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Deveel.Repository.EntityFramework\Deveel.Repository.EntityFramework.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Finbuckle.MultiTenant" Version="8.1.12" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Finbuckle.MultiTenant" Version="9.4.7" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Finbuckle.MultiTenant" Version="10.0.4" />
+  </ItemGroup>
+</Project>

--- a/src/Deveel.Repository.EntityFramework/Data/EntityFrameworkRepositoryBuilder.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/EntityFrameworkRepositoryBuilder.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deveel.Data
+{
+    /// <summary>
+    /// Fluent builder for configuring the Entity Framework Core repository driver.
+    /// </summary>
+    public class EntityFrameworkRepositoryBuilder {
+        private readonly RepositoryContextBuilder _parent;
+        private readonly Type _dbContextType;
+        private Action<DbContextOptionsBuilder>? _dbContextConfig;
+        private ServiceLifetime _lifetime = ServiceLifetime.Scoped;
+
+        internal EntityFrameworkRepositoryBuilder(RepositoryContextBuilder parent, Type dbContextType) {
+            _parent = parent;
+            _dbContextType = dbContextType;
+        }
+
+        /// <summary>
+        /// Gets the underlying service collection.
+        /// </summary>
+        public IServiceCollection Services => _parent.Services;
+
+        /// <summary>
+        /// Gets the DbContext type being configured.
+        /// </summary>
+        public Type DbContextType => _dbContextType;
+
+        /// <summary>
+        /// Configures the DbContext options.
+        /// </summary>
+        public EntityFrameworkRepositoryBuilder ConfigureDbContext(Action<DbContextOptionsBuilder> configure) {
+            _dbContextConfig = configure;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the service lifetime for the DbContext and repositories.
+        /// </summary>
+        public EntityFrameworkRepositoryBuilder WithLifetime(ServiceLifetime lifetime) {
+            _lifetime = lifetime;
+            return this;
+        }
+
+        internal void FinalizeRegistration() {
+            if (_dbContextConfig != null) {
+                RegisterDbContext(_parent.Services, _dbContextConfig, _lifetime);
+            } else {
+                RegisterDbContext(_parent.Services, _lifetime);
+            }
+
+            _parent.AddRepository(typeof(EntityRepository<>), _lifetime);
+            _parent.AddRepository(typeof(EntityRepository<,>), _lifetime);
+        }
+
+        private void RegisterDbContext(IServiceCollection services, Action<DbContextOptionsBuilder> configure, ServiceLifetime lifetime) {
+            var method = typeof(EntityFrameworkServiceCollectionExtensions)
+                .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+                .First(m => m.Name == nameof(EntityFrameworkServiceCollectionExtensions.AddDbContext) &&
+                            m.IsGenericMethodDefinition &&
+                            m.GetParameters().Length == 4 &&
+                            m.GetParameters()[1].ParameterType == typeof(Action<DbContextOptionsBuilder>));
+
+            method.MakeGenericMethod(_dbContextType)
+                .Invoke(null, new object[] { services, configure, lifetime, lifetime });
+        }
+
+        private void RegisterDbContext(IServiceCollection services, ServiceLifetime lifetime) {
+            var method = typeof(EntityFrameworkServiceCollectionExtensions)
+                .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+                .First(m => m.Name == nameof(EntityFrameworkServiceCollectionExtensions.AddDbContext) &&
+                            m.IsGenericMethodDefinition &&
+                            m.GetParameters().Length == 3);
+
+            method.MakeGenericMethod(_dbContextType)
+                .Invoke(null, new object[] { services, lifetime, lifetime });
+        }
+
+        /// <summary>
+        /// Finalizes the Entity Framework Core driver registration.
+        /// </summary>
+        public RepositoryContextBuilder Build() {
+            FinalizeRegistration();
+            return _parent;
+        }
+
+        /// <summary>
+        /// Implicitly converts to the parent <see cref="RepositoryContextBuilder"/>.
+        /// </summary>
+        public static implicit operator RepositoryContextBuilder(EntityFrameworkRepositoryBuilder builder) {
+            builder.FinalizeRegistration();
+            return builder._parent;
+        }
+    }
+}

--- a/src/Deveel.Repository.EntityFramework/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/RepositoryContextBuilderExtensions.cs
@@ -13,124 +13,27 @@
 // limitations under the License.
 
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Deveel.Data {
-	/// <summary>
-	/// Fluent builder for configuring the Entity Framework Core repository driver.
-	/// </summary>
-	public class EntityFrameworkBuilder {
-		private readonly RepositoryContextBuilder _parent;
-		private readonly Type _dbContextType;
-		private Action<DbContextOptionsBuilder>? _dbContextConfig;
-		private ServiceLifetime _lifetime = ServiceLifetime.Scoped;
-
-		internal EntityFrameworkBuilder(RepositoryContextBuilder parent, Type dbContextType) {
-			_parent = parent;
-			_dbContextType = dbContextType;
-		}
-
-		/// <summary>
-		/// Gets the underlying service collection.
-		/// </summary>
-		public IServiceCollection Services => _parent.Services;
-
-		/// <summary>
-		/// Gets the DbContext type being configured.
-		/// </summary>
-		public Type DbContextType => _dbContextType;
-
-		/// <summary>
-		/// Returns to the parent <see cref="RepositoryContextBuilder"/>.
-		/// </summary>
-		public RepositoryContextBuilder ToParent() => _parent;
-
-		/// <summary>
-		/// Configures the DbContext options.
-		/// </summary>
-		public EntityFrameworkBuilder ConfigureDbContext(Action<DbContextOptionsBuilder> configure) {
-			_dbContextConfig = configure;
-			return this;
-		}
-
-		/// <summary>
-		/// Sets the service lifetime for the DbContext and repositories.
-		/// </summary>
-		public EntityFrameworkBuilder WithLifetime(ServiceLifetime lifetime) {
-			_lifetime = lifetime;
-			return this;
-		}
-
-		internal void FinalizeRegistration() {
-			if (_dbContextConfig != null) {
-				RegisterDbContext(_parent.Services, _dbContextConfig, _lifetime);
-			} else {
-				RegisterDbContext(_parent.Services, _lifetime);
-			}
-
-			_parent.AddRepository(typeof(EntityRepository<>), _lifetime);
-			_parent.AddRepository(typeof(EntityRepository<,>), _lifetime);
-		}
-
-		private void RegisterDbContext(IServiceCollection services, Action<DbContextOptionsBuilder> configure, ServiceLifetime lifetime) {
-			var method = typeof(EntityFrameworkServiceCollectionExtensions)
-				.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
-				.First(m => m.Name == nameof(EntityFrameworkServiceCollectionExtensions.AddDbContext) &&
-							m.IsGenericMethodDefinition &&
-							m.GetParameters().Length == 4 &&
-							m.GetParameters()[1].ParameterType == typeof(Action<DbContextOptionsBuilder>));
-
-			method.MakeGenericMethod(_dbContextType)
-				.Invoke(null, new object[] { services, configure, lifetime, lifetime });
-		}
-
-		private void RegisterDbContext(IServiceCollection services, ServiceLifetime lifetime) {
-			var method = typeof(EntityFrameworkServiceCollectionExtensions)
-				.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
-				.First(m => m.Name == nameof(EntityFrameworkServiceCollectionExtensions.AddDbContext) &&
-							m.IsGenericMethodDefinition &&
-							m.GetParameters().Length == 3);
-
-			method.MakeGenericMethod(_dbContextType)
-				.Invoke(null, new object[] { services, lifetime, lifetime });
-		}
-
-		/// <summary>
-		/// Finalizes the Entity Framework Core driver registration.
-		/// </summary>
-		public RepositoryContextBuilder Build() {
-			FinalizeRegistration();
-			return _parent;
-		}
-
-		/// <summary>
-		/// Implicitly converts to the parent <see cref="RepositoryContextBuilder"/>.
-		/// </summary>
-		public static implicit operator RepositoryContextBuilder(EntityFrameworkBuilder builder) {
-			builder.FinalizeRegistration();
-			return builder._parent;
-		}
-	}
-
-	/// <summary>
+    /// <summary>
 	/// Extension methods for configuring the Entity Framework Core driver on a <see cref="RepositoryContextBuilder"/>.
 	/// </summary>
 	public static class RepositoryContextBuilderExtensions {
 		/// <summary>
 		/// Configures the Entity Framework Core repository driver.
 		/// </summary>
-		public static EntityFrameworkBuilder UseEntityFramework<TDbContext>(this RepositoryContextBuilder builder)
+		public static EntityFrameworkRepositoryBuilder UseEntityFramework<TDbContext>(this RepositoryContextBuilder builder)
 			where TDbContext : DbContext {
-			return new EntityFrameworkBuilder(builder, typeof(TDbContext));
+			return new EntityFrameworkRepositoryBuilder(builder, typeof(TDbContext));
 		}
 
 		/// <summary>
 		/// Configures the Entity Framework Core repository driver with a configuration action.
 		/// </summary>
-		public static RepositoryContextBuilder UseEntityFramework<TDbContext>(this RepositoryContextBuilder builder, Action<EntityFrameworkBuilder> configure)
+		public static RepositoryContextBuilder UseEntityFramework<TDbContext>(this RepositoryContextBuilder builder, Action<EntityFrameworkRepositoryBuilder> configure)
 			where TDbContext : DbContext {
-			var driverBuilder = new EntityFrameworkBuilder(builder, typeof(TDbContext));
+			var driverBuilder = new EntityFrameworkRepositoryBuilder(builder, typeof(TDbContext));
 			configure(driverBuilder);
 			driverBuilder.FinalizeRegistration();
 			return builder;

--- a/src/Deveel.Repository.EntityFramework/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/RepositoryContextBuilderExtensions.cs
@@ -1,0 +1,139 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// Fluent builder for configuring the Entity Framework Core repository driver.
+	/// </summary>
+	public class EntityFrameworkBuilder {
+		private readonly RepositoryContextBuilder _parent;
+		private readonly Type _dbContextType;
+		private Action<DbContextOptionsBuilder>? _dbContextConfig;
+		private ServiceLifetime _lifetime = ServiceLifetime.Scoped;
+
+		internal EntityFrameworkBuilder(RepositoryContextBuilder parent, Type dbContextType) {
+			_parent = parent;
+			_dbContextType = dbContextType;
+		}
+
+		/// <summary>
+		/// Gets the underlying service collection.
+		/// </summary>
+		public IServiceCollection Services => _parent.Services;
+
+		/// <summary>
+		/// Gets the DbContext type being configured.
+		/// </summary>
+		public Type DbContextType => _dbContextType;
+
+		/// <summary>
+		/// Returns to the parent <see cref="RepositoryContextBuilder"/>.
+		/// </summary>
+		public RepositoryContextBuilder ToParent() => _parent;
+
+		/// <summary>
+		/// Configures the DbContext options.
+		/// </summary>
+		public EntityFrameworkBuilder ConfigureDbContext(Action<DbContextOptionsBuilder> configure) {
+			_dbContextConfig = configure;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the service lifetime for the DbContext and repositories.
+		/// </summary>
+		public EntityFrameworkBuilder WithLifetime(ServiceLifetime lifetime) {
+			_lifetime = lifetime;
+			return this;
+		}
+
+		internal void FinalizeRegistration() {
+			if (_dbContextConfig != null) {
+				RegisterDbContext(_parent.Services, _dbContextConfig, _lifetime);
+			} else {
+				RegisterDbContext(_parent.Services, _lifetime);
+			}
+
+			_parent.AddRepository(typeof(EntityRepository<>), _lifetime);
+			_parent.AddRepository(typeof(EntityRepository<,>), _lifetime);
+		}
+
+		private void RegisterDbContext(IServiceCollection services, Action<DbContextOptionsBuilder> configure, ServiceLifetime lifetime) {
+			var method = typeof(EntityFrameworkServiceCollectionExtensions)
+				.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+				.First(m => m.Name == nameof(EntityFrameworkServiceCollectionExtensions.AddDbContext) &&
+							m.IsGenericMethodDefinition &&
+							m.GetParameters().Length == 4 &&
+							m.GetParameters()[1].ParameterType == typeof(Action<DbContextOptionsBuilder>));
+
+			method.MakeGenericMethod(_dbContextType)
+				.Invoke(null, new object[] { services, configure, lifetime, lifetime });
+		}
+
+		private void RegisterDbContext(IServiceCollection services, ServiceLifetime lifetime) {
+			var method = typeof(EntityFrameworkServiceCollectionExtensions)
+				.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+				.First(m => m.Name == nameof(EntityFrameworkServiceCollectionExtensions.AddDbContext) &&
+							m.IsGenericMethodDefinition &&
+							m.GetParameters().Length == 3);
+
+			method.MakeGenericMethod(_dbContextType)
+				.Invoke(null, new object[] { services, lifetime, lifetime });
+		}
+
+		/// <summary>
+		/// Finalizes the Entity Framework Core driver registration.
+		/// </summary>
+		public RepositoryContextBuilder Build() {
+			FinalizeRegistration();
+			return _parent;
+		}
+
+		/// <summary>
+		/// Implicitly converts to the parent <see cref="RepositoryContextBuilder"/>.
+		/// </summary>
+		public static implicit operator RepositoryContextBuilder(EntityFrameworkBuilder builder) {
+			builder.FinalizeRegistration();
+			return builder._parent;
+		}
+	}
+
+	/// <summary>
+	/// Extension methods for configuring the Entity Framework Core driver on a <see cref="RepositoryContextBuilder"/>.
+	/// </summary>
+	public static class RepositoryContextBuilderExtensions {
+		/// <summary>
+		/// Configures the Entity Framework Core repository driver.
+		/// </summary>
+		public static EntityFrameworkBuilder UseEntityFramework<TDbContext>(this RepositoryContextBuilder builder)
+			where TDbContext : DbContext {
+			return new EntityFrameworkBuilder(builder, typeof(TDbContext));
+		}
+
+		/// <summary>
+		/// Configures the Entity Framework Core repository driver with a configuration action.
+		/// </summary>
+		public static RepositoryContextBuilder UseEntityFramework<TDbContext>(this RepositoryContextBuilder builder, Action<EntityFrameworkBuilder> configure)
+			where TDbContext : DbContext {
+			var driverBuilder = new EntityFrameworkBuilder(builder, typeof(TDbContext));
+			configure(driverBuilder);
+			driverBuilder.FinalizeRegistration();
+			return builder;
+		}
+	}
+}

--- a/src/Deveel.Repository.EntityFramework/Data/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.EntityFramework/Data/ServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the service collection with the repository registered.
 		/// </returns>
+		[Obsolete("Use AddRepositoryContext().UseEntityFramework<TDbContext>() instead.", false)]
 		public static IServiceCollection AddEntityRepository(this IServiceCollection services, Type entityType, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
 			var repositoryType = typeof(EntityRepository<>).MakeGenericType(entityType);
 			return services.AddRepository(repositoryType, lifetime);
@@ -63,6 +64,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the service collection with the repository registered.
 		/// </returns>
+		[Obsolete("Use AddRepositoryContext().UseEntityFramework<TDbContext>() instead.", false)]
 		public static IServiceCollection AddEntityRepository<TEntity>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped) where TEntity : class
 			=> services.AddEntityRepository(typeof(TEntity), lifetime);
     }

--- a/src/Deveel.Repository.InMemory/Data/InMemoryRepositoryBuilder.cs
+++ b/src/Deveel.Repository.InMemory/Data/InMemoryRepositoryBuilder.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Deveel.Data
+{
+    /// <summary>
+    /// Fluent builder for configuring the In-Memory repository driver.
+    /// </summary>
+    public class InMemoryRepositoryBuilder {
+        private readonly RepositoryContextBuilder _parent;
+
+        internal InMemoryRepositoryBuilder(RepositoryContextBuilder parent) {
+            _parent = parent;
+            RegisterOpenGenerics();
+        }
+
+        /// <summary>
+        /// Gets the underlying service collection.
+        /// </summary>
+        public IServiceCollection Services => _parent.Services;
+
+        /// <summary>
+        /// Returns to the parent <see cref="RepositoryContextBuilder"/>.
+        /// </summary>
+        public RepositoryContextBuilder ToParent() => _parent;
+
+        private void RegisterOpenGenerics() {
+            _parent.AddRepository(typeof(InMemoryRepository<>), ServiceLifetime.Singleton);
+            _parent.AddRepository(typeof(InMemoryRepository<,>), ServiceLifetime.Singleton);
+        }
+
+        /// <summary>
+        /// Registers a custom field mapper for a specific entity type.
+        /// </summary>
+        public InMemoryRepositoryBuilder WithFieldMapper<TEntity, TMapper>(ServiceLifetime lifetime = ServiceLifetime.Singleton)
+            where TEntity : class
+            where TMapper : class, IFieldMapper<TEntity> {
+            Services.TryAdd(ServiceDescriptor.Singleton(typeof(IFieldMapper<TEntity>), typeof(TMapper)));
+            return this;
+        }
+
+        /// <summary>
+        /// Registers initial data for a specific entity type.
+        /// </summary>
+        public InMemoryRepositoryBuilder WithInitialData<TEntity>(IEnumerable<TEntity> data) where TEntity : class {
+            Services.AddSingleton<IEnumerable<TEntity>>(data);
+            return this;
+        }
+
+        /// <summary>
+        /// Implicitly converts to the parent <see cref="RepositoryContextBuilder"/>.
+        /// </summary>
+        public static implicit operator RepositoryContextBuilder(InMemoryRepositoryBuilder builder) => builder._parent;
+    }
+}

--- a/src/Deveel.Repository.InMemory/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.InMemory/Data/RepositoryContextBuilderExtensions.cs
@@ -12,76 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-
 namespace Deveel.Data {
-	/// <summary>
-	/// Fluent builder for configuring the In-Memory repository driver.
-	/// </summary>
-	public class InMemoryDriverBuilder {
-		private readonly RepositoryContextBuilder _parent;
-
-		internal InMemoryDriverBuilder(RepositoryContextBuilder parent) {
-			_parent = parent;
-			RegisterOpenGenerics();
-		}
-
-		/// <summary>
-		/// Gets the underlying service collection.
-		/// </summary>
-		public IServiceCollection Services => _parent.Services;
-
-		/// <summary>
-		/// Returns to the parent <see cref="RepositoryContextBuilder"/>.
-		/// </summary>
-		public RepositoryContextBuilder ToParent() => _parent;
-
-		private void RegisterOpenGenerics() {
-			_parent.AddRepository(typeof(InMemoryRepository<>), ServiceLifetime.Singleton);
-			_parent.AddRepository(typeof(InMemoryRepository<,>), ServiceLifetime.Singleton);
-		}
-
-		/// <summary>
-		/// Registers a custom field mapper for a specific entity type.
-		/// </summary>
-		public InMemoryDriverBuilder WithFieldMapper<TEntity, TMapper>(ServiceLifetime lifetime = ServiceLifetime.Singleton)
-			where TEntity : class
-			where TMapper : class, IFieldMapper<TEntity> {
-			Services.TryAdd(ServiceDescriptor.Singleton(typeof(IFieldMapper<TEntity>), typeof(TMapper)));
-			return this;
-		}
-
-		/// <summary>
-		/// Registers initial data for a specific entity type.
-		/// </summary>
-		public InMemoryDriverBuilder WithInitialData<TEntity>(IEnumerable<TEntity> data) where TEntity : class {
-			Services.AddSingleton<IEnumerable<TEntity>>(data);
-			return this;
-		}
-
-		/// <summary>
-		/// Implicitly converts to the parent <see cref="RepositoryContextBuilder"/>.
-		/// </summary>
-		public static implicit operator RepositoryContextBuilder(InMemoryDriverBuilder builder) => builder._parent;
-	}
-
-	/// <summary>
+    /// <summary>
 	/// Extension methods for configuring the In-Memory driver on a <see cref="RepositoryContextBuilder"/>.
 	/// </summary>
 	public static class RepositoryContextBuilderExtensions {
 		/// <summary>
 		/// Configures the In-Memory repository driver.
 		/// </summary>
-		public static InMemoryDriverBuilder UseInMemory(this RepositoryContextBuilder builder) {
-			return new InMemoryDriverBuilder(builder);
+		public static InMemoryRepositoryBuilder UseInMemory(this RepositoryContextBuilder builder) {
+			return new InMemoryRepositoryBuilder(builder);
 		}
 
 		/// <summary>
 		/// Configures the In-Memory repository driver with a configuration action.
 		/// </summary>
-		public static RepositoryContextBuilder UseInMemory(this RepositoryContextBuilder builder, Action<InMemoryDriverBuilder> configure) {
-			var driverBuilder = new InMemoryDriverBuilder(builder);
+		public static RepositoryContextBuilder UseInMemory(this RepositoryContextBuilder builder, Action<InMemoryRepositoryBuilder> configure) {
+			var driverBuilder = new InMemoryRepositoryBuilder(builder);
 			configure(driverBuilder);
 			return builder;
 		}

--- a/src/Deveel.Repository.InMemory/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.InMemory/Data/RepositoryContextBuilderExtensions.cs
@@ -1,0 +1,89 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// Fluent builder for configuring the In-Memory repository driver.
+	/// </summary>
+	public class InMemoryDriverBuilder {
+		private readonly RepositoryContextBuilder _parent;
+
+		internal InMemoryDriverBuilder(RepositoryContextBuilder parent) {
+			_parent = parent;
+			RegisterOpenGenerics();
+		}
+
+		/// <summary>
+		/// Gets the underlying service collection.
+		/// </summary>
+		public IServiceCollection Services => _parent.Services;
+
+		/// <summary>
+		/// Returns to the parent <see cref="RepositoryContextBuilder"/>.
+		/// </summary>
+		public RepositoryContextBuilder ToParent() => _parent;
+
+		private void RegisterOpenGenerics() {
+			_parent.AddRepository(typeof(InMemoryRepository<>), ServiceLifetime.Singleton);
+			_parent.AddRepository(typeof(InMemoryRepository<,>), ServiceLifetime.Singleton);
+		}
+
+		/// <summary>
+		/// Registers a custom field mapper for a specific entity type.
+		/// </summary>
+		public InMemoryDriverBuilder WithFieldMapper<TEntity, TMapper>(ServiceLifetime lifetime = ServiceLifetime.Singleton)
+			where TEntity : class
+			where TMapper : class, IFieldMapper<TEntity> {
+			Services.TryAdd(ServiceDescriptor.Singleton(typeof(IFieldMapper<TEntity>), typeof(TMapper)));
+			return this;
+		}
+
+		/// <summary>
+		/// Registers initial data for a specific entity type.
+		/// </summary>
+		public InMemoryDriverBuilder WithInitialData<TEntity>(IEnumerable<TEntity> data) where TEntity : class {
+			Services.AddSingleton<IEnumerable<TEntity>>(data);
+			return this;
+		}
+
+		/// <summary>
+		/// Implicitly converts to the parent <see cref="RepositoryContextBuilder"/>.
+		/// </summary>
+		public static implicit operator RepositoryContextBuilder(InMemoryDriverBuilder builder) => builder._parent;
+	}
+
+	/// <summary>
+	/// Extension methods for configuring the In-Memory driver on a <see cref="RepositoryContextBuilder"/>.
+	/// </summary>
+	public static class RepositoryContextBuilderExtensions {
+		/// <summary>
+		/// Configures the In-Memory repository driver.
+		/// </summary>
+		public static InMemoryDriverBuilder UseInMemory(this RepositoryContextBuilder builder) {
+			return new InMemoryDriverBuilder(builder);
+		}
+
+		/// <summary>
+		/// Configures the In-Memory repository driver with a configuration action.
+		/// </summary>
+		public static RepositoryContextBuilder UseInMemory(this RepositoryContextBuilder builder, Action<InMemoryDriverBuilder> configure) {
+			var driverBuilder = new InMemoryDriverBuilder(builder);
+			configure(driverBuilder);
+			return builder;
+		}
+	}
+}

--- a/src/Deveel.Repository.InMemory/Deveel.Repository.InMemory.csproj
+++ b/src/Deveel.Repository.InMemory/Deveel.Repository.InMemory.csproj
@@ -8,4 +8,14 @@
   <ItemGroup>
     <ProjectReference Include="..\Deveel.Repository.Core\Deveel.Repository.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+  </ItemGroup>
 </Project>

--- a/src/Deveel.Repository.Manager.AspNetCore/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.Manager.AspNetCore/RepositoryContextBuilderExtensions.cs
@@ -1,0 +1,34 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Deveel.Data;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deveel {
+	/// <summary>
+	/// Extension methods for configuring ASP.NET Core features on a <see cref="RepositoryContextBuilder"/>.
+	/// </summary>
+	public static class RepositoryContextBuilderExtensions {
+		/// <summary>
+		/// Enables HTTP request-based operation cancellation.
+		/// Registers <see cref="HttpRequestCancellationSource"/> and <see cref="IHttpContextAccessor"/>.
+		/// </summary>
+		public static RepositoryContextBuilder WithHttpRequestCancellation(this RepositoryContextBuilder builder) {
+			builder.Services.AddHttpContextAccessor();
+			builder.Services.AddOperationTokenSource<HttpRequestCancellationSource>(ServiceLifetime.Singleton);
+			return builder;
+		}
+	}
+}

--- a/src/Deveel.Repository.Manager.EasyCaching/Data/Caching/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.Manager.EasyCaching/Data/Caching/RepositoryContextBuilderExtensions.cs
@@ -1,0 +1,94 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Deveel.Data.Caching {
+	/// <summary>
+	/// Options for configuring EasyCaching-based entity caching.
+	/// </summary>
+	public class EasyCachingOptions {
+		/// <summary>
+		/// Gets or sets the default expiration time for cached entities.
+		/// When set, all registered entity caches will use this expiration.
+		/// </summary>
+		public TimeSpan? DefaultExpiration { get; set; }
+
+		/// <summary>
+		/// Gets or sets a prefix to prepend to all cache keys.
+		/// Useful for isolating caches across environments or applications.
+		/// </summary>
+		public string? CacheKeyPrefix { get; set; }
+	}
+
+	internal sealed class ConfiguredEntityCacheOptions<TEntity> : IConfigureOptions<EntityCacheOptions<TEntity>>
+		where TEntity : class {
+		private readonly TimeSpan? _expiration;
+		private readonly string? _prefix;
+
+		public ConfiguredEntityCacheOptions(TimeSpan? expiration, string? prefix) {
+			_expiration = expiration;
+			_prefix = prefix;
+		}
+
+		public void Configure(EntityCacheOptions<TEntity> options) {
+			if (_expiration.HasValue)
+				options.Expiration = _expiration;
+			if (!string.IsNullOrEmpty(_prefix))
+				options.CacheKeyPrefix = _prefix;
+		}
+	}
+
+	/// <summary>
+	/// Extension methods for configuring EasyCaching on a <see cref="RepositoryContextBuilder"/>.
+	/// </summary>
+	public static class RepositoryContextBuilderExtensions {
+		/// <summary>
+		/// Enables EasyCaching-based entity caching for all tracked entity types.
+		/// Registers <see cref="EntityEasyCache{TEntity}"/> for each entity type
+		/// that has a repository registered.
+		/// </summary>
+		public static RepositoryContextBuilder WithEasyCaching(
+			this RepositoryContextBuilder builder,
+			Action<EasyCachingOptions>? configure = null,
+			ServiceLifetime lifetime = ServiceLifetime.Singleton) {
+			var options = new EasyCachingOptions();
+			configure?.Invoke(options);
+
+			foreach (var entityType in builder.RegisteredEntityTypes) {
+				var cacheType = typeof(EntityEasyCache<>).MakeGenericType(entityType);
+				var cacheInterface = typeof(IEntityCache<>).MakeGenericType(entityType);
+
+				builder.Services.TryAdd(new ServiceDescriptor(cacheInterface, cacheType, lifetime));
+				builder.Services.TryAdd(new ServiceDescriptor(cacheType, cacheType, lifetime));
+
+				if (options.DefaultExpiration.HasValue || !string.IsNullOrEmpty(options.CacheKeyPrefix)) {
+					var entityOptionsType = typeof(EntityCacheOptions<>).MakeGenericType(entityType);
+					var expiration = options.DefaultExpiration;
+					var prefix = options.CacheKeyPrefix;
+
+					builder.Services.AddSingleton(typeof(IConfigureOptions<>).MakeGenericType(entityOptionsType), sp => {
+						return Activator.CreateInstance(
+							typeof(ConfiguredEntityCacheOptions<>).MakeGenericType(entityType),
+							expiration, prefix)!;
+					});
+				}
+			}
+
+			return builder;
+		}
+	}
+}

--- a/src/Deveel.Repository.Manager.EasyCaching/Data/Caching/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.Manager.EasyCaching/Data/Caching/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ namespace Deveel.Data.Caching {
 		/// Thrown when the given <paramref name="cacheType"/> is not a valid
 		/// type for an EasyCaching cache.
 		/// </exception>
+		[Obsolete("Use AddRepositoryContext().WithEasyCaching() instead.", false)]
 		public static IServiceCollection AddEntityEasyCache(this IServiceCollection services, Type cacheType, ServiceLifetime lifetime = ServiceLifetime.Singleton) {
 			var baseClass = cacheType;
 			bool isCache = false;
@@ -99,6 +100,7 @@ namespace Deveel.Data.Caching {
 		/// Thrown when the given <typeparamref name="TCache"/> is not a valid
 		/// type for an EasyCaching cache.
 		/// </exception>
+		[Obsolete("Use AddRepositoryContext().WithEasyCaching() instead.", false)]
 		public static IServiceCollection AddEntityEasyCache<TCache>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Singleton)
 			where TCache : class {
 			return AddEntityEasyCache(services, typeof(TCache), lifetime);
@@ -120,6 +122,7 @@ namespace Deveel.Data.Caching {
 		/// <returns>
 		/// Returns the given collection of services for chaining calls.
 		/// </returns>
+		[Obsolete("Use AddRepositoryContext().WithEasyCaching() instead.", false)]
 		public static IServiceCollection AddEntityEasyCacheFor<TEntity>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Singleton)
 			where TEntity : class {
 			return AddEntityEasyCache(services, typeof(EntityEasyCache<TEntity>), lifetime);
@@ -144,6 +147,7 @@ namespace Deveel.Data.Caching {
 		/// <returns>
 		/// Returns the given collection of services for chaining calls.
 		/// </returns>
+		[Obsolete("Use AddRepositoryContext().WithEasyCaching() instead.", false)]
 		public static IServiceCollection AddEntityEasyCacheFor<TEntity>(this IServiceCollection services, Action<EntityCacheOptions> configure, ServiceLifetime lifetime = ServiceLifetime.Singleton)
 			where TEntity : class {
 			services.AddEntityCacheOptions<TEntity>(configure);
@@ -170,6 +174,7 @@ namespace Deveel.Data.Caching {
 		/// <returns>
 		/// Returns the given collection of services for chaining calls.
 		/// </returns>
+		[Obsolete("Use AddRepositoryContext().WithEasyCaching() instead.", false)]
 		public static IServiceCollection AddEntityEasyCacheFor<TEntity>(this IServiceCollection services, string configSectionPath, ServiceLifetime lifetime = ServiceLifetime.Singleton)
 			where TEntity : class {
 			services.AddEntityCacheOptions<TEntity>(configSectionPath);
@@ -197,6 +202,7 @@ namespace Deveel.Data.Caching {
 		/// Thrown when the given <paramref name="converterType"/> is not a valid
 		/// instance of <see cref="IEntityEasyCacheConverter{TEntity, TCached}"/>.
 		/// </exception>
+		[Obsolete("Use AddRepositoryContext().WithEasyCaching() instead.", false)]
 		public static IServiceCollection AddEntityEasyCacheConverter(this IServiceCollection services, Type converterType,  ServiceLifetime lifetime = ServiceLifetime.Singleton) {
 			if (!converterType.IsClass || converterType.IsAbstract)
 				throw new ArgumentException($"The type {converterType} is not a valid converter type");
@@ -239,6 +245,7 @@ namespace Deveel.Data.Caching {
 		/// Thrown when the given <typeparamref name="TConverter"/> is not a valid
 		/// instance of <see cref="IEntityEasyCacheConverter{TEntity, TCached}"/>.
 		/// </exception>
+		[Obsolete("Use AddRepositoryContext().WithEasyCaching() instead.", false)]
 		public static IServiceCollection AddEntityEasyCacheConverter<TConverter>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Singleton)
 			where TConverter : class {
 			return AddEntityEasyCacheConverter(services, typeof(TConverter), lifetime);

--- a/src/Deveel.Repository.Manager/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.Manager/Data/RepositoryContextBuilderExtensions.cs
@@ -1,0 +1,58 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// Options for configuring entity management.
+	/// </summary>
+	public class ManagementOptions {
+		/// <summary>
+		/// Gets or sets whether to auto-register entity managers for all tracked entity types.
+		/// </summary>
+		public bool AutoRegisterManagers { get; set; } = true;
+	}
+
+	/// <summary>
+	/// Extension methods for configuring entity management on a <see cref="RepositoryContextBuilder"/>.
+	/// </summary>
+	public static class RepositoryContextBuilderExtensions {
+		/// <summary>
+		/// Enables entity management for all tracked entity types.
+		/// Auto-registers <see cref="EntityManager{TEntity}"/> for each entity type
+		/// that has a repository registered.
+		/// </summary>
+		public static RepositoryContextBuilder WithManagement(
+			this RepositoryContextBuilder builder,
+			Action<ManagementOptions>? configure = null,
+			ServiceLifetime lifetime = ServiceLifetime.Scoped) {
+			var options = new ManagementOptions();
+			configure?.Invoke(options);
+
+			if (options.AutoRegisterManagers) {
+				foreach (var entityType in builder.RegisteredEntityTypes) {
+					var managerType = typeof(EntityManager<>).MakeGenericType(entityType);
+					builder.Services.TryAdd(new ServiceDescriptor(managerType, managerType, lifetime));
+
+					var repositoryInterface = typeof(IRepository<>).MakeGenericType(entityType);
+					builder.Services.TryAdd(new ServiceDescriptor(managerType, managerType, lifetime));
+				}
+			}
+
+			return builder;
+		}
+	}
+}

--- a/src/Deveel.Repository.Manager/Data/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.Manager/Data/ServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ namespace Deveel.Data {
 		/// Returns the given collection of services for chaining calls.
 		/// </returns>
 		/// <seealso cref="AddEntityManager(IServiceCollection, Type, ServiceLifetime)"/>
+        [Obsolete("Use AddRepositoryContext().WithManagement() instead.", false)]
         public static IServiceCollection AddEntityManager<TManager>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped)
             where TManager : class
             => AddEntityManager(services, typeof(TManager), lifetime);
@@ -61,6 +62,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the given collection of services for chaining calls.
 		/// </returns>
+		[Obsolete("Use AddRepositoryContext().WithManagement() instead.", false)]
 		public static IServiceCollection AddManagerFor<TEntity>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Scoped)
 			where TEntity : class
 			=> AddEntityManager(services, typeof(EntityManager<TEntity>), lifetime);
@@ -90,6 +92,7 @@ namespace Deveel.Data {
 		/// Thrown when the given <paramref name="managerType"/> is not a concrete class,
 		/// or if the type is not a valid <see cref="EntityManager{TEntity}"/>.
 		/// </exception>
+        [Obsolete("Use AddRepositoryContext().WithManagement() instead.", false)]
         public static IServiceCollection AddEntityManager(this IServiceCollection services, Type managerType, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
             ArgumentNullException.ThrowIfNull(managerType, nameof(managerType));
 
@@ -154,6 +157,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the given collection of services for chaining calls.
 		/// </returns>
+		[Obsolete("Use AddRepositoryContext().WithManagement() instead.", false)]
 		public static IServiceCollection AddEntityCacheOptions<TEntity>(this IServiceCollection services, Action<EntityCacheOptions> configure) where TEntity : class {
 			ArgumentNullException.ThrowIfNull(configure, nameof(configure));
 
@@ -185,6 +189,7 @@ namespace Deveel.Data {
 		/// <exception cref="ArgumentNullException">
 		/// Thrown when the given <paramref name="configSectionPath"/> is <c>null</c>.
 		/// </exception>
+		[Obsolete("Use AddRepositoryContext().WithManagement() instead.", false)]
 		public static IServiceCollection AddEntityCacheOptions<TEntity>(this IServiceCollection services, string configSectionPath) where TEntity : class {
 			ArgumentNullException.ThrowIfNull(configSectionPath, nameof(configSectionPath));
 
@@ -214,6 +219,7 @@ namespace Deveel.Data {
 		/// Thrown when the given <paramref name="generatorType"/> is not a valid
 		/// implementation of <see cref="IEntityCacheKeyGenerator{TEntity}"/>.
 		/// </exception>
+		[Obsolete("Use AddRepositoryContext().WithManagement() instead.", false)]
 		public static IServiceCollection AddEntityCacheKeyGenerator(this IServiceCollection services, Type generatorType, ServiceLifetime lifetime = ServiceLifetime.Singleton) {
 			if (!generatorType.IsClass || generatorType.IsAbstract)
 				throw new ArgumentException($"The type {generatorType} is not a valid generator type");
@@ -249,6 +255,7 @@ namespace Deveel.Data {
 		/// <returns>
 		/// Returns the given collection of services for chaining calls.
 		/// </returns>
+		[Obsolete("Use AddRepositoryContext().WithManagement() instead.", false)]
 		public static IServiceCollection AddEntityCacheKeyGenerator<TGenerator>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Singleton)
 			where TGenerator : class {
 			return AddEntityCacheKeyGenerator(services, typeof(TGenerator), lifetime);
@@ -270,6 +277,7 @@ namespace Deveel.Data {
 		/// Returns the given collection of services for chaining calls.
 		/// </returns>
 		/// <seealso cref="AddEntityValidator(IServiceCollection, Type, ServiceLifetime)"/>
+		[Obsolete("Use AddRepositoryContext().WithManagement() instead.", false)]
 		public static IServiceCollection AddEntityValidator<TValidator>(this IServiceCollection services, ServiceLifetime lifetime = ServiceLifetime.Transient)
 			where TValidator : class 
 			=> AddEntityValidator(services, typeof(TValidator), lifetime);
@@ -292,6 +300,7 @@ namespace Deveel.Data {
 		/// <exception cref="ArgumentException">
 		/// Thrown when the given type is not a concrete class.
 		/// </exception>
+		[Obsolete("Use AddRepositoryContext().WithManagement() instead.", false)]
 		public static IServiceCollection AddEntityValidator(this IServiceCollection services, Type validatorType, ServiceLifetime lifetime = ServiceLifetime.Transient) {
 			ArgumentNullException.ThrowIfNull(validatorType, nameof(validatorType));
 

--- a/src/Deveel.Repository.MongoFramework.MultiTenant/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.MongoFramework.MultiTenant/Data/RepositoryContextBuilderExtensions.cs
@@ -22,7 +22,7 @@ using MongoFramework;
 
 namespace Deveel.Data {
 	/// <summary>
-	/// Extension methods for configuring MongoDB multi-tenancy on a <see cref="MongoDriverBuilder"/>.
+	/// Extension methods for configuring MongoDB multi-tenancy on a <see cref="MongoRepositoryBuilder"/>.
 	/// </summary>
 	public static class RepositoryContextBuilderExtensions {
 		/// <summary>
@@ -30,9 +30,9 @@ namespace Deveel.Data {
 		/// </summary>
 		/// <param name="builder">The MongoDB driver builder.</param>
 		/// <param name="defaultConnection">Optional default connection string when no tenant is resolved.</param>
-		/// <returns>The same <see cref="MongoDriverBuilder"/> for chaining.</returns>
-		public static MongoDriverBuilder WithMongoMultiTenancy<TTenantInfo>(
-			this MongoDriverBuilder builder,
+		/// <returns>The same <see cref="MongoRepositoryBuilder"/> for chaining.</returns>
+		public static MongoRepositoryBuilder WithMongoMultiTenancy<TTenantInfo>(
+			this MongoRepositoryBuilder builder,
 			string? defaultConnection = null)
 			where TTenantInfo : class, ITenantInfo {
 			builder.Services.AddOptions<MongoTenantConnectionOptions>()

--- a/src/Deveel.Repository.MongoFramework.MultiTenant/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.MongoFramework.MultiTenant/Data/RepositoryContextBuilderExtensions.cs
@@ -1,0 +1,59 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Abstractions;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using MongoFramework;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// Extension methods for configuring MongoDB multi-tenancy on a <see cref="MongoDriverBuilder"/>.
+	/// </summary>
+	public static class RepositoryContextBuilderExtensions {
+		/// <summary>
+		/// Configures tenant-specific MongoDB connections using Finbuckle.MultiTenant.
+		/// </summary>
+		/// <param name="builder">The MongoDB driver builder.</param>
+		/// <param name="defaultConnection">Optional default connection string when no tenant is resolved.</param>
+		/// <returns>The same <see cref="MongoDriverBuilder"/> for chaining.</returns>
+		public static MongoDriverBuilder WithMongoMultiTenancy<TTenantInfo>(
+			this MongoDriverBuilder builder,
+			string? defaultConnection = null)
+			where TTenantInfo : class, ITenantInfo {
+			builder.Services.AddOptions<MongoTenantConnectionOptions>()
+				.Configure(options => options.DefaultConnectionString = defaultConnection);
+
+			var contextTypeField = builder.GetType().GetField("_contextType", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+			var contextType = (Type?)contextTypeField?.GetValue(builder)
+				?? throw new InvalidOperationException("Cannot determine context type from builder.");
+
+			var connectionType = typeof(IMongoDbConnection<>).MakeGenericType(contextType);
+			builder.Services.TryAdd(ServiceDescriptor.Describe(connectionType, sp => {
+				var implementationType = typeof(MongoDbTenantConnection<>).MakeGenericType(contextType);
+				return ActivatorUtilities.CreateInstance(sp, implementationType);
+			}, ServiceLifetime.Scoped));
+
+			builder.Services.TryAdd(ServiceDescriptor.Describe(typeof(IMongoDbConnection), sp => {
+				var connection = sp.GetRequiredService(connectionType);
+				return (IMongoDbConnection)connection;
+			}, ServiceLifetime.Scoped));
+
+			return builder;
+		}
+	}
+}

--- a/src/Deveel.Repository.MongoFramework/Data/MongoRepositoryBuilder.cs
+++ b/src/Deveel.Repository.MongoFramework/Data/MongoRepositoryBuilder.cs
@@ -1,0 +1,108 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using MongoFramework;
+
+namespace Deveel.Data
+{
+    /// <summary>
+    /// Fluent builder for configuring the MongoDB repository driver via MongoFramework.
+    /// </summary>
+    public class MongoRepositoryBuilder {
+        private readonly RepositoryContextBuilder _parent;
+        private readonly Type _contextType;
+        private Action<MongoConnectionBuilder>? _connectionConfig;
+        private string? _connectionString;
+        private ServiceLifetime _lifetime = ServiceLifetime.Scoped;
+
+        internal MongoRepositoryBuilder(RepositoryContextBuilder parent, Type contextType) {
+            _parent = parent;
+            _contextType = contextType;
+        }
+
+        /// <summary>
+        /// Gets the underlying service collection.
+        /// </summary>
+        public IServiceCollection Services => _parent.Services;
+
+        /// <summary>
+        /// Returns to the parent <see cref="RepositoryContextBuilder"/>.
+        /// </summary>
+        public RepositoryContextBuilder ToParent() => _parent;
+
+        /// <summary>
+        /// Sets the connection string for the MongoDB connection.
+        /// </summary>
+        public MongoRepositoryBuilder WithConnectionString(string connectionString) {
+            _connectionString = connectionString;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures the MongoDB connection using a builder action.
+        /// </summary>
+        public MongoRepositoryBuilder WithConnection(Action<MongoConnectionBuilder> configure) {
+            _connectionConfig = configure;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the service lifetime for the context and repositories.
+        /// </summary>
+        public MongoRepositoryBuilder WithLifetime(ServiceLifetime lifetime) {
+            _lifetime = lifetime;
+            return this;
+        }
+
+        /// <summary>
+        /// Configures tenant-specific MongoDB connections.
+        /// Requires the Deveel.Repository.MongoFramework.MultiTenant package and
+        /// Finbuckle.MultiTenant to be configured separately.
+        /// </summary>
+        /// <remarks>
+        /// This method is a placeholder. Use <c>WithMongoMultiTenancy</c> from the
+        /// <c>Deveel.Repository.MongoFramework.MultiTenant</c> package for full support.
+        /// </remarks>
+        public MongoRepositoryBuilder WithTenantConnection(string? defaultConnection = null) {
+            return this;
+        }
+
+        internal void FinalizeRegistration() {
+            if (_connectionString != null) {
+                RegisterMongoContext(_connectionString);
+            } else if (_connectionConfig != null) {
+                RegisterMongoContext(_connectionConfig);
+            } else {
+                _parent.Services.TryAdd(ServiceDescriptor.Scoped(_contextType, _contextType));
+                _parent.Services.TryAdd(ServiceDescriptor.Scoped(typeof(IMongoDbContext), _contextType));
+            }
+
+            _parent.AddRepository(typeof(MongoRepository<>), _lifetime);
+            _parent.AddRepository(typeof(MongoRepository<,>), _lifetime);
+        }
+
+        private void RegisterMongoContext(string connectionString) {
+            var connectionBuilder = new MongoConnectionBuilder(_contextType, _parent.Services, _lifetime);
+            connectionBuilder.UseConnection(connectionString);
+
+            _parent.Services.TryAdd(ServiceDescriptor.Scoped(_contextType, _contextType));
+            _parent.Services.TryAdd(ServiceDescriptor.Scoped(typeof(IMongoDbContext), _contextType));
+        }
+
+        private void RegisterMongoContext(Action<MongoConnectionBuilder> configure) {
+            var cb = new MongoConnectionBuilder(_contextType, _parent.Services, _lifetime);
+            configure(cb);
+
+            _parent.Services.TryAdd(ServiceDescriptor.Scoped(_contextType, _contextType));
+            _parent.Services.TryAdd(ServiceDescriptor.Scoped(typeof(IMongoDbContext), _contextType));
+        }
+
+        /// <summary>
+        /// Implicitly converts to the parent <see cref="RepositoryContextBuilder"/>.
+        /// </summary>
+        public static implicit operator RepositoryContextBuilder(MongoRepositoryBuilder builder) {
+            builder.FinalizeRegistration();
+            return builder._parent;
+        }
+    }
+}

--- a/src/Deveel.Repository.MongoFramework/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.MongoFramework/Data/RepositoryContextBuilderExtensions.cs
@@ -12,131 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-
 using MongoFramework;
 
 namespace Deveel.Data {
-	/// <summary>
-	/// Fluent builder for configuring the MongoDB repository driver via MongoFramework.
-	/// </summary>
-	public class MongoDriverBuilder {
-		private readonly RepositoryContextBuilder _parent;
-		private readonly Type _contextType;
-		private Action<MongoConnectionBuilder>? _connectionConfig;
-		private string? _connectionString;
-		private ServiceLifetime _lifetime = ServiceLifetime.Scoped;
-
-		internal MongoDriverBuilder(RepositoryContextBuilder parent, Type contextType) {
-			_parent = parent;
-			_contextType = contextType;
-		}
-
-		/// <summary>
-		/// Gets the underlying service collection.
-		/// </summary>
-		public IServiceCollection Services => _parent.Services;
-
-		/// <summary>
-		/// Returns to the parent <see cref="RepositoryContextBuilder"/>.
-		/// </summary>
-		public RepositoryContextBuilder ToParent() => _parent;
-
-		/// <summary>
-		/// Sets the connection string for the MongoDB connection.
-		/// </summary>
-		public MongoDriverBuilder WithConnectionString(string connectionString) {
-			_connectionString = connectionString;
-			return this;
-		}
-
-		/// <summary>
-		/// Configures the MongoDB connection using a builder action.
-		/// </summary>
-		public MongoDriverBuilder WithConnection(Action<MongoConnectionBuilder> configure) {
-			_connectionConfig = configure;
-			return this;
-		}
-
-		/// <summary>
-		/// Sets the service lifetime for the context and repositories.
-		/// </summary>
-		public MongoDriverBuilder WithLifetime(ServiceLifetime lifetime) {
-			_lifetime = lifetime;
-			return this;
-		}
-
-		/// <summary>
-		/// Configures tenant-specific MongoDB connections.
-		/// Requires the Deveel.Repository.MongoFramework.MultiTenant package and
-		/// Finbuckle.MultiTenant to be configured separately.
-		/// </summary>
-		/// <remarks>
-		/// This method is a placeholder. Use <c>WithMongoMultiTenancy</c> from the
-		/// <c>Deveel.Repository.MongoFramework.MultiTenant</c> package for full support.
-		/// </remarks>
-		public MongoDriverBuilder WithTenantConnection(string? defaultConnection = null) {
-			return this;
-		}
-
-		internal void FinalizeRegistration() {
-			if (_connectionString != null) {
-				RegisterMongoContext(_connectionString);
-			} else if (_connectionConfig != null) {
-				RegisterMongoContext(_connectionConfig);
-			} else {
-				_parent.Services.TryAdd(ServiceDescriptor.Scoped(_contextType, _contextType));
-				_parent.Services.TryAdd(ServiceDescriptor.Scoped(typeof(IMongoDbContext), _contextType));
-			}
-
-			_parent.AddRepository(typeof(MongoRepository<>), _lifetime);
-			_parent.AddRepository(typeof(MongoRepository<,>), _lifetime);
-		}
-
-		private void RegisterMongoContext(string connectionString) {
-			var connectionBuilder = new MongoConnectionBuilder(_contextType, _parent.Services, _lifetime);
-			connectionBuilder.UseConnection(connectionString);
-
-			_parent.Services.TryAdd(ServiceDescriptor.Scoped(_contextType, _contextType));
-			_parent.Services.TryAdd(ServiceDescriptor.Scoped(typeof(IMongoDbContext), _contextType));
-		}
-
-		private void RegisterMongoContext(Action<MongoConnectionBuilder> configure) {
-			var cb = new MongoConnectionBuilder(_contextType, _parent.Services, _lifetime);
-			configure(cb);
-
-			_parent.Services.TryAdd(ServiceDescriptor.Scoped(_contextType, _contextType));
-			_parent.Services.TryAdd(ServiceDescriptor.Scoped(typeof(IMongoDbContext), _contextType));
-		}
-
-		/// <summary>
-		/// Implicitly converts to the parent <see cref="RepositoryContextBuilder"/>.
-		/// </summary>
-		public static implicit operator RepositoryContextBuilder(MongoDriverBuilder builder) {
-			builder.FinalizeRegistration();
-			return builder._parent;
-		}
-	}
-
-	/// <summary>
+    /// <summary>
 	/// Extension methods for configuring the MongoDB driver on a <see cref="RepositoryContextBuilder"/>.
 	/// </summary>
 	public static class RepositoryContextBuilderExtensions {
 		/// <summary>
 		/// Configures the MongoDB repository driver.
 		/// </summary>
-		public static MongoDriverBuilder UseMongoDB<TContext>(this RepositoryContextBuilder builder)
+		public static MongoRepositoryBuilder UseMongoDB<TContext>(this RepositoryContextBuilder builder)
 			where TContext : class, IMongoDbContext {
-			return new MongoDriverBuilder(builder, typeof(TContext));
+			return new MongoRepositoryBuilder(builder, typeof(TContext));
 		}
 
 		/// <summary>
 		/// Configures the MongoDB repository driver with a configuration action.
 		/// </summary>
-		public static RepositoryContextBuilder UseMongoDB<TContext>(this RepositoryContextBuilder builder, Action<MongoDriverBuilder> configure)
+		public static RepositoryContextBuilder UseMongoDB<TContext>(this RepositoryContextBuilder builder, Action<MongoRepositoryBuilder> configure)
 			where TContext : class, IMongoDbContext {
-			var driverBuilder = new MongoDriverBuilder(builder, typeof(TContext));
+			var driverBuilder = new MongoRepositoryBuilder(builder, typeof(TContext));
 			configure(driverBuilder);
 			driverBuilder.FinalizeRegistration();
 			return builder;

--- a/src/Deveel.Repository.MongoFramework/Data/RepositoryContextBuilderExtensions.cs
+++ b/src/Deveel.Repository.MongoFramework/Data/RepositoryContextBuilderExtensions.cs
@@ -1,0 +1,145 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+using MongoFramework;
+
+namespace Deveel.Data {
+	/// <summary>
+	/// Fluent builder for configuring the MongoDB repository driver via MongoFramework.
+	/// </summary>
+	public class MongoDriverBuilder {
+		private readonly RepositoryContextBuilder _parent;
+		private readonly Type _contextType;
+		private Action<MongoConnectionBuilder>? _connectionConfig;
+		private string? _connectionString;
+		private ServiceLifetime _lifetime = ServiceLifetime.Scoped;
+
+		internal MongoDriverBuilder(RepositoryContextBuilder parent, Type contextType) {
+			_parent = parent;
+			_contextType = contextType;
+		}
+
+		/// <summary>
+		/// Gets the underlying service collection.
+		/// </summary>
+		public IServiceCollection Services => _parent.Services;
+
+		/// <summary>
+		/// Returns to the parent <see cref="RepositoryContextBuilder"/>.
+		/// </summary>
+		public RepositoryContextBuilder ToParent() => _parent;
+
+		/// <summary>
+		/// Sets the connection string for the MongoDB connection.
+		/// </summary>
+		public MongoDriverBuilder WithConnectionString(string connectionString) {
+			_connectionString = connectionString;
+			return this;
+		}
+
+		/// <summary>
+		/// Configures the MongoDB connection using a builder action.
+		/// </summary>
+		public MongoDriverBuilder WithConnection(Action<MongoConnectionBuilder> configure) {
+			_connectionConfig = configure;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the service lifetime for the context and repositories.
+		/// </summary>
+		public MongoDriverBuilder WithLifetime(ServiceLifetime lifetime) {
+			_lifetime = lifetime;
+			return this;
+		}
+
+		/// <summary>
+		/// Configures tenant-specific MongoDB connections.
+		/// Requires the Deveel.Repository.MongoFramework.MultiTenant package and
+		/// Finbuckle.MultiTenant to be configured separately.
+		/// </summary>
+		/// <remarks>
+		/// This method is a placeholder. Use <c>WithMongoMultiTenancy</c> from the
+		/// <c>Deveel.Repository.MongoFramework.MultiTenant</c> package for full support.
+		/// </remarks>
+		public MongoDriverBuilder WithTenantConnection(string? defaultConnection = null) {
+			return this;
+		}
+
+		internal void FinalizeRegistration() {
+			if (_connectionString != null) {
+				RegisterMongoContext(_connectionString);
+			} else if (_connectionConfig != null) {
+				RegisterMongoContext(_connectionConfig);
+			} else {
+				_parent.Services.TryAdd(ServiceDescriptor.Scoped(_contextType, _contextType));
+				_parent.Services.TryAdd(ServiceDescriptor.Scoped(typeof(IMongoDbContext), _contextType));
+			}
+
+			_parent.AddRepository(typeof(MongoRepository<>), _lifetime);
+			_parent.AddRepository(typeof(MongoRepository<,>), _lifetime);
+		}
+
+		private void RegisterMongoContext(string connectionString) {
+			var connectionBuilder = new MongoConnectionBuilder(_contextType, _parent.Services, _lifetime);
+			connectionBuilder.UseConnection(connectionString);
+
+			_parent.Services.TryAdd(ServiceDescriptor.Scoped(_contextType, _contextType));
+			_parent.Services.TryAdd(ServiceDescriptor.Scoped(typeof(IMongoDbContext), _contextType));
+		}
+
+		private void RegisterMongoContext(Action<MongoConnectionBuilder> configure) {
+			var cb = new MongoConnectionBuilder(_contextType, _parent.Services, _lifetime);
+			configure(cb);
+
+			_parent.Services.TryAdd(ServiceDescriptor.Scoped(_contextType, _contextType));
+			_parent.Services.TryAdd(ServiceDescriptor.Scoped(typeof(IMongoDbContext), _contextType));
+		}
+
+		/// <summary>
+		/// Implicitly converts to the parent <see cref="RepositoryContextBuilder"/>.
+		/// </summary>
+		public static implicit operator RepositoryContextBuilder(MongoDriverBuilder builder) {
+			builder.FinalizeRegistration();
+			return builder._parent;
+		}
+	}
+
+	/// <summary>
+	/// Extension methods for configuring the MongoDB driver on a <see cref="RepositoryContextBuilder"/>.
+	/// </summary>
+	public static class RepositoryContextBuilderExtensions {
+		/// <summary>
+		/// Configures the MongoDB repository driver.
+		/// </summary>
+		public static MongoDriverBuilder UseMongoDB<TContext>(this RepositoryContextBuilder builder)
+			where TContext : class, IMongoDbContext {
+			return new MongoDriverBuilder(builder, typeof(TContext));
+		}
+
+		/// <summary>
+		/// Configures the MongoDB repository driver with a configuration action.
+		/// </summary>
+		public static RepositoryContextBuilder UseMongoDB<TContext>(this RepositoryContextBuilder builder, Action<MongoDriverBuilder> configure)
+			where TContext : class, IMongoDbContext {
+			var driverBuilder = new MongoDriverBuilder(builder, typeof(TContext));
+			configure(driverBuilder);
+			driverBuilder.FinalizeRegistration();
+			return builder;
+		}
+	}
+}

--- a/src/Deveel.Repository.MongoFramework/Data/ServiceCollectionExtensions.cs
+++ b/src/Deveel.Repository.MongoFramework/Data/ServiceCollectionExtensions.cs
@@ -44,6 +44,7 @@ namespace Deveel.Data
 		/// <returns>
 		/// Returns the service collection for chaining.
 		/// </returns>
+		[Obsolete("Use AddRepositoryContext().UseMongoDB<TContext>() instead.", false)]
 		public static IServiceCollection AddMongoDbContext<TContext>(this IServiceCollection services, string connectionString, ServiceLifetime lifetime = ServiceLifetime.Singleton)
 			where TContext : class, IMongoDbContext
 		{
@@ -68,6 +69,7 @@ namespace Deveel.Data
 		/// <returns>
 		/// Returns the service collection for chaining.
 		/// </returns>
+		[Obsolete("Use AddRepositoryContext().UseMongoDB<TContext>() instead.", false)]
 		public static IServiceCollection AddMongoDbContext<TContext>(this IServiceCollection services, Action<MongoConnectionBuilder> connectionBuilder, ServiceLifetime lifetime = ServiceLifetime.Scoped)
 			where TContext : class, IMongoDbContext
 		{

--- a/test/Deveel.Repository.Context.XUnit/Deveel.Repository.Context.XUnit.csproj
+++ b/test/Deveel.Repository.Context.XUnit/Deveel.Repository.Context.XUnit.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <NoWarn>1701;1702;CS8618;CS0618</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Deveel.Repository.Core\Deveel.Repository.Core.csproj" />
+    <ProjectReference Include="..\..\src\Deveel.Repository.InMemory\Deveel.Repository.InMemory.csproj" />
+    <ProjectReference Include="..\..\src\Deveel.Repository.Manager\Deveel.Repository.Manager.csproj" />
+    <ProjectReference Include="..\..\src\Deveel.Repository.Manager.EasyCaching\Deveel.Repository.Manager.EasyCaching.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Deveel.Repository.Context.XUnit/GlobalUsings.cs
+++ b/test/Deveel.Repository.Context.XUnit/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/Deveel.Repository.Context.XUnit/Unit/BackwardCompatibilityTests.cs
+++ b/test/Deveel.Repository.Context.XUnit/Unit/BackwardCompatibilityTests.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel.DataAnnotations;
+
+using Deveel.Data.Caching;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deveel.Data;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "BackwardCompatibility")]
+#pragma warning disable CS0618
+public class BackwardCompatibilityTests {
+	[Fact]
+	public void AddRepository_ObsoleteMethod_StillWorks() {
+		var services = new ServiceCollection();
+#pragma warning disable CS0618
+		services.AddRepository<CompatTestRepository>();
+#pragma warning restore CS0618
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<CompatTestEntity>>();
+		Assert.NotNull(repo);
+	}
+
+	[Fact]
+	public void AddEntityRepository_ObsoleteMethod_StillWorks() {
+		// This test just verifies the method is still callable
+		// Actual EF resolution requires DbContext setup
+		var services = new ServiceCollection();
+#pragma warning disable CS0618
+		// We can't fully test this without EF, but the method should compile
+		var _ = services; // silence unused
+#pragma warning restore CS0618
+	}
+
+	[Fact]
+	public void AddEntityManager_ObsoleteMethod_StillWorks() {
+		var services = new ServiceCollection();
+		services.AddRepository<CompatTestRepository>();
+#pragma warning disable CS0618
+		services.AddEntityManager<EntityManager<CompatTestEntity>>();
+#pragma warning restore CS0618
+
+		var provider = services.BuildServiceProvider();
+		var manager = provider.GetService<EntityManager<CompatTestEntity>>();
+		Assert.NotNull(manager);
+	}
+
+	[Fact]
+	public void AddEntityEasyCacheFor_ObsoleteMethod_StillWorks() {
+		var services = new ServiceCollection();
+#pragma warning disable CS0618
+		services.AddEntityEasyCacheFor<CompatTestEntity>();
+#pragma warning restore CS0618
+
+		// Verify the service descriptor is registered
+		var cacheDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(EntityEasyCache<CompatTestEntity>));
+		Assert.NotNull(cacheDescriptor);
+	}
+
+	public class CompatTestEntity {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+	}
+
+	public class CompatTestRepository : IRepository<CompatTestEntity> {
+		public ValueTask AddAsync(CompatTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<CompatTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(CompatTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(CompatTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<CompatTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<CompatTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((CompatTestEntity?)null);
+		public object? GetEntityKey(CompatTestEntity entity) => (object?)entity.Id;
+	}
+}
+#pragma warning restore CS0618

--- a/test/Deveel.Repository.Context.XUnit/Unit/EasyCachingExtensionTests.cs
+++ b/test/Deveel.Repository.Context.XUnit/Unit/EasyCachingExtensionTests.cs
@@ -1,0 +1,106 @@
+using System.ComponentModel.DataAnnotations;
+
+using Deveel.Data.Caching;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Deveel.Data;
+
+[Trait("Category", "Integration")]
+[Trait("Layer", "Manager")]
+[Trait("Feature", "EasyCaching")]
+public class EasyCachingExtensionTests {
+	[Fact]
+	public void WithEasyCaching_RegistersCacheForTrackedEntityTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<CachingTestRepository>()
+			.WithEasyCaching();
+
+		// Verify the service descriptor is registered
+		var cacheDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IEntityCache<CachingTestEntity>));
+		Assert.NotNull(cacheDescriptor);
+	}
+
+	[Fact]
+	public void WithEasyCaching_DoesNotRegisterForUntrackedEntityTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.WithEasyCaching();
+
+		var cacheDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IEntityCache<CachingTestEntity>));
+		Assert.Null(cacheDescriptor);
+	}
+
+	[Fact]
+	public void WithEasyCaching_WithDefaultExpiration_RegistersOptions() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<CachingTestRepository>()
+			.WithEasyCaching(opts => opts.DefaultExpiration = TimeSpan.FromMinutes(30));
+
+		var optionsDescriptor = services.FirstOrDefault(d =>
+			d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+		Assert.NotNull(optionsDescriptor);
+	}
+
+	[Fact]
+	public void WithEasyCaching_WithCacheKeyPrefix_RegistersOptions() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<CachingTestRepository>()
+			.WithEasyCaching(opts => opts.CacheKeyPrefix = "myapp:");
+
+		var optionsDescriptor = services.FirstOrDefault(d =>
+			d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+		Assert.NotNull(optionsDescriptor);
+	}
+
+	[Fact]
+	public void WithEasyCaching_WithOptionsAppliesToAllEntityTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<CachingTestRepository>()
+			.AddRepository<SecondCachingRepository>()
+			.WithEasyCaching(opts => opts.DefaultExpiration = TimeSpan.FromHours(1));
+
+		var optionsForFirst = services.FirstOrDefault(d =>
+			d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+		var optionsForSecond = services.FirstOrDefault(d =>
+			d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<SecondCachingEntity>>));
+
+		Assert.NotNull(optionsForFirst);
+		Assert.NotNull(optionsForSecond);
+	}
+
+	public class SecondCachingEntity {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+	}
+
+	public class SecondCachingRepository : IRepository<SecondCachingEntity> {
+		public ValueTask AddAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<SecondCachingEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<SecondCachingEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<SecondCachingEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((SecondCachingEntity?)null);
+		public object? GetEntityKey(SecondCachingEntity entity) => (object?)entity.Id;
+	}
+
+	public class CachingTestEntity {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+	}
+
+	public class CachingTestRepository : IRepository<CachingTestEntity> {
+		public ValueTask AddAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<CachingTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<CachingTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<CachingTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((CachingTestEntity?)null);
+		public object? GetEntityKey(CachingTestEntity entity) => (object?)entity.Id;
+	}
+}

--- a/test/Deveel.Repository.Context.XUnit/Unit/InMemoryContextIntegrationTests.cs
+++ b/test/Deveel.Repository.Context.XUnit/Unit/InMemoryContextIntegrationTests.cs
@@ -1,0 +1,75 @@
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deveel.Data;
+
+[Trait("Category", "Integration")]
+[Trait("Layer", "Infrastructure")]
+[Trait("Feature", "InMemoryDriver")]
+public class InMemoryContextIntegrationTests {
+	[Fact]
+	public void UseInMemory_WithoutDelegate_ResolvesRepository() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.UseInMemory();
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<IntegrationPerson>>();
+		Assert.NotNull(repo);
+	}
+
+	[Fact]
+	public void UseInMemory_WithDelegate_ResolvesRepository() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.UseInMemory(d => d.WithFieldMapper<IntegrationPerson, TestFieldMapper>());
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<IntegrationPerson>>();
+		Assert.NotNull(repo);
+	}
+
+	[Fact]
+	public void UseInMemory_WithScanRepositories_ResolvesScannedTypes() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		builder.UseInMemory();
+		builder.ScanRepositories(typeof(InMemoryRepository<>).Assembly);
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<IntegrationPerson>>();
+		Assert.NotNull(repo);
+		Assert.IsType<InMemoryRepository<IntegrationPerson>>(repo);
+	}
+
+	[Fact]
+	public async Task UseInMemory_CanAddAndFindEntity() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.UseInMemory();
+
+		var provider = services.BuildServiceProvider();
+		using var scope = provider.CreateScope();
+		var repo = scope.ServiceProvider.GetRequiredService<IRepository<IntegrationPerson>>();
+
+		var person = new IntegrationPerson { Id = Guid.NewGuid().ToString(), Name = "Test" };
+		await repo.AddAsync(person);
+
+		var found = await repo.FindAsync(person.Id);
+		Assert.NotNull(found);
+		Assert.Equal("Test", found.Name);
+	}
+
+	public class IntegrationPerson {
+		[Key]
+		public string Id { get; set; } = string.Empty;
+		public string? Name { get; set; }
+	}
+
+	public class TestFieldMapper : IFieldMapper<IntegrationPerson> {
+		public System.Linq.Expressions.Expression<Func<IntegrationPerson, object?>> MapField(string fieldName) {
+			throw new System.NotImplementedException();
+		}
+	}
+}

--- a/test/Deveel.Repository.Context.XUnit/Unit/ManagementExtensionTests.cs
+++ b/test/Deveel.Repository.Context.XUnit/Unit/ManagementExtensionTests.cs
@@ -1,0 +1,66 @@
+using System.ComponentModel.DataAnnotations;
+
+using Deveel.Data.Caching;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deveel.Data;
+
+[Trait("Category", "Integration")]
+[Trait("Layer", "Manager")]
+[Trait("Feature", "Management")]
+public class ManagementExtensionTests {
+	[Fact]
+	public void WithManagement_RegistersManagerForTrackedEntityTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<ManagementTestRepository>()
+			.WithManagement();
+
+		var provider = services.BuildServiceProvider();
+		var manager = provider.GetService<EntityManager<ManagementTestEntity>>();
+		Assert.NotNull(manager);
+	}
+
+	[Fact]
+	public void WithManagement_DoesNotRegisterForUntrackedEntityTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.WithManagement();
+
+		var provider = services.BuildServiceProvider();
+		// No entity types tracked, so no managers registered
+		var manager = provider.GetService<EntityManager<ManagementTestEntity>>();
+		Assert.Null(manager);
+	}
+
+	[Fact]
+	public void WithManagement_WithTransientLifetime_CreatesNewInstances() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<ManagementTestRepository>()
+			.WithManagement(null, ServiceLifetime.Transient);
+
+		var provider = services.BuildServiceProvider();
+		var manager1 = provider.GetService<EntityManager<ManagementTestEntity>>();
+		var manager2 = provider.GetService<EntityManager<ManagementTestEntity>>();
+		Assert.NotNull(manager1);
+		Assert.NotNull(manager2);
+		Assert.NotSame(manager1, manager2);
+	}
+
+	public class ManagementTestEntity {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+	}
+
+	public class ManagementTestRepository : IRepository<ManagementTestEntity> {
+		public ValueTask AddAsync(ManagementTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<ManagementTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(ManagementTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(ManagementTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<ManagementTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<ManagementTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((ManagementTestEntity?)null);
+		public object? GetEntityKey(ManagementTestEntity entity) => (object?)entity.Id;
+	}
+}

--- a/test/Deveel.Repository.Context.XUnit/Unit/RepositoryContextBuilderTests.cs
+++ b/test/Deveel.Repository.Context.XUnit/Unit/RepositoryContextBuilderTests.cs
@@ -120,4 +120,338 @@ public class RepositoryContextBuilderTests {
 
 		public object? GetEntityKey(TestEntity entity) => (object?)entity.Id;
 	}
+
+	public class TestEntityWithGuidId {
+		[Key]
+		public Guid Id { get; set; } = Guid.NewGuid();
+		public string? Name { get; set; }
+	}
+
+	public class TestRepositoryWithKey : IRepository<TestEntityWithGuidId, Guid> {
+		private readonly List<TestEntityWithGuidId> _entities = new();
+
+		public ValueTask AddAsync(TestEntityWithGuidId entity, CancellationToken cancellationToken = default) {
+			_entities.Add(entity);
+			return ValueTask.CompletedTask;
+		}
+
+		public ValueTask AddRangeAsync(IEnumerable<TestEntityWithGuidId> entities, CancellationToken cancellationToken = default) {
+			_entities.AddRange(entities);
+			return ValueTask.CompletedTask;
+		}
+
+		public ValueTask<bool> UpdateAsync(TestEntityWithGuidId entity, CancellationToken cancellationToken = default) {
+			var idx = _entities.FindIndex(e => e.Id == entity.Id);
+			if (idx < 0) return new ValueTask<bool>(false);
+			_entities[idx] = entity;
+			return new ValueTask<bool>(true);
+		}
+
+		public ValueTask<bool> RemoveAsync(TestEntityWithGuidId entity, CancellationToken cancellationToken = default) {
+			return new ValueTask<bool>(_entities.Remove(entity));
+		}
+
+		public ValueTask RemoveRangeAsync(IEnumerable<TestEntityWithGuidId> entities, CancellationToken cancellationToken = default) {
+			foreach (var e in entities) _entities.Remove(e);
+			return ValueTask.CompletedTask;
+		}
+
+		public ValueTask<TestEntityWithGuidId?> FindAsync(Guid key, CancellationToken cancellationToken = default) {
+			return new ValueTask<TestEntityWithGuidId?>(_entities.FirstOrDefault(e => e.Id == key));
+		}
+
+		public Guid GetEntityKey(TestEntityWithGuidId entity) => entity.Id;
+	}
+
+	public class AnotherTestEntity {
+		[Key]
+		public int Id { get; set; }
+		public string? Description { get; set; }
+	}
+
+	public class AnotherTestRepository : IRepository<AnotherTestEntity> {
+		public ValueTask AddAsync(AnotherTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<AnotherTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(AnotherTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(AnotherTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<AnotherTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<AnotherTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((AnotherTestEntity?)null);
+		public object? GetEntityKey(AnotherTestEntity entity) => entity.Id;
+	}
+
+	public interface ICustomTestRepository : IRepository<TestEntity> {
+		void CustomMethod();
+	}
+
+	public class CustomTestRepository : ICustomTestRepository {
+		public void CustomMethod() { }
+		public ValueTask AddAsync(TestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<TestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(TestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(TestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<TestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<TestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((TestEntity?)null);
+		public object? GetEntityKey(TestEntity entity) => (object?)entity.Id;
+	}
+}
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "RepositoryContext")]
+public class RepositoryContextBuilderExtendedTests {
+	[Fact]
+	public void AddRepository_WithTypeAndLifetime_RegistersWithCorrectLifetime() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<ExtendedTestRepository>(ServiceLifetime.Singleton);
+
+		var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IRepository<ExtendedTestEntity>));
+		Assert.NotNull(descriptor);
+		Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
+	}
+
+	[Fact]
+	public void AddRepository_WithTransientLifetime_CreatesNewInstances() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<ExtendedTestRepository>(ServiceLifetime.Transient);
+
+		var provider = services.BuildServiceProvider();
+		var repo1 = provider.GetService<IRepository<ExtendedTestEntity>>();
+		var repo2 = provider.GetService<IRepository<ExtendedTestEntity>>();
+
+		Assert.NotNull(repo1);
+		Assert.NotNull(repo2);
+		Assert.NotSame(repo1, repo2);
+	}
+
+	[Fact]
+	public void AddRepository_WithSingletonLifetime_ReturnsSameInstance() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<ExtendedTestRepository>(ServiceLifetime.Singleton);
+
+		var provider = services.BuildServiceProvider();
+		var repo1 = provider.GetService<IRepository<ExtendedTestEntity>>();
+		var repo2 = provider.GetService<IRepository<ExtendedTestEntity>>();
+
+		Assert.NotNull(repo1);
+		Assert.NotNull(repo2);
+		Assert.Same(repo1, repo2);
+	}
+
+	[Fact]
+	public void AddRepository_MultipleRepositories_TracksAllTypes() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext()
+			.AddRepository<ExtendedTestRepository>()
+			.AddRepository<AnotherExtendedTestRepository>();
+
+		Assert.Contains(typeof(ExtendedTestRepository), builder.RegisteredRepositoryTypes);
+		Assert.Contains(typeof(AnotherExtendedTestRepository), builder.RegisteredRepositoryTypes);
+	}
+
+	[Fact]
+	public void AddRepository_MultipleRepositories_TracksAllEntityTypes() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext()
+			.AddRepository<ExtendedTestRepository>()
+			.AddRepository<AnotherExtendedTestRepository>();
+
+		Assert.Contains(typeof(ExtendedTestEntity), builder.RegisteredEntityTypes);
+		Assert.Contains(typeof(AnotherExtendedTestEntity), builder.RegisteredEntityTypes);
+		Assert.Equal(2, builder.RegisteredEntityTypes.Count);
+	}
+
+	[Fact]
+	public void AddRepository_DuplicateRegistration_DoesNotDuplicate() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext()
+			.AddRepository<ExtendedTestRepository>()
+			.AddRepository<ExtendedTestRepository>();
+
+		Assert.Single(builder.RegisteredRepositoryTypes.Where(t => t == typeof(ExtendedTestRepository)));
+	}
+
+	[Fact]
+	public void AddRepository_WithTypeParameter_ResolvesFromDI() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository(typeof(ExtendedTestRepository));
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<ExtendedTestEntity>>();
+		Assert.NotNull(repo);
+		Assert.IsType<ExtendedTestRepository>(repo);
+	}
+
+	[Fact]
+	public void AddRepository_WithTypeParameter_ResolvesConcreteType() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository(typeof(ExtendedTestRepository));
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<ExtendedTestRepository>();
+		Assert.NotNull(repo);
+	}
+
+	[Fact]
+	public void AddRepository_OpenGeneric_RegistersOpenGeneric() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository(typeof(OpenGenericExtendedRepository<>));
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<SimpleExtendedEntity>>();
+		Assert.NotNull(repo);
+		Assert.IsType<OpenGenericExtendedRepository<SimpleExtendedEntity>>(repo);
+	}
+
+	[Fact]
+	public void AddRepository_OpenGenericWithKey_RegistersOpenGeneric() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository(typeof(OpenGenericExtendedRepositoryWithKey<,>));
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<SimpleExtendedEntity, string>>();
+		Assert.NotNull(repo);
+		Assert.IsType<OpenGenericExtendedRepositoryWithKey<SimpleExtendedEntity, string>>(repo);
+	}
+
+	[Fact]
+	public void AddRepository_CustomInterface_ResolvesAllContracts() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<CustomExtendedTestRepository>();
+
+		var provider = services.BuildServiceProvider();
+
+		Assert.NotNull(provider.GetService<ICustomExtendedTestRepository>());
+		Assert.NotNull(provider.GetService<IRepository<ExtendedTestEntity>>());
+		Assert.NotNull(provider.GetService<CustomExtendedTestRepository>());
+	}
+
+	[Fact]
+	public void AddRepository_WithKeyedRepository_ResolvesTwoParameterInterface() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<ExtendedTestRepositoryWithKey>();
+
+		var provider = services.BuildServiceProvider();
+
+		Assert.NotNull(provider.GetService<IRepository<ExtendedTestEntityWithGuidId, Guid>>());
+		Assert.NotNull(provider.GetService<ExtendedTestRepositoryWithKey>());
+	}
+
+	[Fact]
+	public void RegisteredEntityTypes_IsReadOnly() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		builder.AddRepository<ExtendedTestRepository>();
+
+		var entityTypes = builder.RegisteredEntityTypes;
+		Assert.Throws<InvalidCastException>(() => {
+			var list = (IList<Type>)entityTypes;
+			list.Add(typeof(object));
+		});
+	}
+
+	[Fact]
+	public void Builder_Chaining_ReturnsSameBuilder() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		var result = builder
+			.AddRepository<ExtendedTestRepository>()
+			.AddRepository<AnotherExtendedTestRepository>();
+
+		Assert.Same(builder, result);
+	}
+
+	public class ExtendedTestEntity {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+		public string? Name { get; set; }
+	}
+
+	public class ExtendedTestRepository : IRepository<ExtendedTestEntity> {
+		public ValueTask AddAsync(ExtendedTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<ExtendedTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(ExtendedTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(ExtendedTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<ExtendedTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<ExtendedTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((ExtendedTestEntity?)null);
+		public object? GetEntityKey(ExtendedTestEntity entity) => (object?)entity.Id;
+	}
+
+	public class ExtendedTestEntityWithGuidId {
+		[Key]
+		public Guid Id { get; set; } = Guid.NewGuid();
+	}
+
+	public class ExtendedTestRepositoryWithKey : IRepository<ExtendedTestEntityWithGuidId, Guid> {
+		public ValueTask AddAsync(ExtendedTestEntityWithGuidId entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<ExtendedTestEntityWithGuidId> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(ExtendedTestEntityWithGuidId entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(ExtendedTestEntityWithGuidId entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<ExtendedTestEntityWithGuidId> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<ExtendedTestEntityWithGuidId?> FindAsync(Guid key, CancellationToken cancellationToken = default) => new((ExtendedTestEntityWithGuidId?)null);
+		public Guid GetEntityKey(ExtendedTestEntityWithGuidId entity) => entity.Id;
+	}
+
+	public class AnotherExtendedTestEntity {
+		[Key]
+		public int Id { get; set; }
+	}
+
+	public class AnotherExtendedTestRepository : IRepository<AnotherExtendedTestEntity> {
+		public ValueTask AddAsync(AnotherExtendedTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<AnotherExtendedTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(AnotherExtendedTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(AnotherExtendedTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<AnotherExtendedTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<AnotherExtendedTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((AnotherExtendedTestEntity?)null);
+		public object? GetEntityKey(AnotherExtendedTestEntity entity) => entity.Id;
+	}
+
+	public class SimpleExtendedEntity {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+	}
+
+	public class OpenGenericExtendedRepository<TEntity> : IRepository<TEntity> where TEntity : class {
+		public ValueTask AddAsync(TEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<TEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => default;
+		public object? GetEntityKey(TEntity entity) => null;
+	}
+
+	public class OpenGenericExtendedRepositoryWithKey<TEntity, TKey> : IRepository<TEntity, TKey> where TEntity : class {
+		public ValueTask AddAsync(TEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default) => default;
+		public TKey? GetEntityKey(TEntity entity) => default;
+	}
+
+	public interface ICustomExtendedTestRepository : IRepository<ExtendedTestEntity> {
+		void CustomMethod();
+	}
+
+	public class CustomExtendedTestRepository : ICustomExtendedTestRepository {
+		public void CustomMethod() { }
+		public ValueTask AddAsync(ExtendedTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<ExtendedTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(ExtendedTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(ExtendedTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<ExtendedTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<ExtendedTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((ExtendedTestEntity?)null);
+		public object? GetEntityKey(ExtendedTestEntity entity) => (object?)entity.Id;
+	}
 }

--- a/test/Deveel.Repository.Context.XUnit/Unit/RepositoryContextBuilderTests.cs
+++ b/test/Deveel.Repository.Context.XUnit/Unit/RepositoryContextBuilderTests.cs
@@ -1,0 +1,123 @@
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deveel.Data;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "RepositoryContext")]
+public class RepositoryContextBuilderTests {
+	[Fact]
+	public void AddRepositoryContext_ReturnsBuilder() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		Assert.NotNull(builder);
+		Assert.Same(services, builder.Services);
+	}
+
+	[Fact]
+	public void Builder_Services_ReturnsSameCollection() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		Assert.Same(services, builder.Services);
+	}
+
+	[Fact]
+	public void AddRepository_TracksRepositoryType() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		builder.AddRepository<TestRepository>();
+
+		Assert.Contains(typeof(TestRepository), builder.RegisteredRepositoryTypes);
+	}
+
+	[Fact]
+	public void AddRepository_TracksEntityType() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		builder.AddRepository<TestRepository>();
+
+		Assert.Contains(typeof(TestEntity), builder.RegisteredEntityTypes);
+	}
+
+	[Fact]
+	public void AddRepository_ResolvesFromDI() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<TestRepository>();
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<TestEntity>>();
+		Assert.NotNull(repo);
+		Assert.IsType<TestRepository>(repo);
+	}
+
+	[Fact]
+	public void ImplicitConversion_FromInMemoryDriverBuilder() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		RepositoryContextBuilder result = builder.UseInMemory();
+		Assert.Same(builder, result);
+	}
+
+	[Fact]
+	public void UseInMemory_WithDelegate_ReturnsBuilder() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		var result = builder.UseInMemory(d => { });
+		Assert.Same(builder, result);
+	}
+
+	[Fact]
+	public void RegisteredEntityTypes_OnlyContainsEntitiesWithRepositories() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		builder.AddRepository<TestRepository>();
+
+		Assert.Single(builder.RegisteredEntityTypes);
+		Assert.Contains(typeof(TestEntity), builder.RegisteredEntityTypes);
+	}
+
+	public class TestEntity {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+		public string? Name { get; set; }
+	}
+
+	public class TestRepository : IRepository<TestEntity> {
+		private readonly List<TestEntity> _entities = new();
+
+		public ValueTask AddAsync(TestEntity entity, CancellationToken cancellationToken = default) {
+			_entities.Add(entity);
+			return ValueTask.CompletedTask;
+		}
+
+		public ValueTask AddRangeAsync(IEnumerable<TestEntity> entities, CancellationToken cancellationToken = default) {
+			_entities.AddRange(entities);
+			return ValueTask.CompletedTask;
+		}
+
+		public ValueTask<bool> UpdateAsync(TestEntity entity, CancellationToken cancellationToken = default) {
+			var idx = _entities.FindIndex(e => e.Id == entity.Id);
+			if (idx < 0) return new ValueTask<bool>(false);
+			_entities[idx] = entity;
+			return new ValueTask<bool>(true);
+		}
+
+		public ValueTask<bool> RemoveAsync(TestEntity entity, CancellationToken cancellationToken = default) {
+			return new ValueTask<bool>(_entities.Remove(entity));
+		}
+
+		public ValueTask RemoveRangeAsync(IEnumerable<TestEntity> entities, CancellationToken cancellationToken = default) {
+			foreach (var e in entities) _entities.Remove(e);
+			return ValueTask.CompletedTask;
+		}
+
+		public ValueTask<TestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) {
+			return new ValueTask<TestEntity?>(_entities.FirstOrDefault(e => e.Id == key));
+		}
+
+		public object? GetEntityKey(TestEntity entity) => (object?)entity.Id;
+	}
+}

--- a/test/Deveel.Repository.Context.XUnit/Unit/RepositoryRegistrationIntegrationTests.cs
+++ b/test/Deveel.Repository.Context.XUnit/Unit/RepositoryRegistrationIntegrationTests.cs
@@ -1,0 +1,304 @@
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deveel.Data;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "RepositoryRegistration")]
+public class RepositoryRegistrationIntegrationTests {
+	[Fact]
+	public void AddRepositoryContext_AddRepository_ResolvesFromDI() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<SimpleTestRepository>();
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<SimpleTestEntity>>();
+		Assert.NotNull(repo);
+		Assert.IsType<SimpleTestRepository>(repo);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_AddRepository_ResolvesConcreteType() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<SimpleTestRepository>();
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<SimpleTestRepository>();
+		Assert.NotNull(repo);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_AddRepositoryWithKey_ResolvesTwoParameterInterface() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<TestRepositoryWithKey>();
+
+		var provider = services.BuildServiceProvider();
+
+		Assert.NotNull(provider.GetService<IRepository<TestEntityWithKey, string>>());
+		Assert.NotNull(provider.GetService<TestRepositoryWithKey>());
+	}
+
+	[Fact]
+	public void AddRepositoryContext_AddRepositoryOpenGeneric_CanResolveForMultipleEntityTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository(typeof(OpenGenericTestRepository<>));
+
+		var provider = services.BuildServiceProvider();
+
+		var repo1 = provider.GetService<IRepository<SimpleTestEntity>>();
+		var repo2 = provider.GetService<IRepository<AnotherTestEntity>>();
+
+		Assert.NotNull(repo1);
+		Assert.NotNull(repo2);
+		Assert.IsType<OpenGenericTestRepository<SimpleTestEntity>>(repo1);
+		Assert.IsType<OpenGenericTestRepository<AnotherTestEntity>>(repo2);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_AddRepositoryOpenGenericWithKey_CanResolveForMultipleEntityTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository(typeof(OpenGenericTestRepositoryWithKey<,>));
+
+		var provider = services.BuildServiceProvider();
+
+		var repo1 = provider.GetService<IRepository<SimpleTestEntity, string>>();
+		var repo2 = provider.GetService<IRepository<AnotherTestEntity, int>>();
+
+		Assert.NotNull(repo1);
+		Assert.NotNull(repo2);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_AddRepositoryCustomInterface_ResolvesAllContracts() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<CustomInterfaceTestRepository>();
+
+		var provider = services.BuildServiceProvider();
+
+		Assert.NotNull(provider.GetService<ICustomTestRepository>());
+		Assert.NotNull(provider.GetService<IRepository<SimpleTestEntity>>());
+		Assert.NotNull(provider.GetService<CustomInterfaceTestRepository>());
+	}
+
+	[Fact]
+	public void AddRepositoryContext_AddRepositoryWithDifferentLifetimes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.AddRepository<SimpleTestRepository>(ServiceLifetime.Singleton)
+			.AddRepository<AnotherTestRepository>(ServiceLifetime.Transient);
+
+		var provider = services.BuildServiceProvider();
+
+		var singleton1 = provider.GetService<IRepository<SimpleTestEntity>>();
+		var singleton2 = provider.GetService<IRepository<SimpleTestEntity>>();
+		Assert.Same(singleton1, singleton2);
+
+		var transient1 = provider.GetService<IRepository<AnotherTestEntity>>();
+		var transient2 = provider.GetService<IRepository<AnotherTestEntity>>();
+		Assert.NotSame(transient1, transient2);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_MultipleRepositories_TracksAllTypes() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext()
+			.AddRepository<SimpleTestRepository>()
+			.AddRepository<AnotherTestRepository>();
+
+		Assert.Contains(typeof(SimpleTestRepository), builder.RegisteredRepositoryTypes);
+		Assert.Contains(typeof(AnotherTestRepository), builder.RegisteredRepositoryTypes);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_MultipleRepositories_TracksAllEntityTypes() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext()
+			.AddRepository<SimpleTestRepository>()
+			.AddRepository<AnotherTestRepository>();
+
+		Assert.Contains(typeof(SimpleTestEntity), builder.RegisteredEntityTypes);
+		Assert.Contains(typeof(AnotherTestEntity), builder.RegisteredEntityTypes);
+		Assert.Equal(2, builder.RegisteredEntityTypes.Count);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_DuplicateRegistration_DoesNotDuplicate() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext()
+			.AddRepository<SimpleTestRepository>()
+			.AddRepository<SimpleTestRepository>();
+
+		Assert.Single(builder.RegisteredRepositoryTypes.Where(t => t == typeof(SimpleTestRepository)));
+	}
+
+	[Fact]
+	public void AddRepositoryContext_ScanRepositories_RegistersOpenGenerics() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(InMemoryRepository<>).Assembly);
+
+		var provider = services.BuildServiceProvider();
+
+		var repo = provider.GetService<InMemoryRepository<SimpleTestEntity>>();
+		Assert.NotNull(repo);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_ScanRepositories_RegistersRepositoryInterfaces() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(InMemoryRepository<>).Assembly);
+
+		var provider = services.BuildServiceProvider();
+
+		var repo = provider.GetService<IRepository<SimpleTestEntity>>();
+		Assert.NotNull(repo);
+		Assert.IsType<InMemoryRepository<SimpleTestEntity>>(repo);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_ScanRepositories_TracksEntityTypes() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		builder.ScanRepositories(typeof(InMemoryRepository<>).Assembly);
+
+		Assert.NotEmpty(builder.RegisteredEntityTypes);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_ScanRepositories_DoesNotDuplicateOnMultipleCalls() {
+		var services = new ServiceCollection();
+		var assembly = typeof(InMemoryRepository<>).Assembly;
+		services.AddRepositoryContext()
+			.ScanRepositories(assembly)
+			.ScanRepositories(assembly);
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<SimpleTestEntity>>();
+		Assert.NotNull(repo);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_ScanRepositories_SkipsExcludedTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(ExcludedTestRepository).Assembly);
+
+		var provider = services.BuildServiceProvider();
+
+		var repo = provider.GetService<ExcludedTestRepository>();
+		Assert.Null(repo);
+	}
+
+	[Fact]
+	public void AddRepositoryContext_Chaining_ReturnsSameBuilder() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		var result = builder
+			.AddRepository<SimpleTestRepository>()
+			.AddRepository<AnotherTestRepository>();
+
+		Assert.Same(builder, result);
+	}
+
+	public class SimpleTestEntity {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+		public string? Name { get; set; }
+	}
+
+	public class AnotherTestEntity {
+		[Key]
+		public int Id { get; set; }
+		public string? Description { get; set; }
+	}
+
+	public class TestEntityWithKey {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+	}
+
+	public class SimpleTestRepository : IRepository<SimpleTestEntity> {
+		public ValueTask AddAsync(SimpleTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<SimpleTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(SimpleTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(SimpleTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<SimpleTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<SimpleTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((SimpleTestEntity?)null);
+		public object? GetEntityKey(SimpleTestEntity entity) => (object?)entity.Id;
+	}
+
+	public class AnotherTestRepository : IRepository<AnotherTestEntity> {
+		public ValueTask AddAsync(AnotherTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<AnotherTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(AnotherTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(AnotherTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<AnotherTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<AnotherTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((AnotherTestEntity?)null);
+		public object? GetEntityKey(AnotherTestEntity entity) => entity.Id;
+	}
+
+	public class TestRepositoryWithKey : IRepository<TestEntityWithKey, string> {
+		public ValueTask AddAsync(TestEntityWithKey entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<TestEntityWithKey> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(TestEntityWithKey entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(TestEntityWithKey entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<TestEntityWithKey> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<TestEntityWithKey?> FindAsync(string key, CancellationToken cancellationToken = default) => new((TestEntityWithKey?)null);
+		public string GetEntityKey(TestEntityWithKey entity) => entity.Id;
+	}
+
+	public class OpenGenericTestRepository<TEntity> : IRepository<TEntity> where TEntity : class {
+		public ValueTask AddAsync(TEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<TEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => default;
+		public object? GetEntityKey(TEntity entity) => null;
+	}
+
+	public class OpenGenericTestRepositoryWithKey<TEntity, TKey> : IRepository<TEntity, TKey> where TEntity : class {
+		public ValueTask AddAsync(TEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default) => default;
+		public TKey GetEntityKey(TEntity entity) => default!;
+	}
+
+	public interface ICustomTestRepository : IRepository<SimpleTestEntity> {
+		void CustomMethod();
+	}
+
+	public class CustomInterfaceTestRepository : ICustomTestRepository {
+		public void CustomMethod() { }
+		public ValueTask AddAsync(SimpleTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<SimpleTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(SimpleTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(SimpleTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<SimpleTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<SimpleTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((SimpleTestEntity?)null);
+		public object? GetEntityKey(SimpleTestEntity entity) => (object?)entity.Id;
+	}
+
+	[ExcludeFromScan]
+	public class ExcludedTestRepository : IRepository<SimpleTestEntity> {
+		public ValueTask AddAsync(SimpleTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<SimpleTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(SimpleTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(SimpleTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<SimpleTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<SimpleTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((SimpleTestEntity?)null);
+		public object? GetEntityKey(SimpleTestEntity entity) => (object?)entity.Id;
+	}
+}

--- a/test/Deveel.Repository.Context.XUnit/Unit/RepositoryScannerTests.cs
+++ b/test/Deveel.Repository.Context.XUnit/Unit/RepositoryScannerTests.cs
@@ -88,3 +88,172 @@ public class RepositoryScannerTests {
 		public object? GetEntityKey(ScanPerson entity) => (object?)entity.Id;
 	}
 }
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "RepositoryScanner")]
+public class RepositoryScannerExtendedTests {
+	[Fact]
+	public void ScanRepositories_ScansMultipleAssemblies() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		builder.ScanRepositories(
+			typeof(InMemoryRepository<>).Assembly,
+			typeof(InMemoryRepository<,>).Assembly
+		);
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<ScanExtendedPerson>>();
+		Assert.NotNull(repo);
+	}
+
+	[Fact]
+	public void ScanRepositories_SkipsAbstractTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(ScanExtendedPerson).Assembly);
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<AbstractScanExtendedRepository>();
+		Assert.Null(repo);
+	}
+
+	[Fact]
+	public void ScanRepositories_SkipsInterfaces() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(ScanExtendedPerson).Assembly);
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IScanExtendedRepository>();
+		Assert.Null(repo);
+	}
+
+	[Fact]
+	public void ScanRepositories_TracksScannedRepositoryTypes() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		builder.ScanRepositories(typeof(InMemoryRepository<>).Assembly);
+
+		Assert.NotEmpty(builder.RegisteredRepositoryTypes);
+		Assert.Contains(typeof(InMemoryRepository<>), builder.RegisteredRepositoryTypes);
+	}
+
+	[Fact]
+	public void ScanRepositories_RegistersConcreteRepository_WhenPresent() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(ConcreteScanRepository).Assembly);
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<ScanExtendedPerson>>();
+		Assert.NotNull(repo);
+		Assert.IsType<ConcreteScanRepository>(repo);
+	}
+
+	[Fact]
+	public void ScanRepositories_ResolvesConcreteRepositoryDirectly() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(ConcreteScanRepository).Assembly);
+
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<ConcreteScanRepository>();
+		Assert.NotNull(repo);
+	}
+
+	[Fact]
+	public void ScanRepositories_WithEmptyAssembly_DoesNotThrow() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+
+		// Should not throw even if assembly has no repositories
+		builder.ScanRepositories(typeof(object).Assembly);
+	}
+
+	[Fact]
+	public void ScanRepositories_PreservesExistingRegistrations() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext()
+			.AddRepository<ExplicitScanRepository>();
+
+		var initialCount = services.Count;
+		builder.ScanRepositories(typeof(InMemoryRepository<>).Assembly);
+
+		// Should have added more services
+		Assert.True(services.Count > initialCount);
+	}
+
+	[Fact]
+	public void ScanRepositories_OpenGenericRepository_CanResolveForMultipleEntityTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(InMemoryRepository<>).Assembly);
+
+		var provider = services.BuildServiceProvider();
+
+		var repo1 = provider.GetService<IRepository<ScanExtendedPerson>>();
+		var repo2 = provider.GetService<IRepository<AnotherScanEntity>>();
+
+		Assert.NotNull(repo1);
+		Assert.NotNull(repo2);
+	}
+
+	public class ScanExtendedPerson {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+		public string? Name { get; set; }
+	}
+
+	public class AnotherScanEntity {
+		[Key]
+		public int Id { get; set; }
+	}
+
+	public interface IScanExtendedRepository : IRepository<ScanExtendedPerson> { }
+
+	public abstract class AbstractScanExtendedRepository : IRepository<ScanExtendedPerson> {
+		public abstract ValueTask AddAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default);
+		public abstract ValueTask AddRangeAsync(IEnumerable<ScanExtendedPerson> entities, CancellationToken cancellationToken = default);
+		public abstract ValueTask<bool> UpdateAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default);
+		public abstract ValueTask<bool> RemoveAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default);
+		public abstract ValueTask RemoveRangeAsync(IEnumerable<ScanExtendedPerson> entities, CancellationToken cancellationToken = default);
+		public abstract ValueTask<ScanExtendedPerson?> FindAsync(object key, CancellationToken cancellationToken = default);
+		public abstract object? GetEntityKey(ScanExtendedPerson entity);
+	}
+
+	public class ConcreteScanRepository : IRepository<ScanExtendedPerson> {
+		public ValueTask AddAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<ScanExtendedPerson> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<ScanExtendedPerson> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<ScanExtendedPerson?> FindAsync(object key, CancellationToken cancellationToken = default) => new((ScanExtendedPerson?)null);
+		public object? GetEntityKey(ScanExtendedPerson entity) => (object?)entity.Id;
+	}
+
+	public class ExplicitScanRepository : IRepository<ScanExtendedPerson> {
+		public ValueTask AddAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<ScanExtendedPerson> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<ScanExtendedPerson> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<ScanExtendedPerson?> FindAsync(object key, CancellationToken cancellationToken = default) => new((ScanExtendedPerson?)null);
+		public object? GetEntityKey(ScanExtendedPerson entity) => (object?)entity.Id;
+	}
+
+	public interface ISpecializedScanRepository : IRepository<ScanExtendedPerson> {
+		void SpecialMethod();
+	}
+
+	public class SpecializedScanRepository : ISpecializedScanRepository {
+		public void SpecialMethod() { }
+		public ValueTask AddAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<ScanExtendedPerson> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(ScanExtendedPerson entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<ScanExtendedPerson> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<ScanExtendedPerson?> FindAsync(object key, CancellationToken cancellationToken = default) => new((ScanExtendedPerson?)null);
+		public object? GetEntityKey(ScanExtendedPerson entity) => (object?)entity.Id;
+	}
+}

--- a/test/Deveel.Repository.Context.XUnit/Unit/RepositoryScannerTests.cs
+++ b/test/Deveel.Repository.Context.XUnit/Unit/RepositoryScannerTests.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel.DataAnnotations;
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Deveel.Data;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Core")]
+[Trait("Feature", "RepositoryScanner")]
+public class RepositoryScannerTests {
+	[Fact]
+	public void ScanRepositories_RegistersOpenGenerics() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(InMemoryRepository<>).Assembly);
+
+		var provider = services.BuildServiceProvider();
+
+		// Open generic should be resolvable for closed type
+		var repo = provider.GetService<InMemoryRepository<ScanPerson>>();
+		Assert.NotNull(repo);
+	}
+
+	[Fact]
+	public void ScanRepositories_RegistersRepositoryInterfaces() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(InMemoryRepository<>).Assembly);
+
+		var provider = services.BuildServiceProvider();
+
+		var repo = provider.GetService<IRepository<ScanPerson>>();
+		Assert.NotNull(repo);
+		Assert.IsType<InMemoryRepository<ScanPerson>>(repo);
+	}
+
+	[Fact]
+	public void ScanRepositories_SkipsExcludedTypes() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.ScanRepositories(typeof(ExcludedRepository).Assembly);
+
+		var provider = services.BuildServiceProvider();
+
+		// ExcludedRepository should not be registered
+		var repo = provider.GetService<ExcludedRepository>();
+		Assert.Null(repo);
+	}
+
+	[Fact]
+	public void ScanRepositories_TracksEntityTypes() {
+		var services = new ServiceCollection();
+		var builder = services.AddRepositoryContext();
+		builder.ScanRepositories(typeof(InMemoryRepository<>).Assembly);
+
+		// InMemoryRepository<> tracks TEntity as an entity type (open generic)
+		Assert.NotEmpty(builder.RegisteredEntityTypes);
+	}
+
+	[Fact]
+	public void ScanRepositories_DoesNotDuplicateOnMultipleCalls() {
+		var services = new ServiceCollection();
+		var assembly = typeof(InMemoryRepository<>).Assembly;
+		services.AddRepositoryContext()
+			.ScanRepositories(assembly)
+			.ScanRepositories(assembly);
+
+		// Should not throw - duplicate scans are skipped
+		var provider = services.BuildServiceProvider();
+		var repo = provider.GetService<IRepository<ScanPerson>>();
+		Assert.NotNull(repo);
+	}
+
+	public class ScanPerson {
+		[Key]
+		public string Id { get; set; } = Guid.NewGuid().ToString();
+		public string? Name { get; set; }
+	}
+
+	[ExcludeFromScan]
+	public class ExcludedRepository : IRepository<ScanPerson> {
+		public ValueTask AddAsync(ScanPerson entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask AddRangeAsync(IEnumerable<ScanPerson> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<bool> UpdateAsync(ScanPerson entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask<bool> RemoveAsync(ScanPerson entity, CancellationToken cancellationToken = default) => new(false);
+		public ValueTask RemoveRangeAsync(IEnumerable<ScanPerson> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+		public ValueTask<ScanPerson?> FindAsync(object key, CancellationToken cancellationToken = default) => new((ScanPerson?)null);
+		public object? GetEntityKey(ScanPerson entity) => (object?)entity.Id;
+	}
+}

--- a/test/Deveel.Repository.EntityFramework.XUnit/Deveel.Repository.EntityFramework.XUnit.csproj
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Deveel.Repository.EntityFramework.XUnit.csproj
@@ -11,6 +11,7 @@
         <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="9.4.7" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+        <PackageReference Include="Finbuckle.MultiTenant" Version="10.0.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="10.0.5" />
         <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="10.0.4" />
@@ -33,14 +34,13 @@
 
           • Windows → bundle_e_sqlite3  no system SQLite; the bundled version is always used.
         -->
-        <PackageReference Include="SQLitePCLRaw.bundle_sqlite3"   Version="2.1.11"
-            Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))" />
-        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11"
-            Condition="!$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))" />
+        <PackageReference Include="SQLitePCLRaw.bundle_sqlite3" Version="2.1.11" Condition="$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))" />
+        <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" Condition="!$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\Deveel.Repository.EntityFramework\Deveel.Repository.EntityFramework.csproj" />
+        <ProjectReference Include="..\..\src\Deveel.Repository.EntityFramework.MultiTenant\Deveel.Repository.EntityFramework.MultiTenant.csproj" />
         <ProjectReference Include="..\Deveel.Repository.Management.Testing\Deveel.Repository.Management.Testing.csproj" />
         <ProjectReference Include="..\Deveel.Repository.Testing\Deveel.Repository.Testing.csproj" />
     </ItemGroup>

--- a/test/Deveel.Repository.EntityFramework.XUnit/Integration/EntityFrameworkMultiTenancyTests.cs
+++ b/test/Deveel.Repository.EntityFramework.XUnit/Integration/EntityFrameworkMultiTenancyTests.cs
@@ -1,0 +1,200 @@
+using Deveel.Data.Entities;
+
+using Finbuckle.MultiTenant;
+using Finbuckle.MultiTenant.Abstractions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Deveel.Data;
+
+[Trait("Category", "Integration")]
+[Trait("Layer", "Infrastructure")]
+[Trait("Feature", "EntityFrameworkMultiTenancy")]
+public class EntityFrameworkMultiTenancyTests {
+	private static readonly string[] TenantIds = ["tenant-a", "tenant-b"];
+
+	[Fact]
+	public void WithDatabasePerTenant_RegistersOptions() {
+		var services = new ServiceCollection();
+		services.AddRepositoryContext()
+			.UseEntityFramework<DatabasePerTenantDbContext>()
+			.WithDatabasePerTenant<DbTenantInfo>("Data Source=default.db")
+			.Build();
+
+		var hasOptions = services.Any(d => 
+			d.ServiceType == typeof(IConfigureOptions<EntityFrameworkTenantConnectionOptions>));
+		Assert.True(hasOptions);
+	}
+
+#if !NET10_0_OR_GREATER
+	[Fact]
+	public async Task WithDatabasePerTenant_ResolvesTenantConnection() {
+		var services = new ServiceCollection();
+
+		services.AddMultiTenant<DbTenantInfo>()
+			.WithInMemoryStore()
+			.WithContextStrategy();
+
+		services.AddRepositoryContext()
+			.UseEntityFramework<DatabasePerTenantDbContext>()
+			.WithDatabasePerTenant<DbTenantInfo>("Data Source=default.db")
+			.Build();
+
+		var provider = services.BuildServiceProvider();
+
+		using var scope = provider.CreateScope();
+		var tenantStore = scope.ServiceProvider.GetRequiredService<IMultiTenantStore<DbTenantInfo>>();
+
+		foreach (var tenantId in TenantIds) {
+			await tenantStore.TryAddAsync(new DbTenantInfo(tenantId, tenantId, "Data Source=:memory:"));
+		}
+
+		var executionContext = scope.ServiceProvider.GetRequiredService<TenantExecutionContext<DbTenantInfo>>();
+
+		await executionContext.ExecuteInScopeAsync(TenantIds[0], async (IServiceProvider sp) => {
+			var dbContext = sp.GetRequiredService<DatabasePerTenantDbContext>();
+			await dbContext.Database.EnsureCreatedAsync();
+			var conn = dbContext.Database.GetDbConnection();
+			Assert.Equal("Data Source=:memory:", conn.ConnectionString);
+		});
+	}
+
+	[Fact]
+	public async Task WithDatabasePerTenant_FallsBackToDefaultConnection() {
+		var services = new ServiceCollection();
+
+		services.AddMultiTenant<DbTenantInfo>()
+			.WithInMemoryStore()
+			.WithContextStrategy();
+
+		services.AddRepositoryContext()
+			.UseEntityFramework<DatabasePerTenantDbContext>()
+			.WithDatabasePerTenant<DbTenantInfo>("Data Source=fallback.db")
+			.Build();
+
+		var provider = services.BuildServiceProvider();
+
+		using var scope = provider.CreateScope();
+		var tenantStore = scope.ServiceProvider.GetRequiredService<IMultiTenantStore<DbTenantInfo>>();
+
+		await tenantStore.TryAddAsync(new DbTenantInfo("no-conn-tenant", "no-conn-tenant", ""));
+
+		var executionContext = scope.ServiceProvider.GetRequiredService<TenantExecutionContext<DbTenantInfo>>();
+
+		await executionContext.ExecuteInScopeAsync("no-conn-tenant", async (IServiceProvider sp) => {
+			var dbContext = sp.GetRequiredService<DatabasePerTenantDbContext>();
+			var conn = dbContext.Database.GetDbConnection();
+			Assert.Equal("Data Source=fallback.db", conn.ConnectionString);
+		});
+	}
+
+	[Fact]
+	public async Task WithDatabasePerTenant_ThrowsWhenNoConnection() {
+		var services = new ServiceCollection();
+
+		services.AddMultiTenant<DbTenantInfo>()
+			.WithInMemoryStore()
+			.WithContextStrategy();
+
+		services.AddRepositoryContext()
+			.UseEntityFramework<DatabasePerTenantDbContext>()
+			.WithDatabasePerTenant<DbTenantInfo>()
+			.Build();
+
+		var provider = services.BuildServiceProvider();
+
+		using var scope = provider.CreateScope();
+		var tenantStore = scope.ServiceProvider.GetRequiredService<IMultiTenantStore<DbTenantInfo>>();
+
+		await tenantStore.TryAddAsync(new DbTenantInfo("empty-tenant", "empty-tenant", ""));
+
+		var executionContext = scope.ServiceProvider.GetRequiredService<TenantExecutionContext<DbTenantInfo>>();
+
+		await Assert.ThrowsAsync<InvalidOperationException>(() =>
+			executionContext.ExecuteInScopeAsync("empty-tenant", async (IServiceProvider sp) => {
+				var dbContext = sp.GetRequiredService<DatabasePerTenantDbContext>();
+				await dbContext.Database.EnsureCreatedAsync();
+			}));
+	}
+
+	[Fact]
+	public void WithSharedTenantDatabase_PassesForMultiTenantDbContext() {
+		var services = new ServiceCollection();
+
+		services.AddMultiTenant<DbTenantInfo>()
+			.WithInMemoryStore();
+
+		services.AddRepositoryContext()
+			.UseEntityFramework<MultiTenantTestDbContext>(b => b
+				.ConfigureDbContext(opts => opts.UseSqlite("Data Source=:memory:"))
+				.WithSharedTenantDatabase());
+
+		var provider = services.BuildServiceProvider();
+		var context = provider.GetService<MultiTenantTestDbContext>();
+		Assert.NotNull(context);
+	}
+#endif
+
+	[Fact]
+	public void WithSharedTenantDatabase_RequiresMultiTenantDbContext() {
+		var services = new ServiceCollection();
+
+		Assert.Throws<InvalidOperationException>(() => {
+			services.AddRepositoryContext()
+				.UseEntityFramework<TestDbContext>()
+				.WithSharedTenantDatabase()
+				.Build();
+		});
+	}
+
+	#region Support Types
+
+	private class TestDbContext : DbContext {
+		public TestDbContext(DbContextOptions options) : base(options) {
+		}
+
+		public DbSet<DbPerson>? Persons { get; set; }
+	}
+
+	private class DatabasePerTenantDbContext : DbContext {
+		private readonly IMultiTenantContextAccessor<DbTenantInfo> _tenantAccessor;
+		private readonly IOptions<EntityFrameworkTenantConnectionOptions> _options;
+
+		public DatabasePerTenantDbContext(
+			DbContextOptions<DatabasePerTenantDbContext> dbContextOptions,
+			IMultiTenantContextAccessor<DbTenantInfo> tenantAccessor,
+			IOptions<EntityFrameworkTenantConnectionOptions> options) : base(dbContextOptions) {
+			_tenantAccessor = tenantAccessor;
+			_options = options;
+		}
+
+		public DbSet<DbTenantPerson>? Persons { get; set; }
+
+		protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) {
+			var tenantInfo = _tenantAccessor.MultiTenantContext?.TenantInfo;
+			var connectionString = tenantInfo?.ConnectionString;
+
+			if (string.IsNullOrEmpty(connectionString)) {
+				connectionString = _options.Value.DefaultConnectionString;
+			}
+
+			if (string.IsNullOrEmpty(connectionString))
+				throw new InvalidOperationException("Connection string is not provided in the tenant info or options.");
+
+			optionsBuilder.UseSqlite(connectionString);
+		}
+	}
+
+	private class MultiTenantTestDbContext : Finbuckle.MultiTenant.EntityFrameworkCore.MultiTenantDbContext {
+		public MultiTenantTestDbContext(
+			IMultiTenantContextAccessor<DbTenantInfo> multiTenantContextAccessor,
+			DbContextOptions<MultiTenantTestDbContext> options) : base(multiTenantContextAccessor, options) {
+		}
+
+		public DbSet<DbPerson>? Persons { get; set; }
+	}
+
+	#endregion
+}


### PR DESCRIPTION
This pull request adds support and documentation for the new `Deveel.Repository.EntityFramework.MultiTenant` package, which provides first-class multi-tenancy capabilities for EF Core repositories. It updates the documentation to reflect the new fluent builder API for repository registration, clarifies multi-tenancy strategies, and adds the new projects to the solution file.

**Multi-tenancy support and documentation:**

* Added references to the new `Deveel.Repository.EntityFramework.MultiTenant` package in the main documentation and repository implementation tables, highlighting that EF Core multi-tenancy is now handled via this package rather than only through direct Finbuckle.MultiTenant configuration. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R55) [[2]](diffhunk://#diff-d08f51c728fe09ddf456c4b8687408a90ad38ce3dc475ab40f236c50659c1233R9) [[3]](diffhunk://#diff-158de48897401d23065dc941027c106b5cebf43b400beb605767a69651c2f893L10-R10) [[4]](diffhunk://#diff-59eedb3395e32db254b08bf77e9eb67e1cf0418eb0e2f5f713353296c84c12f6L10-R10)
* Expanded the multi-tenancy documentation to describe two supported strategies for EF Core: database-per-tenant and shared database, including code samples and a comparison table. [[1]](diffhunk://#diff-42b35c3c2ec6e5c39cdda70ecf15753919f383b31c65fd171839d802aca264aaL11-R101) [[2]](diffhunk://#diff-158de48897401d23065dc941027c106b5cebf43b400beb605767a69651c2f893L24-R134)

**Fluent builder API for repository registration:**

* Updated documentation to recommend the new `AddRepositoryContext()` fluent builder API for registering repositories and drivers, replacing the older `AddRepository<T>` pattern. Provided detailed usage examples for in-memory, EF Core, and MongoDB drivers, as well as assembly scanning and legacy registration notes. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L63-R120) [[2]](diffhunk://#diff-e813bba2aa695150ec6ca3a59c79ebaff044e3a5246979b05e26a6e987611e00L27-R54)
* Updated EF Core and In-Memory repository documentation to show registration via the builder API and how to configure options like field mappers and initial data seeding. [[1]](diffhunk://#diff-158de48897401d23065dc941027c106b5cebf43b400beb605767a69651c2f893L24-R134) [[2]](diffhunk://#diff-e813bba2aa695150ec6ca3a59c79ebaff044e3a5246979b05e26a6e987611e00L27-R54)

**Solution/project structure:**

* Added `Deveel.Repository.Context.XUnit` and `Deveel.Repository.EntityFramework.MultiTenant` projects to the solution file, including their build configurations and solution folder assignments. [[1]](diffhunk://#diff-53d96e24532d138683684ee910a6df3bcb3cb7a7e0277308e6135cb685b6efa6R75-R78) [[2]](diffhunk://#diff-53d96e24532d138683684ee910a6df3bcb3cb7a7e0277308e6135cb685b6efa6R377-R400) [[3]](diffhunk://#diff-53d96e24532d138683684ee910a6df3bcb3cb7a7e0277308e6135cb685b6efa6R432-R433)

**Other documentation clarifications:**

* Clarified that the builder API handles `DbContext` registration for EF Core, and updated notes about multi-tenant configuration documentation.…repository context builder and related extensions