### PR TITLE
Enhance user identifier strategies and improve error handling

### DIFF
--- a/samples/Kista.SampleApp.Owners/src/Kista.SampleApp.Owners/Program.cs
+++ b/samples/Kista.SampleApp.Owners/src/Kista.SampleApp.Owners/Program.cs
@@ -38,4 +38,4 @@ app.UseMiddleware<FakeUserMiddleware>();
 app.MapNoteEndpoints();
 app.MapTaskEndpoints();
 
-app.Run();
+await app.RunAsync();

--- a/src/Kista.Owners/ClaimUserIdentifierStrategy.cs
+++ b/src/Kista.Owners/ClaimUserIdentifierStrategy.cs
@@ -56,7 +56,7 @@ namespace Kista
 			return ConvertValue(value);
 		}
 
-		private TKey? ConvertValue(string value)
+		private static TKey? ConvertValue(string value)
 		{
 			try
 			{
@@ -66,7 +66,19 @@ namespace Kista
 				var converter = TypeDescriptor.GetConverter(typeof(TKey));
 				return (TKey?)converter.ConvertFromInvariantString(value);
 			}
-			catch
+			catch (FormatException)
+			{
+				return default;
+			}
+			catch (NotSupportedException)
+			{
+				return default;
+			}
+			catch (ArgumentException)
+			{
+				return default;
+			}
+			catch (InvalidCastException)
 			{
 				return default;
 			}

--- a/src/Kista.Owners/CompositeUserIdentifierStrategy.cs
+++ b/src/Kista.Owners/CompositeUserIdentifierStrategy.cs
@@ -43,14 +43,9 @@ namespace Kista
 		/// <inheritdoc/>
 		public TKey? GetUserId(IServiceProvider? serviceProvider = null)
 		{
-			foreach (var strategy in strategies)
-			{
-				var userId = strategy.GetUserId(serviceProvider);
-				if (userId != null)
-					return userId;
-			}
-
-			return default;
+			return strategies
+				.Select(strategy => strategy.GetUserId(serviceProvider))
+				.FirstOrDefault(userId => !EqualityComparer<TKey>.Default.Equals(userId, default));
 		}
 	}
 

--- a/src/Kista.Owners/IUserIdentifierStrategy.cs
+++ b/src/Kista.Owners/IUserIdentifierStrategy.cs
@@ -18,7 +18,7 @@ namespace Kista
 	/// Defines a strategy for resolving the current user identifier.
 	/// </summary>
 	/// <typeparam name="TKey">The type of the user identifier key.</typeparam>
-	public interface IUserIdentifierStrategy<TKey>
+	public interface IUserIdentifierStrategy<out TKey>
 	{
 		/// <summary>
 		/// Resolves the current user identifier.

--- a/src/Kista.Owners/QueryStringUserIdentifierStrategy.cs
+++ b/src/Kista.Owners/QueryStringUserIdentifierStrategy.cs
@@ -54,7 +54,7 @@ namespace Kista
 			return ConvertValue(value);
 		}
 
-		private TKey? ConvertValue(string value)
+		private static TKey? ConvertValue(string value)
 		{
 			try
 			{
@@ -64,7 +64,19 @@ namespace Kista
 				var converter = TypeDescriptor.GetConverter(typeof(TKey));
 				return (TKey?)converter.ConvertFromInvariantString(value);
 			}
-			catch
+			catch (FormatException)
+			{
+				return default;
+			}
+			catch (NotSupportedException)
+			{
+				return default;
+			}
+			catch (ArgumentException)
+			{
+				return default;
+			}
+			catch (InvalidCastException)
 			{
 				return default;
 			}

--- a/src/Kista.Owners/RepositoryBuilderExtensions.cs
+++ b/src/Kista.Owners/RepositoryBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Kista
@@ -53,10 +54,8 @@ namespace Kista
 
 		private static Type? FindUserKeyType(Type entityType)
 		{
-			foreach (var iface in entityType.GetInterfaces())
+			foreach (var iface in entityType.GetInterfaces().Where(iface => iface.IsGenericType))
 			{
-				if (!iface.IsGenericType) continue;
-
 				var genericDef = iface.GetGenericTypeDefinition();
 				if (genericDef == typeof(IHaveOwner<>) ||
 					genericDef.FullName == "Kista.IHaveOwner`1")

--- a/src/Kista.Owners/RouteUserIdentifierStrategy.cs
+++ b/src/Kista.Owners/RouteUserIdentifierStrategy.cs
@@ -54,7 +54,7 @@ namespace Kista
 			return ConvertValue(value);
 		}
 
-		private TKey? ConvertValue(string value)
+		private static TKey? ConvertValue(string value)
 		{
 			try
 			{
@@ -64,7 +64,19 @@ namespace Kista
 				var converter = TypeDescriptor.GetConverter(typeof(TKey));
 				return (TKey?)converter.ConvertFromInvariantString(value);
 			}
-			catch
+			catch (FormatException)
+			{
+				return default;
+			}
+			catch (NotSupportedException)
+			{
+				return default;
+			}
+			catch (ArgumentException)
+			{
+				return default;
+			}
+			catch (InvalidCastException)
 			{
 				return default;
 			}

--- a/src/Kista.Owners/UserScopedRepositoryDecorator.cs
+++ b/src/Kista.Owners/UserScopedRepositoryDecorator.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -36,6 +37,7 @@ namespace Kista
 		where TEntity : class, IHaveOwner<TUserKey>
 		where TKey : notnull
 	{
+		private const string UserContextNotSetMessage = "User context is not set";
 		private static readonly Lazy<PropertyInfo> _ownerProperty = new(DiscoverOwnerProperty);
 
 		private readonly IRepository<TEntity, TKey> _inner;
@@ -72,9 +74,9 @@ namespace Kista
 		public ValueTask<TEntity?> FindAsync(TKey key, CancellationToken cancellationToken = default)
 		{
 			var userId = _userAccessor.GetUserId();
-			if (userId == null)
+			if (EqualityComparer<TUserKey>.Default.Equals(userId, default))
 				return Options.ThrowWhenUserNotSet
-					? throw new System.InvalidOperationException("User context is not set")
+					? throw new System.InvalidOperationException(UserContextNotSetMessage)
 					: new ValueTask<TEntity?>(default(TEntity));
 
 			return FindScopedAsync(key, userId, cancellationToken);
@@ -102,7 +104,7 @@ namespace Kista
 			System.ArgumentNullException.ThrowIfNull(entities);
 
 			var userId = _userAccessor.GetUserId();
-			if (userId != null)
+			if (!EqualityComparer<TUserKey>.Default.Equals(userId, default))
 			{
 				foreach (var entity in entities)
 				{
@@ -111,7 +113,7 @@ namespace Kista
 			}
 			else if (Options.ThrowWhenUserNotSet)
 			{
-				throw new System.InvalidOperationException("User context is not set");
+				throw new System.InvalidOperationException(UserContextNotSetMessage);
 			}
 
 			return _inner.AddRangeAsync(entities, cancellationToken);
@@ -162,13 +164,13 @@ namespace Kista
 			System.ArgumentNullException.ThrowIfNull(entity);
 
 			var userId = _userAccessor.GetUserId();
-			if (userId != null)
+			if (!EqualityComparer<TUserKey>.Default.Equals(userId, default))
 			{
 				_ownerProperty.Value.SetValue(entity, userId);
 			}
 			else if (Options.ThrowWhenUserNotSet)
 			{
-				throw new System.InvalidOperationException("User context is not set");
+				throw new System.InvalidOperationException(UserContextNotSetMessage);
 			}
 
 			return action();
@@ -178,9 +180,9 @@ namespace Kista
 			IQuery query, Func<IQuery, ValueTask<IList<TEntity>>> action)
 		{
 			var userId = _userAccessor.GetUserId();
-			if (userId == null)
+			if (EqualityComparer<TUserKey>.Default.Equals(userId, default))
 				return Options.ThrowWhenUserNotSet
-					? throw new System.InvalidOperationException("User context is not set")
+					? throw new System.InvalidOperationException(UserContextNotSetMessage)
 					: Array.Empty<TEntity>();
 
 			var scopedQuery = ApplyOwnerToQuery(query, userId);
@@ -191,7 +193,7 @@ namespace Kista
 			IQuery query, Func<IQuery, ValueTask<TEntity?>> action)
 		{
 			var userId = _userAccessor.GetUserId();
-			if (userId == null)
+			if (EqualityComparer<TUserKey>.Default.Equals(userId, default))
 				return null;
 
 			var scopedQuery = ApplyOwnerToQuery(query, userId);
@@ -202,7 +204,7 @@ namespace Kista
 			IQueryFilter filter, Func<IQueryFilter, ValueTask<long>> action)
 		{
 			var userId = _userAccessor.GetUserId();
-			if (userId == null)
+			if (EqualityComparer<TUserKey>.Default.Equals(userId, default))
 				return 0;
 
 			var ownerFilter = BuildOwnerFilter(userId);
@@ -214,7 +216,7 @@ namespace Kista
 			IQueryFilter filter, Func<IQueryFilter, ValueTask<bool>> action)
 		{
 			var userId = _userAccessor.GetUserId();
-			if (userId == null)
+			if (EqualityComparer<TUserKey>.Default.Equals(userId, default))
 				return false;
 
 			var ownerFilter = BuildOwnerFilter(userId);
@@ -226,9 +228,9 @@ namespace Kista
 			PageQuery<TEntity> request, Func<PageQuery<TEntity>, ValueTask<PageResult<TEntity>>> action)
 		{
 			var userId = _userAccessor.GetUserId();
-			if (userId == null)
+			if (EqualityComparer<TUserKey>.Default.Equals(userId, default))
 				return Options.ThrowWhenUserNotSet
-					? throw new System.InvalidOperationException("User context is not set")
+					? throw new System.InvalidOperationException(UserContextNotSetMessage)
 					: new PageResult<TEntity>(request, 0, Array.Empty<TEntity>());
 
 			var scopedRequest = ApplyOwnerToRequest(request, userId);
@@ -261,9 +263,8 @@ namespace Kista
 
 			foreach (var prop in entityType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
 			{
-				foreach (var attr in prop.GetCustomAttributes())
+				foreach (var attrType in prop.GetCustomAttributes().Select(attr => attr.GetType()))
 				{
-					var attrType = attr.GetType();
 					if (attrType.Name == "DataOwnerAttribute" &&
 						(attrType.Namespace == "Kista" || attrType.Namespace == "Kista.Owners"))
 					{
@@ -287,7 +288,7 @@ namespace Kista
 
 		// === FILTER BUILDING ===
 
-		private IQueryFilter BuildOwnerFilter(TUserKey userId)
+		private static IQueryFilter BuildOwnerFilter(TUserKey userId)
 		{
 			return new ExpressionQueryFilter<TEntity>(BuildOwnerExpression(userId));
 		}

--- a/src/Kista/RepositoryContextBuilder.cs
+++ b/src/Kista/RepositoryContextBuilder.cs
@@ -97,10 +97,14 @@ namespace Kista {
 	/// further type-specific configuration (e.g. owner scoping).
 	/// </summary>
 	public RepositoryBuilder AddRepository<TRepository>(ServiceLifetime lifetime = ServiceLifetime.Scoped) where TRepository : class {
-		_services.AddRepository(typeof(TRepository), lifetime);
+		var repoInterface = FindRepositoryInterface(typeof(TRepository));
+		var serviceTypes = RepositoryRegistrationUtil.GetRepositoryServiceTypes(typeof(TRepository));
+		foreach (var serviceType in serviceTypes) {
+			_services.TryAdd(new ServiceDescriptor(serviceType, typeof(TRepository), lifetime));
+		}
+		_services.TryAdd(new ServiceDescriptor(typeof(TRepository), typeof(TRepository), lifetime));
 		TrackRepositoryType(typeof(TRepository));
 
-		var repoInterface = FindRepositoryInterface(typeof(TRepository));
 		var entityType = repoInterface.GetGenericArguments()[0];
 		var keyType = repoInterface.GetGenericArguments()[1];
 
@@ -117,6 +121,19 @@ namespace Kista {
 		return this;
 	}
 
+	/// <summary>
+	/// Registers a repository type in the service collection and tracks it.
+	/// </summary>
+	public RepositoryContextBuilder AddRepository(Type repositoryType, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
+		if (repositoryType.IsGenericTypeDefinition) {
+			RegisterOpenGenericRepository(repositoryType, lifetime);
+		} else {
+			_services.AddRepository(repositoryType, lifetime);
+		}
+		TrackRepositoryType(repositoryType);
+		return this;
+	}
+
 	private static Type FindRepositoryInterface(Type repositoryType) {
 		foreach (var iface in repositoryType.GetInterfaces()) {
 			if (iface.IsGenericType &&
@@ -128,19 +145,6 @@ namespace Kista {
 		throw new InvalidOperationException(
 			$"The type '{repositoryType}' does not implement IRepository<,>");
 	}
-
-		/// <summary>
-		/// Registers a repository type in the service collection and tracks it.
-		/// </summary>
-		public RepositoryContextBuilder AddRepository(Type repositoryType, ServiceLifetime lifetime = ServiceLifetime.Scoped) {
-			if (repositoryType.IsGenericTypeDefinition) {
-				RegisterOpenGenericRepository(repositoryType, lifetime);
-			} else {
-				_services.AddRepository(repositoryType, lifetime);
-			}
-			TrackRepositoryType(repositoryType);
-			return this;
-		}
 
 		/// <summary>
 		/// Registers an open generic repository type with the service collection.

--- a/test/Kista.Manager.XUnit/Unit/UserAccessorTests.cs
+++ b/test/Kista.Manager.XUnit/Unit/UserAccessorTests.cs
@@ -25,7 +25,7 @@ public class UserAccessorTests {
 
 		var userId = strategy.GetUserId(null);
 
-		Assert.NotEqual(default(Guid), userId);
+		Assert.NotEqual(Guid.Empty, userId);
 	}
 
 	#endregion
@@ -170,7 +170,7 @@ public class UserAccessorTests {
 
 		var userId = strategy.GetUserId(services);
 
-		Assert.Equal(default(Guid), userId);
+		Assert.Equal(Guid.Empty, userId);
 	}
 
 	#endregion
@@ -456,7 +456,7 @@ public class UserAccessorTests {
 		return services.BuildServiceProvider();
 	}
 
-	private class NullReturningStrategy<TKey> : IUserIdentifierStrategy<TKey> {
+	private sealed class NullReturningStrategy<TKey> : IUserIdentifierStrategy<TKey> {
 		public TKey? GetUserId(IServiceProvider? serviceProvider = null) => default;
 	}
 

--- a/test/Kista.Owners.XUnit/Unit/UserScopedRepositoryDecoratorEdgeTests.cs
+++ b/test/Kista.Owners.XUnit/Unit/UserScopedRepositoryDecoratorEdgeTests.cs
@@ -349,7 +349,7 @@ public class UserScopedRepositoryDecoratorEdgeTests
     // Helpers
     // ============================================================
 
-    private class StaticUserAccessor : IUserAccessor<string>
+    private sealed class StaticUserAccessor : IUserAccessor<string>
     {
         private readonly string _userId;
         public StaticUserAccessor(string userId) => _userId = userId;

--- a/test/Kista.Owners.XUnit/Unit/UserScopedRepositoryDecoratorTests.cs
+++ b/test/Kista.Owners.XUnit/Unit/UserScopedRepositoryDecoratorTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using Kista;
@@ -370,7 +371,7 @@ public class UserScopedRepositoryDecoratorTests
 
         var strategy = new StaticUserIdentifierStrategy<TUserKey>(userId);
         var composite = new CompositeUserIdentifierStrategy<TUserKey>();
-        if (userId != null)
+        if (!EqualityComparer<TUserKey>.Default.Equals(userId, default))
             composite.Add(strategy);
         services.AddSingleton(composite);
         services.AddSingleton<IUserAccessor<TUserKey>>(

--- a/test/Kista.Testing.TUnit/Suites/MultiTenantRepositoryTestSuite_T3.cs
+++ b/test/Kista.Testing.TUnit/Suites/MultiTenantRepositoryTestSuite_T3.cs
@@ -25,9 +25,7 @@ public abstract class MultiTenantRepositoryTestSuite<TTenantInfo, TPerson, TKey>
 
     protected virtual int EntitySetCount => 100;
 
-    private static readonly string[] DefaultTenantIds = { "tenant1", "tenant2", "tenant3" };
-
-    protected virtual string[] TenantIds => DefaultTenantIds;
+    protected virtual string[] TenantIds => Defaults.TenantIds;
 
     protected virtual IDictionary<string, IReadOnlyList<TPerson>>? People { get; private set; }
 
@@ -42,6 +40,11 @@ public abstract class MultiTenantRepositoryTestSuite<TTenantInfo, TPerson, TKey>
     protected abstract TKey GeneratePersonId();
 
     protected abstract TTenantInfo CreateTenantInfo(string tenantId);
+
+    private static class Defaults
+    {
+        public static readonly string[] TenantIds = { "tenant1", "tenant2", "tenant3" };
+    }
 
     protected virtual void ConfigureServices(IServiceCollection services)
     {

--- a/test/Kista.Testing/Suites/MultiTenantRepositoryTestSuite_T3.cs
+++ b/test/Kista.Testing/Suites/MultiTenantRepositoryTestSuite_T3.cs
@@ -31,9 +31,7 @@ public abstract class MultiTenantRepositoryTestSuite<TTenantInfo, TPerson, TKey>
 
 	protected virtual int EntitySetCount => 100;
 
-	private static readonly string[] DefaultTenantIds = { "tenant1", "tenant2", "tenant3" };
-
-	protected virtual string[] TenantIds => DefaultTenantIds;
+	protected virtual string[] TenantIds => Defaults.TenantIds;
 
 	protected virtual IDictionary<string, IReadOnlyList<TPerson>>? People { get; private set; }
 
@@ -48,6 +46,11 @@ public abstract class MultiTenantRepositoryTestSuite<TTenantInfo, TPerson, TKey>
 	protected abstract TKey GeneratePersonId();
 
 	protected abstract TTenantInfo CreateTenantInfo(string tenantId);
+
+	private static class Defaults
+	{
+		public static readonly string[] TenantIds = { "tenant1", "tenant2", "tenant3" };
+	}
 
 	protected virtual void ConfigureServices(IServiceCollection services) {
 		if (TestOutput != null)

--- a/test/Kista.XUnit/Unit/CombinedFilterTests.cs
+++ b/test/Kista.XUnit/Unit/CombinedFilterTests.cs
@@ -135,7 +135,7 @@ public class CombinedFilterTests
 		}.AsQueryable();
 		var f1 = QueryFilter.Where<Person>(x => x.FirstName == "A");
 		var f2 = QueryFilter.Where<Person>(x => x.LastName == "B");
-		var combined = QueryFilter.Combine(new[] { f1, f2 });
+		var combined = QueryFilter.Combine(f1, f2);
 
 		var result = combined.Apply(people).ToList();
 
@@ -148,7 +148,7 @@ public class CombinedFilterTests
 	public void CombinedQueryFilter_Initialize_CallsAllFilters() {
 		var f1 = QueryFilter.Where<Person>(x => x.FirstName == "A");
 		var f2 = QueryFilter.Where<Person>(x => x.LastName == "B");
-		var combined = QueryFilter.Combine(new[] { f1, f2 });
+		var combined = QueryFilter.Combine(f1, f2);
 		var ctx = new DefaultFilterContext(new ServiceCollection().BuildServiceProvider());
 		combined.Initialize(ctx);
 	}

--- a/test/Kista.XUnit/Unit/LifecycleTests.cs
+++ b/test/Kista.XUnit/Unit/LifecycleTests.cs
@@ -1360,7 +1360,7 @@ public class LifecycleTests {
 			=> throw new NotSupportedException();
 	}
 
-	private class LifecycleEnvOrchestrator : RepositoryLifecycleService {
+	private sealed class LifecycleEnvOrchestrator : RepositoryLifecycleService {
 		public LifecycleEnvOrchestrator(IOptions<RepositoryLifecycleOptions> options, IServiceProvider sp)
 			: base(options, sp, NullLogger.Instance) { }
 

--- a/test/Kista.XUnit/Unit/RepositoryCoreTests.cs
+++ b/test/Kista.XUnit/Unit/RepositoryCoreTests.cs
@@ -816,7 +816,7 @@ public class RepositoryCoreTests {
         public ValueTask AddRangeAsync(IEnumerable<Person> entities, CancellationToken cancellationToken = default) { AddRange(entities); return ValueTask.CompletedTask; }
         public ValueTask<bool> UpdateAsync(Person entity, CancellationToken cancellationToken = default) => throw new NotSupportedException();
         public ValueTask<bool> RemoveAsync(Person entity, CancellationToken cancellationToken = default) { var r = Remove(entity); return new ValueTask<bool>(r); }
-        public ValueTask RemoveRangeAsync(IEnumerable<Person> entities, CancellationToken cancellationToken = default) { foreach (var e in entities.ToList()) Remove(e); return ValueTask.CompletedTask; }
+        public ValueTask RemoveRangeAsync(IEnumerable<Person> entities, CancellationToken cancellationToken = default) { foreach (var e in entities.ToList()) { Remove(e); } return ValueTask.CompletedTask; }
         public ValueTask<Person?> FindAsync(object key, CancellationToken cancellationToken = default) => new ValueTask<Person?>(this.FirstOrDefault(x => x.Id == (string)key));
     }
 
@@ -895,12 +895,6 @@ public class RepositoryCoreTests {
         var repo = new List<Person> { new Person() }.AsRepository();
         var queryable = repo.AsQueryable();
         Assert.NotNull(queryable);
-    }
-
-    [Fact]
-    public void RepositoryExtensions_RequirePageable_NonPageable_Throws() {
-        IRepository<Person, object> repo = new NonFilterableRepo<Person>();
-        Assert.Throws<NotSupportedException>(() => repo.GetPage(new PageQuery<Person>(1, 10)));
     }
 }
 

--- a/test/Kista.XUnit/Unit/ServiceCollectionExtensionsTests.cs
+++ b/test/Kista.XUnit/Unit/ServiceCollectionExtensionsTests.cs
@@ -86,7 +86,7 @@ public class ServiceCollectionExtensionsTests
 	[Fact]
 	public void ServiceCollectionExtensions_AddRepositoryController_Default_Obsolete_StillWorks() {
 		var services = new ServiceCollection();
-		services.AddRepositoryController();
+		services.AddRepositoryController<TestRepositoryController>();
 		var provider = services.BuildServiceProvider();
 		Assert.NotNull(provider.GetService<IRepositoryController>());
 	}
@@ -95,16 +95,16 @@ public class ServiceCollectionExtensionsTests
 	/// A stub implementation of <see cref="ISystemTime"/> that delegates to the real system clock,
 	/// used to verify custom <see cref="ISystemTime"/> registration overloads.
 	/// </summary>
-	private class TestTime : ISystemTime
+	private sealed class TestTime : ISystemTime
 	{
 		public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
 		public DateTimeOffset Now => DateTimeOffset.Now;
 	}
 
-	private class TestRepositoryController : IRepositoryController {
-		public ValueTask CreateRepositoryAsync<TEntity>(CancellationToken ct = default) where TEntity : class => ValueTask.CompletedTask;
-		public ValueTask CreateRepositoryAsync<TEntity, TKey>(CancellationToken ct = default) where TEntity : class => ValueTask.CompletedTask;
-		public ValueTask DropRepositoryAsync<TEntity>(CancellationToken ct = default) where TEntity : class => ValueTask.CompletedTask;
-		public ValueTask DropRepositoryAsync<TEntity, TKey>(CancellationToken ct = default) where TEntity : class => ValueTask.CompletedTask;
+	private sealed class TestRepositoryController : IRepositoryController {
+		public ValueTask CreateRepositoryAsync<TEntity>(CancellationToken cancellationToken = default) where TEntity : class => ValueTask.CompletedTask;
+		public ValueTask CreateRepositoryAsync<TEntity, TKey>(CancellationToken cancellationToken = default) where TEntity : class => ValueTask.CompletedTask;
+		public ValueTask DropRepositoryAsync<TEntity>(CancellationToken cancellationToken = default) where TEntity : class => ValueTask.CompletedTask;
+		public ValueTask DropRepositoryAsync<TEntity, TKey>(CancellationToken cancellationToken = default) where TEntity : class => ValueTask.CompletedTask;
 	}
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the user identifier strategy and owner scoping infrastructure, focusing on robustness, code clarity, and type safety. The main changes include enhanced exception handling during user ID conversion, improved equality checks for user IDs, making interfaces more flexible, and minor code cleanups.

**User Identifier Strategy Improvements:**

* Exception handling in `ConvertValue` methods for `ClaimUserIdentifierStrategy`, `RouteUserIdentifierStrategy`, and `QueryStringUserIdentifierStrategy` is now more robust, catching specific exceptions and returning default values on failure. The methods are also now static. [[1]](diffhunk://#diff-a8285514c894af28f8ed2b6055e2df24350dc6f248342099c6da32dd9a41e8a5L59-R59) [[2]](diffhunk://#diff-a8285514c894af28f8ed2b6055e2df24350dc6f248342099c6da32dd9a41e8a5L69-R81) [[3]](diffhunk://#diff-9a38e54631d026997cd2db95c642809d5a14d29dc86b8d5bcc7dc50a43512acdL57-R57) [[4]](diffhunk://#diff-9a38e54631d026997cd2db95c642809d5a14d29dc86b8d5bcc7dc50a43512acdL67-R79) [[5]](diffhunk://#diff-cf2b618a9f99b31f9e27bc620a250fe022e4fc435d844dedc379b92c59fe42a0L57-R57) [[6]](diffhunk://#diff-cf2b618a9f99b31f9e27bc620a250fe022e4fc435d844dedc379b92c59fe42a0L67-R79)
* The `IUserIdentifierStrategy<TKey>` interface is now covariant (`out TKey`), improving type safety and flexibility.
* The composite strategy uses `EqualityComparer<TKey>.Default` for safer default checks, instead of null checks.

**User Scoped Repository Enhancements:**

* All checks for unset user context now use `EqualityComparer<TUserKey>.Default.Equals(userId, default)` for correctness, and a constant message is used for exceptions. [[1]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8R40) [[2]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L75-R79) [[3]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L105-R107) [[4]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L114-R116) [[5]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L165-R173) [[6]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L181-R185) [[7]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L194-R196) [[8]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L205-R207) [[9]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L217-R219) [[10]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L229-R233)
* `BuildOwnerFilter` is now static, and property/attribute discovery uses LINQ for clarity. [[1]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L264-L266) [[2]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8L290-R291)

**Repository Registration and Builder Refactoring:**

* `AddRepository` now registers all repository service types properly and repositions the `FindRepositoryInterface` helper for better code organization. [[1]](diffhunk://#diff-8a29cdd9db9824c685a47a76daf1140b3891cc3a2746e30735152b3050f09400L100-L103) [[2]](diffhunk://#diff-8a29cdd9db9824c685a47a76daf1140b3891cc3a2746e30735152b3050f09400L120-L131) [[3]](diffhunk://#diff-8a29cdd9db9824c685a47a76daf1140b3891cc3a2746e30735152b3050f09400R137-R148)
* The method for finding user key types in `RepositoryBuilderExtensions` uses LINQ for cleaner generic interface filtering.

**General Code Cleanups:**

* Added missing `using` directives for `System.Linq` and `System.Collections.Generic` in several files. [[1]](diffhunk://#diff-96da48ab944c4aad340eb2e33c8cbcfee68cf596f08f59de1943af06cbdf50dcR1) [[2]](diffhunk://#diff-bd436bf2055917d4ad1f3ced237500e2dea0b6ae98bb56b0315ef46dd2769ed8R1) [[3]](diffhunk://#diff-590b7914cce9c0da8879ebebf1129eb1caa5597901b1099d6b92e4c9ab7855dfR1)
* Several helper and test classes are now marked as `sealed` for clarity and intent. [[1]](diffhunk://#diff-8b68fd57c9d6f4150fb8f49ba5c337be6e3fc0d0d00aa13f91aef8fdff5aa264L459-R459) [[2]](diffhunk://#diff-6bf3227197aeb4bbf48bd75c67fe5b2fa7cf5c747b938547ce094cfac83a3eb7L352-R352)
* Test assertions now consistently use `Guid.Empty` instead of `default(Guid)` for clarity. [[1]](diffhunk://#diff-8b68fd57c9d6f4150fb8f49ba5c337be6e3fc0d0d00aa13f91aef8fdff5aa264L28-R28) [[2]](diffhunk://#diff-8b68fd57c9d6f4150fb8f49ba5c337be6e3fc0d0d00aa13f91aef8fdff5aa264L173-R173)

**Application Startup:**

* The main application now uses `await app.RunAsync()` for proper async startup.