### PR TITLE
Update package references

### DIFF
--- a/benchmarks/repobench/repobench.csproj
+++ b/benchmarks/repobench/repobench.csproj
@@ -12,8 +12,8 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.15" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="8.0.14" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="9.0.11" Condition="'$(TargetFramework)' == 'net9.0'" />
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.1" Condition="'$(TargetFramework)' == 'net10.0'" />

--- a/src/Kista.EntityFramework.MultiTenant/Kista.EntityFramework.MultiTenant.csproj
+++ b/src/Kista.EntityFramework.MultiTenant/Kista.EntityFramework.MultiTenant.csproj
@@ -9,12 +9,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Finbuckle.MultiTenant" Version="8.1.12" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="8.1.14" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Finbuckle.MultiTenant" Version="9.4.7" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="9.4.9" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Finbuckle.MultiTenant" Version="10.0.4" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/src/Kista.EntityFramework/Kista.EntityFramework.csproj
+++ b/src/Kista.EntityFramework/Kista.EntityFramework.csproj
@@ -6,13 +6,13 @@
 	</PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.27" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.15" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.16" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Kista.InMemory/Kista.InMemory.csproj
+++ b/src/Kista.InMemory/Kista.InMemory.csproj
@@ -11,12 +11,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/src/Kista.Manager/Kista.Manager.csproj
+++ b/src/Kista.Manager/Kista.Manager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Deveel.Results" Version="1.2.1" />
+        <PackageReference Include="Deveel.Results" Version="1.2.2" />
     </ItemGroup>
     
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -14,12 +14,12 @@
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.15" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.16" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5"/>
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.6" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8"/>
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
     </ItemGroup>
 
   <ItemGroup>

--- a/src/Kista.MongoFramework.MultiTenant/Kista.MongoFramework.MultiTenant.csproj
+++ b/src/Kista.MongoFramework.MultiTenant/Kista.MongoFramework.MultiTenant.csproj
@@ -9,12 +9,12 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Finbuckle.MultiTenant" Version="8.1.12" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="8.1.14" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Finbuckle.MultiTenant" Version="9.4.7" />
+        <PackageReference Include="Finbuckle.MultiTenant" Version="9.4.9" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Finbuckle.MultiTenant" Version="10.0.4" />
+        <PackageReference Include="Finbuckle.MultiTenant" Version="10.0.8" />
     </ItemGroup>
 </Project>

--- a/src/Kista.MongoFramework/Kista.MongoFramework.csproj
+++ b/src/Kista.MongoFramework/Kista.MongoFramework.csproj
@@ -9,13 +9,13 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.14" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.16" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
     </ItemGroup>
   <ItemGroup>
-		<PackageReference Include="MongoFramework" Version="0.29.0" />
+      <PackageReference Include="MongoFramework" Version="0.29.0" />
       <PackageReference Include="Snappier" Version="1.3.1"/>
       <PackageReference Include="SharpCompress" Version="0.48.1"/>
 	</ItemGroup>

--- a/src/Kista/Kista.csproj
+++ b/src/Kista/Kista.csproj
@@ -6,19 +6,19 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.14" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.14" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.14" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.16" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.16" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.16" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
     </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Deveel.Filters" Version="2.0.1" />

--- a/test/Kista.EntityFramework.XUnit/Kista.EntityFramework.XUnit.csproj
+++ b/test/Kista.EntityFramework.XUnit/Kista.EntityFramework.XUnit.csproj
@@ -10,17 +10,17 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="8.0.26" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="8.0.11" />
-        <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="8.0.0" />
+        <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="8.1.14" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="9.0.15" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="9.0.15" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="9.0.4" />
-        <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="9.4.7" />
+        <PackageReference Include="Finbuckle.MultiTenant.EntityFrameworkCore" Version="9.4.9" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-        <PackageReference Include="Finbuckle.MultiTenant" Version="10.0.4" />
+        <PackageReference Include="Finbuckle.MultiTenant" Version="10.1.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="10.0.5" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite" Version="10.0.5" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />

--- a/test/Kista.MongoFramework.XUnit/Kista.MongoFramework.XUnit.csproj
+++ b/test/Kista.MongoFramework.XUnit/Kista.MongoFramework.XUnit.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Finbuckle.MultiTenant" Version="8.1.12" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="8.1.14" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageReference Include="Finbuckle.MultiTenant" Version="9.4.7" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="9.4.9" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageReference Include="Finbuckle.MultiTenant" Version="10.0.4" />
+    <PackageReference Include="Finbuckle.MultiTenant" Version="10.0.8" />
   </ItemGroup>
 
 


### PR DESCRIPTION
This pull request updates various package dependencies across multiple project files to their latest patch or minor versions. The changes focus on keeping the codebase up-to-date with the most recent stable releases, primarily for Microsoft.Extensions, Entity Framework Core, Finbuckle.MultiTenant, and related libraries. These updates help ensure compatibility, security, and access to the latest features and bug fixes.

**Dependency version updates:**

* Microsoft.Extensions.DependencyInjection and related libraries have been updated to the latest patch versions for all target frameworks in several projects, including `Kista.InMemory`, `Kista.Manager`, `Kista`, and `repobench` (`Kista.InMemory.csproj`, `Kista.Manager.csproj`, `Kista.csproj`, `repobench.csproj`). [[1]](diffhunk://#diff-2da543830e2b53584ba19742d17fd918a5a58ac82f4a776f5a6ad75c0fefbe57L14-R20) [[2]](diffhunk://#diff-5739bc7aa8a98954fe62164e2a8d9d23be792218579fda52bfb4490acbab840cL9-R22) [[3]](diffhunk://#diff-7168ef680d4e395eef4b1638c54b5ad6805a1dd1a2fe1804552cd574e27e5768L9-R21) [[4]](diffhunk://#diff-9573fd61ada19f045316603681facf3386713ba0b391db5d623cc51b3949e33cL15-R16)
* Microsoft.EntityFrameworkCore and related packages have been updated to newer versions in `Kista.EntityFramework` and its test projects (`Kista.EntityFramework.csproj`, `Kista.EntityFramework.XUnit.csproj`). [[1]](diffhunk://#diff-3e85bc97eab87ee2ec16861a3cf1c6d3a9e981e27393cd3add3efab90d0b8391L9-R15) [[2]](diffhunk://#diff-e335360c35824972b5f9e92090abc7d11a7a525f6c56a2f0cb62d0186fae3985L13-R23)
* Finbuckle.MultiTenant and Finbuckle.MultiTenant.EntityFrameworkCore dependencies have been updated to newer versions across all relevant projects and test projects (`Kista.EntityFramework.MultiTenant.csproj`, `Kista.MongoFramework.MultiTenant.csproj`, `Kista.EntityFramework.XUnit.csproj`, `Kista.MongoFramework.XUnit.csproj`). [[1]](diffhunk://#diff-c0c11f99178f6fe0d88f79694dc502cf44374359ef8a59c7363350cbfa3138aeL12-R18) [[2]](diffhunk://#diff-2a41e9feaa55eb1a314cfbc7416a2cef570d36b3e034f4cdc1c1cdeaa2d0d460L12-R18) [[3]](diffhunk://#diff-e335360c35824972b5f9e92090abc7d11a7a525f6c56a2f0cb62d0186fae3985L13-R23) [[4]](diffhunk://#diff-5f5dbaa1900f9304731f65f84c212b98cffb83eb571e7cf53e4afd40ac4d3b32L4-R10)
* Microsoft.Extensions.Options.ConfigurationExtensions and Microsoft.Extensions.Logging.Abstractions have been updated to the latest patch versions in `Kista.Manager`, `Kista.MongoFramework`, and `Kista` (`Kista.Manager.csproj`, `Kista.MongoFramework.csproj`, `Kista.csproj`). [[1]](diffhunk://#diff-5739bc7aa8a98954fe62164e2a8d9d23be792218579fda52bfb4490acbab840cL9-R22) [[2]](diffhunk://#diff-3d7ae77346ab347d88640aaadb402a0d79629bcba3f1ba5bcb6eb7c27b1cd2c0L12-R15) [[3]](diffhunk://#diff-7168ef680d4e395eef4b1638c54b5ad6805a1dd1a2fe1804552cd574e27e5768L9-R21)
* Deveel.Results has been updated to version 1.2.2 in `Kista.Manager.csproj`.

These updates are routine maintenance to keep the dependencies current and do not introduce any breaking changes or new features.