### PR TITLE
Update README and index documentation for project renaming and logo

### DIFF
--- a/.github/workflows/reusable-pipeline.yml
+++ b/.github/workflows/reusable-pipeline.yml
@@ -125,7 +125,7 @@ jobs:
         if: ${{ inputs.publish-github-packages }}
         env: 
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_API_TOKEN }}
-        run: dotnet nuget push ./nupkgs/*.nupkg --skip-duplicate --api-key $GITHUB_API_TOKEN --source https://nuget.pkg.github.com/kista/index.json
+        run: dotnet nuget push ./nupkgs/*.nupkg --skip-duplicate --api-key $GITHUB_API_TOKEN --source https://nuget.pkg.github.com/deveel/index.json
 
       - name: Publish packages to NuGet.org
         if: ${{ inputs.publish-nuget-org }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,16 @@
+![GitHub release](https://img.shields.io/github/v/release/deveel/kista)
+![GitHub license](https://img.shields.io/github/license/deveel/kista?color=blue)
+![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/deveel/kista/ci.yml?logo=github)
+[![codecov](https://codecov.io/gh/deveel/kista/graph/badge.svg?token=5US7L3C7ES)](https://codecov.io/gh/deveel/kista)
+[![Documentation](https://img.shields.io/badge/gitbook-docs?logo=gitbook&label=docs&color=blue)](https://deveel.gitbook.io/kista/)
+
+<p align="center">
+  <img src="kista-full-logo.png" alt="Kista logo">
+</p>
+
+> **Renamed:** This project was renamed from **Deveel.Repository** to **Kista** on **May 26, 2025**. The name *Kista* is Old Norse for "chest" or "repository", better reflecting the project's purpose as a data access framework.
+
+
 # Why Kista?
 > **Renamed:** This project was renamed from **Deveel.Repository** to **Kista** on **May 26, 2025**. The name *Kista* is Old Norse for "chest" or "repository", better reflecting the project purpose as a data access framework.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,5 @@
 # Getting Started
 
-![GitHub release](https://img.shields.io/github/v/release/deveel/kista)
-![GitHub license](https://img.shields.io/github/license/deveel/kista?color=blue)
-![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/deveel/kista/ci.yml?logo=github)
-[![codecov](https://codecov.io/gh/deveel/kista/graph/badge.svg?token=5US7L3C7ES)](https://codecov.io/gh/deveel/kista)
-[![Documentation](https://img.shields.io/badge/gitbook-docs?logo=gitbook&label=docs&color=blue)](https://deveel.gitbook.io/kista/)
-
-<p align="center">
-  <img src="kista-full-logo.png" alt="Kista logo">
-</p>
-
-> **Renamed:** This project was renamed from **Deveel.Repository** to **Kista** on **May 26, 2025**. The name *Kista* is Old Norse for "chest" or "repository", better reflecting the project's purpose as a data access framework.
-
 Kista is a framework that provides a set of abstractions and implementations of the [_Repository Pattern_](https://en.wikipedia.org/wiki/Repository_pattern), to simplify the access to data sources in your application while keeping your domain model decoupled from any specific persistence technology.
 
 Below you will find a quick and generic guide to start using the framework in your application.


### PR DESCRIPTION
…ails and logo
This pull request updates project documentation and CI configuration to reflect the recent renaming of the project from "Deveel.Repository" to "Kista," and corrects the GitHub Packages NuGet source. The most important changes are summarized below:

Documentation updates:

* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R1-R13): Added project badges, logo, and a prominent note about the renaming from "Deveel.Repository" to "Kista" to clarify the new project identity and its meaning.
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L3-L14): Removed badges, logo, and renaming note (now present in `README.md`) to streamline the "Getting Started" documentation.

Continuous Integration configuration:

* [`.github/workflows/reusable-pipeline.yml`](diffhunk://#diff-5fe84e9f67a58184c1cf92f8642933831edcdefcd19d4110ed05bf8014a747d8L128-R128): Updated the NuGet push source from `kista` to `deveel` to match the new project namespace and ensure packages are published to the correct GitHub Packages feed.