### PR TITLE
Decouple entity caching and introduce FusionCache and DistributedCache

### DIFF
--- a/Kista.sln
+++ b/Kista.sln
@@ -50,6 +50,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kista.Manager.EasyCaching",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kista.Manager.EasyCaching.XUnit", "test\Kista.Manager.EasyCaching.XUnit\Kista.Manager.EasyCaching.XUnit.csproj", "{F47C196B-758D-4C05-8918-FB63C61649EB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kista.Manager.FusionCache", "src\Kista.Manager.FusionCache\Kista.Manager.FusionCache.csproj", "{2D9B7C1A-3E5F-4A8B-BC1D-6F8E9A7B4C2D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kista.Manager.FusionCache.XUnit", "test\Kista.Manager.FusionCache.XUnit\Kista.Manager.FusionCache.XUnit.csproj", "{3E0C8D2B-4F6A-5B9C-C0E2-7A9F0B8C5D3E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kista.Manager.DistributedCache", "src\Kista.Manager.DistributedCache\Kista.Manager.DistributedCache.csproj", "{4F1D9E3C-5A7B-6C0D-D1F3-8B0A1C9D6E4F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kista.Manager.DistributedCache.XUnit", "test\Kista.Manager.DistributedCache.XUnit\Kista.Manager.DistributedCache.XUnit.csproj", "{5A2E0F4D-6B8C-7D1E-E2A4-9C1B2D0E7F5A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kista.Manager.MemoryCache.XUnit", "test\Kista.Manager.MemoryCache.XUnit\Kista.Manager.MemoryCache.XUnit.csproj", "{6B3F1A5E-7C9D-8E2F-F3B5-0D2C3E1F8A6B}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kista.Management.Testing", "test\Kista.Management.Testing\Kista.Management.Testing.csproj", "{7DC0EA52-DAAB-49D4-8443-3409C001E27E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "management", "management", "{85200FA4-CC68-4758-B6E5-287E8AFA79FE}"
@@ -426,6 +436,16 @@ Global
 		{92B6334E-D360-4EDB-9E34-A8F661E433F7}.Release|x64.Build.0 = Release|Any CPU
 		{92B6334E-D360-4EDB-9E34-A8F661E433F7}.Release|x86.ActiveCfg = Release|Any CPU
 		{92B6334E-D360-4EDB-9E34-A8F661E433F7}.Release|x86.Build.0 = Release|Any CPU
+		{4F1D9E3C-5A7B-6C0D-D1F3-8B0A1C9D6E4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F1D9E3C-5A7B-6C0D-D1F3-8B0A1C9D6E4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A2E0F4D-6B8C-7D1E-E2A4-9C1B2D0E7F5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A2E0F4D-6B8C-7D1E-E2A4-9C1B2D0E7F5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D9B7C1A-3E5F-4A8B-BC1D-6F8E9A7B4C2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D9B7C1A-3E5F-4A8B-BC1D-6F8E9A7B4C2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E0C8D2B-4F6A-5B9C-C0E2-7A9F0B8C5D3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E0C8D2B-4F6A-5B9C-C0E2-7A9F0B8C5D3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B3F1A5E-7C9D-8E2F-F3B5-0D2C3E1F8A6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B3F1A5E-7C9D-8E2F-F3B5-0D2C3E1F8A6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -461,6 +481,11 @@ Global
 		{C4CE594C-71F8-4052-98CA-99B027DA9A8E} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 		{62506A7F-7217-4204-9B6B-5638AE44AC05} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
 		{92B6334E-D360-4EDB-9E34-A8F661E433F7} = {50434E05-0F21-4871-AFB3-A483CEE4A300}
+		{4F1D9E3C-5A7B-6C0D-D1F3-8B0A1C9D6E4F} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
+		{2D9B7C1A-3E5F-4A8B-BC1D-6F8E9A7B4C2D} = {2860FD4D-510F-43C8-870E-5559B90D0CAD}
+		{5A2E0F4D-6B8C-7D1E-E2A4-9C1B2D0E7F5A} = {50434E05-0F21-4871-AFB3-A483CEE4A300}
+		{3E0C8D2B-4F6A-5B9C-C0E2-7A9F0B8C5D3E} = {50434E05-0F21-4871-AFB3-A483CEE4A300}
+		{6B3F1A5E-7C9D-8E2F-F3B5-0D2C3E1F8A6B} = {50434E05-0F21-4871-AFB3-A483CEE4A300}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {01FD9B16-84B3-4D99-80C1-11B2F3D65B56}

--- a/src/Kista.Manager.DistributedCache/Caching/DistributedCacheExtensions.cs
+++ b/src/Kista.Manager.DistributedCache/Caching/DistributedCacheExtensions.cs
@@ -1,0 +1,145 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Kista.Caching {
+	/// <summary>
+	/// Options for configuring <see cref="IDistributedCache"/>-based entity caching.
+	/// </summary>
+	public class DistributedCachingOptions {
+		/// <summary>
+		/// Gets or sets the default expiration time for cached entities.
+		/// When set, all registered entity caches will use this expiration.
+		/// </summary>
+		public TimeSpan? DefaultExpiration { get; set; }
+
+		/// <summary>
+		/// Gets or sets a prefix to prepend to all cache keys.
+		/// Useful for isolating caches across environments or applications.
+		/// </summary>
+		public string? CacheKeyPrefix { get; set; }
+	}
+
+	internal sealed class ConfiguredDistributedCacheOptions<TEntity> : IConfigureOptions<EntityCacheOptions<TEntity>>
+		where TEntity : class {
+
+		private readonly TimeSpan? _expiration;
+		private readonly string? _prefix;
+
+		public ConfiguredDistributedCacheOptions(TimeSpan? expiration, string? prefix) {
+			_expiration = expiration;
+			_prefix = prefix;
+		}
+
+		public void Configure(EntityCacheOptions<TEntity> options) {
+			if (_expiration.HasValue)
+				options.Expiration = _expiration;
+			if (!string.IsNullOrEmpty(_prefix))
+				options.CacheKeyPrefix = _prefix;
+		}
+	}
+
+	/// <summary>
+	/// Extension methods for configuring <see cref="IDistributedCache"/>-based caching
+	/// on a <see cref="RepositoryContextBuilder"/> or <see cref="IServiceCollection"/>.
+	/// </summary>
+	public static class DistributedCacheServiceExtensions {
+		/// <summary>
+		/// Enables distributed caching for all tracked entity types.
+		/// Registers <see cref="EntityDistributedCache{TEntity}"/> for each entity type
+		/// that has a repository registered.
+		/// </summary>
+		/// <param name="builder">
+		/// The repository context builder to configure.
+		/// </param>
+		/// <param name="configure">
+		/// An optional delegate to configure the distributed caching options.
+		/// </param>
+		/// <param name="lifetime">
+		/// The service lifetime for the cache registrations (default: Singleton).
+		/// </param>
+		/// <returns>
+		/// Returns the builder for chaining.
+		/// </returns>
+		public static RepositoryContextBuilder WithDistributedCaching(
+			this RepositoryContextBuilder builder,
+			Action<DistributedCachingOptions>? configure = null,
+			ServiceLifetime lifetime = ServiceLifetime.Singleton) {
+
+			var options = new DistributedCachingOptions();
+			configure?.Invoke(options);
+
+			foreach (var entityType in builder.RegisteredEntityTypes) {
+				var cacheType = typeof(EntityDistributedCache<>).MakeGenericType(entityType);
+				var cacheInterface = typeof(IEntityCache<>).MakeGenericType(entityType);
+
+				builder.Services.TryAdd(new ServiceDescriptor(cacheInterface, cacheType, lifetime));
+				builder.Services.TryAdd(new ServiceDescriptor(cacheType, cacheType, lifetime));
+
+				if (options.DefaultExpiration.HasValue || !string.IsNullOrEmpty(options.CacheKeyPrefix)) {
+					var entityOptionsType = typeof(EntityCacheOptions<>).MakeGenericType(entityType);
+					var expiration = options.DefaultExpiration;
+					var prefix = options.CacheKeyPrefix;
+
+					builder.Services.AddSingleton(typeof(IConfigureOptions<>).MakeGenericType(entityOptionsType), sp => {
+						return Activator.CreateInstance(
+							typeof(ConfiguredDistributedCacheOptions<>).MakeGenericType(entityType),
+							expiration, prefix)!;
+					});
+				}
+			}
+
+			return builder;
+		}
+
+		/// <summary>
+		/// Registers an <see cref="EntityDistributedCache{TEntity}"/> for the given entity type.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of the entity to cache.
+		/// </typeparam>
+		/// <param name="services">
+		/// The service collection to register the cache.
+		/// </param>
+		/// <param name="configure">
+		/// An optional delegate to configure the cache options.
+		/// </param>
+		/// <param name="lifetime">
+		/// The service lifetime (default: Singleton).
+		/// </param>
+		/// <returns>
+		/// Returns the service collection for chaining.
+		/// </returns>
+		public static IServiceCollection AddEntityDistributedCacheFor<TEntity>(
+			this IServiceCollection services,
+			Action<EntityCacheOptions>? configure = null,
+			ServiceLifetime lifetime = ServiceLifetime.Singleton)
+			where TEntity : class {
+
+			if (configure != null) {
+				services.AddOptions<EntityCacheOptions<TEntity>>()
+					.Configure(options => configure(options));
+			}
+
+			services.TryAdd(new ServiceDescriptor(typeof(IEntityCache<TEntity>), typeof(EntityDistributedCache<TEntity>), lifetime));
+			services.TryAdd(new ServiceDescriptor(typeof(EntityDistributedCache<TEntity>), typeof(EntityDistributedCache<TEntity>), lifetime));
+
+			return services;
+		}
+	}
+}

--- a/src/Kista.Manager.DistributedCache/Caching/EntityDistributedCache.cs
+++ b/src/Kista.Manager.DistributedCache/Caching/EntityDistributedCache.cs
@@ -1,0 +1,145 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.Json;
+
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
+
+namespace Kista.Caching {
+	/// <summary>
+	/// An implementation of <see cref="IEntityCache{TEntity}"/> that
+	/// uses <see cref="IDistributedCache"/> as the backing cache store.
+	/// </summary>
+	/// <typeparam name="TEntity">
+	/// The type of the entity to cache.
+	/// </typeparam>
+	/// <remarks>
+	/// <para>
+	/// This implementation serializes entities to JSON using
+	/// <see cref="System.Text.Json"/> for storage in a distributed cache
+	/// (e.g. Redis via <c>Microsoft.Extensions.Caching.StackExchangeRedis</c>,
+	/// SQL Server via <c>Microsoft.Extensions.Caching.SqlServer</c>).
+	/// </para>
+	/// <para>
+	/// Expiration is configured via <see cref="EntityCacheOptions{TEntity}"/>.
+	/// When no expiration is configured, entities are cached with a default
+	/// of 5 minutes.
+	/// </para>
+	/// </remarks>
+	public class EntityDistributedCache<TEntity> : IEntityCache<TEntity>
+		where TEntity : class {
+
+		private static readonly JsonSerializerOptions DefaultJsonOptions = new() {
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+			PropertyNameCaseInsensitive = true,
+		};
+
+		private readonly IDistributedCache _cache;
+		private readonly EntityCacheOptions<TEntity>? _options;
+
+		/// <summary>
+		/// Constructs the cache with the given distributed cache and options.
+		/// </summary>
+		/// <param name="cache">
+		/// The <see cref="IDistributedCache"/> instance used to store entities.
+		/// </param>
+		/// <param name="options">
+		/// An optional set of options to configure the entity cache.
+		/// </param>
+		public EntityDistributedCache(
+			IDistributedCache cache,
+			IOptions<EntityCacheOptions<TEntity>>? options = null) {
+			_cache = cache;
+			_options = options?.Value;
+		}
+
+		/// <summary>
+		/// Gets the expiration time for cached entities.
+		/// </summary>
+		protected virtual TimeSpan Expiration => _options?.Expiration ?? TimeSpan.FromMinutes(5);
+
+		/// <summary>
+		/// Gets the <see cref="JsonSerializerOptions"/> used for serialization.
+		/// Override to customize serialization behavior.
+		/// </summary>
+		protected virtual JsonSerializerOptions JsonOptions => DefaultJsonOptions;
+
+		/// <inheritdoc/>
+		public async ValueTask<TEntity?> GetOrSetAsync(string cacheKey, Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken = default) {
+			var bytes = await _cache.GetAsync(cacheKey, cancellationToken);
+			if (bytes != null) {
+				return Deserialize(bytes);
+			}
+
+			var entity = await valueFactory();
+			if (entity == null)
+				return null;
+
+			var entryOptions = GetDistributedCacheEntryOptions();
+			var serialized = Serialize(entity);
+			await _cache.SetAsync(cacheKey, serialized, entryOptions, cancellationToken);
+
+			return entity;
+		}
+
+		/// <inheritdoc/>
+		public async ValueTask SetAsync(string[] cacheKeys, TEntity entity, CancellationToken cancellationToken = default) {
+			var entryOptions = GetDistributedCacheEntryOptions();
+			var serialized = Serialize(entity);
+
+			foreach (var key in cacheKeys) {
+				await _cache.SetAsync(key, serialized, entryOptions, cancellationToken);
+			}
+		}
+
+		/// <inheritdoc/>
+		public async ValueTask RemoveAsync(string[] cacheKeys, CancellationToken cancellationToken = default) {
+			foreach (var key in cacheKeys) {
+				await _cache.RemoveAsync(key, cancellationToken);
+			}
+		}
+
+		/// <summary>
+		/// Creates the <see cref="DistributedCacheEntryOptions"/> from the
+		/// configured <see cref="EntityCacheOptions{TEntity}"/>.
+		/// </summary>
+		/// <returns>
+		/// Returns an instance of <see cref="DistributedCacheEntryOptions"/>.
+		/// </returns>
+		protected virtual DistributedCacheEntryOptions GetDistributedCacheEntryOptions() {
+			return new DistributedCacheEntryOptions {
+				AbsoluteExpirationRelativeToNow = Expiration,
+			};
+		}
+
+		/// <summary>
+		/// Serializes the given entity to a byte array.
+		/// </summary>
+		/// <param name="entity">The entity to serialize.</param>
+		/// <returns>The serialized bytes.</returns>
+		protected virtual byte[] Serialize(TEntity entity) {
+			return JsonSerializer.SerializeToUtf8Bytes(entity, JsonOptions);
+		}
+
+		/// <summary>
+		/// Deserializes the given byte array back to an entity.
+		/// </summary>
+		/// <param name="bytes">The serialized bytes.</param>
+		/// <returns>The deserialized entity, or <c>null</c> if deserialization failed.</returns>
+		protected virtual TEntity? Deserialize(byte[] bytes) {
+			return JsonSerializer.Deserialize<TEntity>(bytes, JsonOptions);
+		}
+	}
+}

--- a/src/Kista.Manager.DistributedCache/Kista.Manager.DistributedCache.csproj
+++ b/src/Kista.Manager.DistributedCache/Kista.Manager.DistributedCache.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageTags>repository;manager;entitymanager;entity;cache;caching;distributedcache;redis</PackageTags>
+    <Description>Extends the Entity Manager with an implementation of the entity cache backed by IDistributedCache</Description>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.16" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kista.Manager\Kista.Manager.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Kista.Manager.EasyCaching/Caching/EntityEasyCache_2.cs
+++ b/src/Kista.Manager.EasyCaching/Caching/EntityEasyCache_2.cs
@@ -127,14 +127,6 @@ namespace Kista.Caching {
 		}
 
 		/// <inheritdoc/>
-		public virtual string[] GenerateKeys(TEntity entity) {
-			if (keyGenerator == null)
-				throw new NotSupportedException("The key generator is not defined for this cache");
-
-			return keyGenerator.GenerateAllKeys(entity);
-		}
-
-		/// <inheritdoc/>
 		public async ValueTask<TEntity?> GetOrSetAsync(string cacheKey, Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken = default) {
 			try {
 				var factory = Factory(valueFactory, cancellationToken);

--- a/src/Kista.Manager.FusionCache/Caching/EntityFusionCache.cs
+++ b/src/Kista.Manager.FusionCache/Caching/EntityFusionCache.cs
@@ -1,0 +1,92 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Kista.Caching {
+	public class EntityFusionCache<TEntity> : IEntityCache<TEntity>
+		where TEntity : class {
+
+		private readonly IFusionCache _cache;
+		private readonly EntityCacheOptions<TEntity>? _entityOptions;
+		private readonly FusionCachingOptions? _fusionOptions;
+
+		public EntityFusionCache(
+			IFusionCache cache,
+			IOptions<EntityCacheOptions<TEntity>>? entityOptions = null,
+			IOptions<FusionCachingOptions>? fusionOptions = null) {
+			_cache = cache;
+			_entityOptions = entityOptions?.Value;
+			_fusionOptions = fusionOptions?.Value;
+		}
+
+		protected virtual FusionCacheEntryOptions GetEntryOptions() {
+			if (_fusionOptions != null) {
+				var options = new FusionCacheEntryOptions {
+					Duration = _fusionOptions.DefaultEntryDuration ?? _entityOptions?.Expiration ?? TimeSpan.FromMinutes(5),
+					IsFailSafeEnabled = _fusionOptions.FailSafeEnabled ?? false,
+					Priority = _fusionOptions.Priority ?? CacheItemPriority.Normal,
+				};
+
+				if (_fusionOptions.FailSafeMaxDuration.HasValue)
+					options.FailSafeMaxDuration = _fusionOptions.FailSafeMaxDuration.Value;
+				if (_fusionOptions.FactorySoftTimeout.HasValue)
+					options.FactorySoftTimeout = _fusionOptions.FactorySoftTimeout.Value;
+				if (_fusionOptions.FactoryHardTimeout.HasValue)
+					options.FactoryHardTimeout = _fusionOptions.FactoryHardTimeout.Value;
+				if (_fusionOptions.EagerRefreshThreshold.HasValue)
+					options.EagerRefreshThreshold = _fusionOptions.EagerRefreshThreshold.Value;
+
+				return options;
+			}
+
+			return new FusionCacheEntryOptions {
+				Duration = _entityOptions?.Expiration ?? TimeSpan.FromMinutes(5),
+			};
+		}
+
+		public async ValueTask<TEntity?> GetOrSetAsync(string cacheKey, Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken = default) {
+			var entryOptions = GetEntryOptions();
+
+			var result = await _cache.GetOrSetAsync<TEntity?>(cacheKey, async (ct) => {
+				return await valueFactory();
+			}, entryOptions, cancellationToken);
+
+			return result;
+		}
+
+		public async ValueTask SetAsync(string[] cacheKeys, TEntity entity, CancellationToken cancellationToken = default) {
+			if (cacheKeys.Length == 0)
+				return;
+
+			var entryOptions = GetEntryOptions();
+
+			foreach (var key in cacheKeys) {
+				await _cache.SetAsync(key, entity, entryOptions, cancellationToken);
+			}
+		}
+
+		public async ValueTask RemoveAsync(string[] cacheKeys, CancellationToken cancellationToken = default) {
+			if (cacheKeys.Length == 0)
+				return;
+
+			foreach (var key in cacheKeys) {
+				await _cache.RemoveAsync(key, default(Action<FusionCacheEntryOptions>?), cancellationToken);
+			}
+		}
+	}
+}

--- a/src/Kista.Manager.FusionCache/Caching/FusionCacheExtensions.cs
+++ b/src/Kista.Manager.FusionCache/Caching/FusionCacheExtensions.cs
@@ -1,0 +1,130 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Kista.Caching {
+	public class FusionCachingOptions {
+		public TimeSpan? DefaultEntryDuration { get; set; }
+		public bool? FailSafeEnabled { get; set; }
+		public TimeSpan? FailSafeMaxDuration { get; set; }
+		public TimeSpan? FactorySoftTimeout { get; set; }
+		public TimeSpan? FactoryHardTimeout { get; set; }
+		public CacheItemPriority? Priority { get; set; }
+		public float? EagerRefreshThreshold { get; set; }
+	}
+
+	internal sealed class ConfiguredFusionCacheOptions<TEntity> : IConfigureOptions<EntityCacheOptions<TEntity>>
+		where TEntity : class {
+
+		private readonly FusionCachingOptions _fusionOptions;
+
+		public ConfiguredFusionCacheOptions(FusionCachingOptions fusionOptions) {
+			_fusionOptions = fusionOptions;
+		}
+
+		public void Configure(EntityCacheOptions<TEntity> options) {
+			if (_fusionOptions.DefaultEntryDuration.HasValue)
+				options.Expiration = _fusionOptions.DefaultEntryDuration;
+		}
+	}
+
+	internal sealed class ConfiguredFusionCachingOptions : IConfigureOptions<FusionCachingOptions> {
+		private readonly FusionCachingOptions _options;
+
+		public ConfiguredFusionCachingOptions(FusionCachingOptions options) {
+			_options = options;
+		}
+
+		public void Configure(FusionCachingOptions options) {
+			if (_options.DefaultEntryDuration.HasValue)
+				options.DefaultEntryDuration = _options.DefaultEntryDuration;
+			if (_options.FailSafeEnabled.HasValue)
+				options.FailSafeEnabled = _options.FailSafeEnabled;
+			if (_options.FailSafeMaxDuration.HasValue)
+				options.FailSafeMaxDuration = _options.FailSafeMaxDuration;
+			if (_options.FactorySoftTimeout.HasValue)
+				options.FactorySoftTimeout = _options.FactorySoftTimeout;
+			if (_options.FactoryHardTimeout.HasValue)
+				options.FactoryHardTimeout = _options.FactoryHardTimeout;
+			if (_options.Priority.HasValue)
+				options.Priority = _options.Priority;
+			if (_options.EagerRefreshThreshold.HasValue)
+				options.EagerRefreshThreshold = _options.EagerRefreshThreshold;
+		}
+	}
+
+	public static class FusionCacheServiceExtensions {
+		public static RepositoryContextBuilder WithFusionCaching(
+			this RepositoryContextBuilder builder,
+			Action<FusionCachingOptions>? configure = null,
+			ServiceLifetime lifetime = ServiceLifetime.Singleton) {
+
+			var fusionOptions = new FusionCachingOptions();
+			configure?.Invoke(fusionOptions);
+
+			builder.Services.AddSingleton<IConfigureOptions<FusionCachingOptions>>(
+				new ConfiguredFusionCachingOptions(fusionOptions));
+
+			foreach (var entityType in builder.RegisteredEntityTypes) {
+				var cacheType = typeof(EntityFusionCache<>).MakeGenericType(entityType);
+				var cacheInterface = typeof(IEntityCache<>).MakeGenericType(entityType);
+
+				builder.Services.TryAdd(new ServiceDescriptor(cacheInterface, cacheType, lifetime));
+				builder.Services.TryAdd(new ServiceDescriptor(cacheType, cacheType, lifetime));
+
+				if (fusionOptions.DefaultEntryDuration.HasValue) {
+					var entityOptionsType = typeof(EntityCacheOptions<>).MakeGenericType(entityType);
+					builder.Services.AddSingleton(typeof(IConfigureOptions<>).MakeGenericType(entityOptionsType), sp => {
+						return Activator.CreateInstance(
+							typeof(ConfiguredFusionCacheOptions<>).MakeGenericType(entityType),
+							fusionOptions)!;
+					});
+				}
+			}
+
+			return builder;
+		}
+
+		public static IServiceCollection AddEntityFusionCacheFor<TEntity>(
+			this IServiceCollection services,
+			Action<FusionCachingOptions>? configure = null,
+			ServiceLifetime lifetime = ServiceLifetime.Singleton)
+			where TEntity : class {
+
+			if (configure != null) {
+				var fusionOptions = new FusionCachingOptions();
+				configure(fusionOptions);
+				services.AddSingleton<IConfigureOptions<FusionCachingOptions>>(
+					new ConfiguredFusionCachingOptions(fusionOptions));
+
+				if (fusionOptions.DefaultEntryDuration.HasValue) {
+					services.Configure<EntityCacheOptions<TEntity>>(options => {
+						options.Expiration = fusionOptions.DefaultEntryDuration;
+					});
+				}
+			}
+
+			services.TryAdd(new ServiceDescriptor(typeof(IEntityCache<TEntity>), typeof(EntityFusionCache<TEntity>), lifetime));
+			services.TryAdd(new ServiceDescriptor(typeof(EntityFusionCache<TEntity>), typeof(EntityFusionCache<TEntity>), lifetime));
+
+			return services;
+		}
+	}
+}

--- a/src/Kista.Manager.FusionCache/Kista.Manager.FusionCache.csproj
+++ b/src/Kista.Manager.FusionCache/Kista.Manager.FusionCache.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <PackageTags>repository;manager;entitymanager;entity;cache;caching;fusioncache</PackageTags>
+    <Description>Extends the Entity Manager with an implementation of the entity cache backed by FusionCache</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ZiggyCreatures.FusionCache" Version="2.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kista.Manager\Kista.Manager.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Kista.Manager/Caching/EntityMemoryCache.cs
+++ b/src/Kista.Manager/Caching/EntityMemoryCache.cs
@@ -1,0 +1,106 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Kista.Caching {
+	/// <summary>
+	/// An implementation of <see cref="IEntityCache{TEntity}"/> that
+	/// uses the <see cref="IMemoryCache"/> to store entities in-process.
+	/// </summary>
+	/// <typeparam name="TEntity">
+	/// The type of the entity to cache.
+	/// </typeparam>
+	/// <remarks>
+	/// <para>
+	/// This implementation provides a default in-process caching strategy
+	/// that requires no external dependencies beyond the standard
+	/// <c>Microsoft.Extensions.Caching.Memory</c> package.
+	/// </para>
+	/// <para>
+	/// Expiration is configured via <see cref="EntityCacheOptions{TEntity}"/>.
+	/// When no expiration is configured, entities are cached indefinitely
+	/// (subject to memory pressure eviction by <see cref="IMemoryCache"/>).
+	/// </para>
+	/// </remarks>
+	public class EntityMemoryCache<TEntity> : IEntityCache<TEntity>
+		where TEntity : class {
+
+		private readonly IMemoryCache _cache;
+		private readonly EntityCacheOptions<TEntity>? _options;
+
+		/// <summary>
+		/// Constructs the cache with the given memory cache and options.
+		/// </summary>
+		/// <param name="cache">
+		/// The <see cref="IMemoryCache"/> instance used to store entities.
+		/// </param>
+		/// <param name="options">
+		/// An optional set of options to configure the entity cache.
+		/// </param>
+		public EntityMemoryCache(
+			IMemoryCache cache,
+			IOptions<EntityCacheOptions<TEntity>>? options = null) {
+			_cache = cache;
+			_options = options?.Value;
+		}
+
+		/// <summary>
+		/// Gets the expiration time for cached entities.
+		/// </summary>
+		protected virtual TimeSpan? Expiration => _options?.Expiration;
+
+		/// <inheritdoc/>
+		public async ValueTask<TEntity?> GetOrSetAsync(string cacheKey, Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken = default) {
+			if (_cache.TryGetValue(cacheKey, out TEntity? cached))
+				return cached;
+
+			var entity = await valueFactory();
+			if (entity == null)
+				return null;
+
+			SetCacheEntry(cacheKey, entity);
+
+			return entity;
+		}
+
+		/// <inheritdoc/>
+		public ValueTask SetAsync(string[] cacheKeys, TEntity entity, CancellationToken cancellationToken = default) {
+			foreach (var key in cacheKeys) {
+				SetCacheEntry(key, entity);
+			}
+
+			return ValueTask.CompletedTask;
+		}
+
+		/// <inheritdoc/>
+		public ValueTask RemoveAsync(string[] cacheKeys, CancellationToken cancellationToken = default) {
+			foreach (var key in cacheKeys) {
+				_cache.Remove(key);
+			}
+
+			return ValueTask.CompletedTask;
+		}
+
+		private void SetCacheEntry(string key, TEntity entity) {
+			var expiration = Expiration;
+			if (expiration.HasValue) {
+				_cache.Set(key, entity, expiration.Value);
+			} else {
+				_cache.Set(key, entity);
+			}
+		}
+	}
+}

--- a/src/Kista.Manager/Caching/IEntityCache.cs
+++ b/src/Kista.Manager/Caching/IEntityCache.cs
@@ -19,20 +19,15 @@ namespace Kista.Caching {
 	/// <typeparam name="TEntity">
 	/// The type of the entity to cache.
 	/// </typeparam>
+	/// <remarks>
+	/// <para>
+	/// Implementations of this interface are responsible for storing,
+	/// retrieving, and removing entities from the cache. The key
+	/// generation is handled separately by
+	/// <see cref="IEntityCacheKeyGenerator{TEntity}"/>.
+	/// </para>
+	/// </remarks>
 	public interface IEntityCache<TEntity> where TEntity : class {
-		/// <summary>
-		/// Generates all the keys that can be used to identify
-		/// the given entity in the cache.
-		/// </summary>
-		/// <param name="entity">
-		/// The instance of the entity to generate the keys for.
-		/// </param>
-		/// <returns>
-		/// Returns an array of strings that are the keys that
-		/// will be used to identify the entity in the cache.
-		/// </returns>
-		string[] GenerateKeys(TEntity entity);
-
 		/// <summary>
 		/// Gets the given entity from the cache, if available,
 		/// and uses the given factory to create the entity if to

--- a/src/Kista.Manager/Caching/MemoryCacheExtensions.cs
+++ b/src/Kista.Manager/Caching/MemoryCacheExtensions.cs
@@ -1,0 +1,144 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Kista.Caching {
+	/// <summary>
+	/// Options for configuring the in-process memory caching of entities.
+	/// </summary>
+	public class MemoryCachingOptions {
+		/// <summary>
+		/// Gets or sets the default expiration time for cached entities.
+		/// When set, all registered entity caches will use this expiration.
+		/// </summary>
+		public TimeSpan? DefaultExpiration { get; set; }
+
+		/// <summary>
+		/// Gets or sets a prefix to prepend to all cache keys.
+		/// Useful for isolating caches across environments or applications.
+		/// </summary>
+		public string? CacheKeyPrefix { get; set; }
+	}
+
+	internal sealed class ConfiguredEntityMemoryCacheOptions<TEntity> : IConfigureOptions<EntityCacheOptions<TEntity>>
+		where TEntity : class {
+
+		private readonly TimeSpan? _expiration;
+		private readonly string? _prefix;
+
+		public ConfiguredEntityMemoryCacheOptions(TimeSpan? expiration, string? prefix) {
+			_expiration = expiration;
+			_prefix = prefix;
+		}
+
+		public void Configure(EntityCacheOptions<TEntity> options) {
+			if (_expiration.HasValue)
+				options.Expiration = _expiration;
+			if (!string.IsNullOrEmpty(_prefix))
+				options.CacheKeyPrefix = _prefix;
+		}
+	}
+
+	/// <summary>
+	/// Extension methods for configuring <c>IMemoryCache</c>-based caching
+	/// on a <see cref="RepositoryContextBuilder"/> or <see cref="IServiceCollection"/>.
+	/// </summary>
+	public static class MemoryCacheServiceExtensions {
+		/// <summary>
+		/// Enables in-process memory caching for all tracked entity types.
+		/// Registers <see cref="EntityMemoryCache{TEntity}"/> for each entity type
+		/// that has a repository registered.
+		/// </summary>
+		/// <param name="builder">
+		/// The repository context builder to configure.
+		/// </param>
+		/// <param name="configure">
+		/// An optional delegate to configure the memory caching options.
+		/// </param>
+		/// <param name="lifetime">
+		/// The service lifetime for the cache registrations (default: Singleton).
+		/// </param>
+		/// <returns>
+		/// Returns the builder for chaining.
+		/// </returns>
+		public static RepositoryContextBuilder WithMemoryCaching(
+			this RepositoryContextBuilder builder,
+			Action<MemoryCachingOptions>? configure = null,
+			ServiceLifetime lifetime = ServiceLifetime.Singleton) {
+
+			var options = new MemoryCachingOptions();
+			configure?.Invoke(options);
+
+			foreach (var entityType in builder.RegisteredEntityTypes) {
+				var cacheType = typeof(EntityMemoryCache<>).MakeGenericType(entityType);
+				var cacheInterface = typeof(IEntityCache<>).MakeGenericType(entityType);
+
+				builder.Services.TryAdd(new ServiceDescriptor(cacheInterface, cacheType, lifetime));
+				builder.Services.TryAdd(new ServiceDescriptor(cacheType, cacheType, lifetime));
+
+				if (options.DefaultExpiration.HasValue || !string.IsNullOrEmpty(options.CacheKeyPrefix)) {
+					var entityOptionsType = typeof(EntityCacheOptions<>).MakeGenericType(entityType);
+					var expiration = options.DefaultExpiration;
+					var prefix = options.CacheKeyPrefix;
+
+					builder.Services.AddSingleton(typeof(IConfigureOptions<>).MakeGenericType(entityOptionsType), sp => {
+						return Activator.CreateInstance(
+							typeof(ConfiguredEntityMemoryCacheOptions<>).MakeGenericType(entityType),
+							expiration, prefix)!;
+					});
+				}
+			}
+
+			return builder;
+		}
+
+		/// <summary>
+		/// Registers an <see cref="EntityMemoryCache{TEntity}"/> for the given entity type.
+		/// </summary>
+		/// <typeparam name="TEntity">
+		/// The type of the entity to cache.
+		/// </typeparam>
+		/// <param name="services">
+		/// The service collection to register the cache.
+		/// </param>
+		/// <param name="configure">
+		/// An optional delegate to configure the cache options.
+		/// </param>
+		/// <param name="lifetime">
+		/// The service lifetime (default: Singleton).
+		/// </param>
+		/// <returns>
+		/// Returns the service collection for chaining.
+		/// </returns>
+		public static IServiceCollection AddEntityMemoryCacheFor<TEntity>(
+			this IServiceCollection services,
+			Action<EntityCacheOptions>? configure = null,
+			ServiceLifetime lifetime = ServiceLifetime.Singleton)
+			where TEntity : class {
+
+			if (configure != null) {
+				services.AddOptions<EntityCacheOptions<TEntity>>()
+					.Configure(options => configure(options));
+			}
+
+			services.TryAdd(new ServiceDescriptor(typeof(IEntityCache<TEntity>), typeof(EntityMemoryCache<TEntity>), lifetime));
+			services.TryAdd(new ServiceDescriptor(typeof(EntityMemoryCache<TEntity>), typeof(EntityMemoryCache<TEntity>), lifetime));
+
+			return services;
+		}
+	}
+}

--- a/src/Kista.Manager/EntityManager_T2.cs
+++ b/src/Kista.Manager/EntityManager_T2.cs
@@ -608,20 +608,21 @@ namespace Kista {
 		/// </param>
 		/// <remarks>
 		/// The default implementation of this method uses the
-		/// the <see cref="IEntityCache{TEntity}.GenerateKeys(TEntity)"/>
-		/// method, if any is available, otherwise it returns an
-		/// empty array, that means that the entity will not be
-		/// cached.
+		/// <see cref="IEntityCacheKeyGenerator{TEntity}"/> service
+		/// to generate the cache keys, if any is available, otherwise
+		/// it returns an empty array, meaning that the entity will
+		/// not be cached.
 		/// </remarks>
 		/// <returns>
 		/// Returns an array of strings that are the keys that
 		/// are used to identify the entity in the cache.
 		/// </returns>
 		protected virtual string[] GenerateCacheKeys(TEntity entity) {
-			if (EntityCache == null)
+			var generator = EntityCacheKeyGenerator;
+			if (generator == null)
 				return Array.Empty<string>();
 
-			return EntityCache.GenerateKeys(entity);
+			return generator.GenerateAllKeys(entity);
 		}
 
 		private async ValueTask SetToCacheAsync(TEntity entity, CancellationToken cancellationToken) {

--- a/src/Kista.Manager/Kista.Manager.csproj
+++ b/src/Kista.Manager/Kista.Manager.csproj
@@ -12,14 +12,17 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.*" />
   </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.16" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.*" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8"/>
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.*" />
     </ItemGroup>
 
   <ItemGroup>

--- a/test/Kista.Context.XUnit/Kista.Context.XUnit.csproj
+++ b/test/Kista.Context.XUnit/Kista.Context.XUnit.csproj
@@ -9,6 +9,8 @@
     <ProjectReference Include="..\..\src\Kista.InMemory\Kista.InMemory.csproj" />
     <ProjectReference Include="..\..\src\Kista.Manager\Kista.Manager.csproj" />
     <ProjectReference Include="..\..\src\Kista.Manager.EasyCaching\Kista.Manager.EasyCaching.csproj" />
+    <ProjectReference Include="..\..\src\Kista.Manager.FusionCache\Kista.Manager.FusionCache.csproj" />
+    <ProjectReference Include="..\..\src\Kista.Manager.DistributedCache\Kista.Manager.DistributedCache.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Kista.Context.XUnit/Unit/DistributedCacheExtensionTests.cs
+++ b/test/Kista.Context.XUnit/Unit/DistributedCacheExtensionTests.cs
@@ -1,0 +1,171 @@
+using System.ComponentModel.DataAnnotations;
+
+using Kista.Caching;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Kista;
+
+[Trait("Category", "Integration")]
+[Trait("Layer", "Manager")]
+[Trait("Feature", "DistributedCaching")]
+public class DistributedCacheExtensionTests {
+    [Fact]
+    public void WithDistributedCaching_RegistersCacheForTrackedEntityTypes() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithDistributedCaching();
+
+        var cacheDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IEntityCache<CachingTestEntity>));
+        Assert.NotNull(cacheDescriptor);
+    }
+
+    [Fact]
+    public void WithDistributedCaching_DoesNotRegisterForUntrackedEntityTypes() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .WithDistributedCaching();
+
+        var cacheDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IEntityCache<CachingTestEntity>));
+        Assert.Null(cacheDescriptor);
+    }
+
+    [Fact]
+    public void WithDistributedCaching_WithDefaultExpiration_RegistersOptions() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithDistributedCaching(opts => opts.DefaultExpiration = TimeSpan.FromMinutes(30));
+
+        var optionsDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        Assert.NotNull(optionsDescriptor);
+    }
+
+    [Fact]
+    public void WithDistributedCaching_WithCacheKeyPrefix_RegistersOptions() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithDistributedCaching(opts => opts.CacheKeyPrefix = "myapp:");
+
+        var optionsDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        Assert.NotNull(optionsDescriptor);
+    }
+
+    [Fact]
+    public void WithDistributedCaching_WithOptionsAppliesToAllEntityTypes() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .AddRepository<SecondCachingRepository>(_ => { })
+            .WithDistributedCaching(opts => opts.DefaultExpiration = TimeSpan.FromHours(1));
+
+        var optionsForFirst = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        var optionsForSecond = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<SecondCachingEntity>>));
+
+        Assert.NotNull(optionsForFirst);
+        Assert.NotNull(optionsForSecond);
+    }
+
+    [Fact]
+    public void WithDistributedCaching_EntitySpecificExpirationOverridesGlobal() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithDistributedCaching(opts => opts.DefaultExpiration = TimeSpan.FromHours(1));
+
+        services.AddEntityCacheOptions<CachingTestEntity>(opts => opts.Expiration = TimeSpan.FromMinutes(5));
+
+        var provider = services.BuildServiceProvider();
+        var entityOptions = provider.GetRequiredService<IOptions<EntityCacheOptions<CachingTestEntity>>>();
+
+        Assert.NotNull(entityOptions);
+        Assert.Equal(TimeSpan.FromMinutes(5), entityOptions.Value.Expiration);
+    }
+
+    [Fact]
+    public void WithDistributedCaching_GlobalExpirationAppliedAsFallback() {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithDistributedCaching(opts => opts.DefaultExpiration = TimeSpan.FromHours(1));
+
+        var provider = services.BuildServiceProvider();
+        var entityOptions = provider.GetRequiredService<IOptions<EntityCacheOptions<CachingTestEntity>>>();
+
+        Assert.Equal(TimeSpan.FromHours(1), entityOptions.Value.Expiration);
+    }
+
+    [Fact]
+    public void WithDistributedCaching_WithNoExpiration_DoesNotRegisterOptions() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithDistributedCaching();
+
+        var optionsDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        Assert.Null(optionsDescriptor);
+    }
+
+    [Fact]
+    public void AddEntityDistributedCacheFor_ResolvesCache_WhenDistributedCacheRegistered() {
+        var services = new ServiceCollection();
+        services.AddDistributedMemoryCache();
+        services.AddEntityDistributedCacheFor<CachingTestEntity>(opts => opts.Expiration = TimeSpan.FromMinutes(10));
+
+        var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<IEntityCache<CachingTestEntity>>());
+    }
+
+    [Fact]
+    public void WithDistributedCaching_ResolvesEntityCache_WhenProviderBuilt() {
+        var services = new ServiceCollection();
+        services.AddDistributedMemoryCache();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithDistributedCaching();
+
+        var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<IEntityCache<CachingTestEntity>>());
+    }
+
+    public class SecondCachingEntity {
+        [Key]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+    }
+
+    public class SecondCachingRepository : IRepository<SecondCachingEntity> {
+        public ValueTask AddAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask AddRangeAsync(IEnumerable<SecondCachingEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<bool> UpdateAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask<bool> RemoveAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask RemoveRangeAsync(IEnumerable<SecondCachingEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<SecondCachingEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((SecondCachingEntity?)null);
+        public object? GetEntityKey(SecondCachingEntity entity) => (object?)entity.Id;
+        public ValueTask<PageResult<SecondCachingEntity>> GetPageAsync(PageRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    public class CachingTestEntity {
+        [Key]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+    }
+
+    public class CachingTestRepository : IRepository<CachingTestEntity> {
+        public ValueTask AddAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask AddRangeAsync(IEnumerable<CachingTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<bool> UpdateAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask<bool> RemoveAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask RemoveRangeAsync(IEnumerable<CachingTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<CachingTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((CachingTestEntity?)null);
+        public object? GetEntityKey(CachingTestEntity entity) => (object?)entity.Id;
+        public ValueTask<PageResult<CachingTestEntity>> GetPageAsync(PageRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+}

--- a/test/Kista.Context.XUnit/Unit/FusionCacheExtensionTests.cs
+++ b/test/Kista.Context.XUnit/Unit/FusionCacheExtensionTests.cs
@@ -1,0 +1,202 @@
+using System.ComponentModel.DataAnnotations;
+
+using Kista.Caching;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Kista;
+
+[Trait("Category", "Integration")]
+[Trait("Layer", "Manager")]
+[Trait("Feature", "FusionCaching")]
+public class FusionCacheExtensionTests {
+    [Fact]
+    public void WithFusionCaching_RegistersCacheForTrackedEntityTypes() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithFusionCaching();
+
+        var cacheDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IEntityCache<CachingTestEntity>));
+        Assert.NotNull(cacheDescriptor);
+    }
+
+    [Fact]
+    public void WithFusionCaching_DoesNotRegisterForUntrackedEntityTypes() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .WithFusionCaching();
+
+        var cacheDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IEntityCache<CachingTestEntity>));
+        Assert.Null(cacheDescriptor);
+    }
+
+    [Fact]
+    public void WithFusionCaching_WithDefaultDuration_RegistersOptions() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithFusionCaching(opts => opts.DefaultEntryDuration = TimeSpan.FromMinutes(30));
+
+        var optionsDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        Assert.NotNull(optionsDescriptor);
+    }
+
+    [Fact]
+    public void WithFusionCaching_WithOptionsAppliesToAllEntityTypes() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .AddRepository<SecondCachingRepository>(_ => { })
+            .WithFusionCaching(opts => opts.DefaultEntryDuration = TimeSpan.FromHours(1));
+
+        var optionsForFirst = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        var optionsForSecond = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<SecondCachingEntity>>));
+
+        Assert.NotNull(optionsForFirst);
+        Assert.NotNull(optionsForSecond);
+    }
+
+    [Fact]
+    public void WithFusionCaching_EntitySpecificOptionsOverrideGlobal() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithFusionCaching(opts => opts.DefaultEntryDuration = TimeSpan.FromHours(1));
+
+        services.AddEntityCacheOptions<CachingTestEntity>(opts => opts.Expiration = TimeSpan.FromMinutes(5));
+
+        var provider = services.BuildServiceProvider();
+        var entityOptions = provider.GetRequiredService<IOptions<EntityCacheOptions<CachingTestEntity>>>();
+
+        Assert.NotNull(entityOptions);
+        Assert.Equal(TimeSpan.FromMinutes(5), entityOptions.Value.Expiration);
+    }
+
+    [Fact]
+    public void WithFusionCaching_GlobalDurationAppliedAsFallback() {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithFusionCaching(opts => opts.DefaultEntryDuration = TimeSpan.FromHours(1));
+
+        var provider = services.BuildServiceProvider();
+        var entityOptions = provider.GetRequiredService<IOptions<EntityCacheOptions<CachingTestEntity>>>();
+
+        Assert.Equal(TimeSpan.FromHours(1), entityOptions.Value.Expiration);
+    }
+
+    [Fact]
+    public void WithFusionCaching_NoDuration_DoesNotRegisterOptions() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithFusionCaching();
+
+        var optionsDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        Assert.Null(optionsDescriptor);
+    }
+
+    [Fact]
+    public void WithFusionCaching_FailSafeOptions_AppliedWhenProvided() {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithFusionCaching(opts => {
+                opts.DefaultEntryDuration = TimeSpan.FromMinutes(10);
+                opts.FailSafeEnabled = true;
+                opts.FailSafeMaxDuration = TimeSpan.FromHours(1);
+            });
+
+        var fusionOptions = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<FusionCachingOptions>>();
+
+        Assert.True(fusionOptions.Value.FailSafeEnabled);
+        Assert.Equal(TimeSpan.FromHours(1), fusionOptions.Value.FailSafeMaxDuration);
+    }
+
+    [Fact]
+    public void WithFusionCaching_PriorityAndThreshold_AppliedWhenProvided() {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithFusionCaching(opts => {
+                opts.DefaultEntryDuration = TimeSpan.FromMinutes(10);
+                opts.Priority = CacheItemPriority.High;
+                opts.EagerRefreshThreshold = 0.5f;
+            });
+
+        var fusionOptions = services.BuildServiceProvider()
+            .GetRequiredService<IOptions<FusionCachingOptions>>();
+
+        Assert.Equal(CacheItemPriority.High, fusionOptions.Value.Priority);
+        Assert.Equal(0.5f, fusionOptions.Value.EagerRefreshThreshold);
+    }
+
+    [Fact]
+    public void AddEntityFusionCacheFor_ResolvesCache_WhenFusionCacheRegistered() {
+        var services = new ServiceCollection();
+        services.AddFusionCache();
+        services.AddEntityFusionCacheFor<CachingTestEntity>(opts => {
+            opts.DefaultEntryDuration = TimeSpan.FromMinutes(10);
+        });
+
+        var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<IEntityCache<CachingTestEntity>>());
+    }
+
+    [Fact]
+    public void WithFusionCaching_ResolvesEntityCache_WhenProviderBuilt() {
+        var services = new ServiceCollection();
+        services.AddFusionCache();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithFusionCaching();
+
+        var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<IEntityCache<CachingTestEntity>>());
+    }
+
+    public class SecondCachingEntity {
+        [Key]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+    }
+
+    public class SecondCachingRepository : IRepository<SecondCachingEntity> {
+        public ValueTask AddAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask AddRangeAsync(IEnumerable<SecondCachingEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<bool> UpdateAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask<bool> RemoveAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask RemoveRangeAsync(IEnumerable<SecondCachingEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<SecondCachingEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((SecondCachingEntity?)null);
+        public object? GetEntityKey(SecondCachingEntity entity) => (object?)entity.Id;
+        public ValueTask<PageResult<SecondCachingEntity>> GetPageAsync(PageRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    public class CachingTestEntity {
+        [Key]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+    }
+
+    public class CachingTestRepository : IRepository<CachingTestEntity> {
+        public ValueTask AddAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask AddRangeAsync(IEnumerable<CachingTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<bool> UpdateAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask<bool> RemoveAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask RemoveRangeAsync(IEnumerable<CachingTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<CachingTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((CachingTestEntity?)null);
+        public object? GetEntityKey(CachingTestEntity entity) => (object?)entity.Id;
+        public ValueTask<PageResult<CachingTestEntity>> GetPageAsync(PageRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+}

--- a/test/Kista.Context.XUnit/Unit/MemoryCacheExtensionTests.cs
+++ b/test/Kista.Context.XUnit/Unit/MemoryCacheExtensionTests.cs
@@ -1,0 +1,175 @@
+using System.ComponentModel.DataAnnotations;
+
+using Kista.Caching;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Kista;
+
+[Trait("Category", "Integration")]
+[Trait("Layer", "Manager")]
+[Trait("Feature", "MemoryCaching")]
+public class MemoryCacheExtensionTests {
+    [Fact]
+    public void WithMemoryCaching_RegistersCacheForTrackedEntityTypes() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithMemoryCaching();
+
+        var cacheDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IEntityCache<CachingTestEntity>));
+        Assert.NotNull(cacheDescriptor);
+    }
+
+    [Fact]
+    public void WithMemoryCaching_DoesNotRegisterForUntrackedEntityTypes() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .WithMemoryCaching();
+
+        var cacheDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IEntityCache<CachingTestEntity>));
+        Assert.Null(cacheDescriptor);
+    }
+
+    [Fact]
+    public void WithMemoryCaching_WithDefaultExpiration_RegistersOptions() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithMemoryCaching(opts => opts.DefaultExpiration = TimeSpan.FromMinutes(30));
+
+        var optionsDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        Assert.NotNull(optionsDescriptor);
+    }
+
+    [Fact]
+    public void WithMemoryCaching_WithCacheKeyPrefix_RegistersOptions() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithMemoryCaching(opts => opts.CacheKeyPrefix = "myapp:");
+
+        var optionsDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        Assert.NotNull(optionsDescriptor);
+    }
+
+    [Fact]
+    public void WithMemoryCaching_WithOptionsAppliesToAllEntityTypes() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .AddRepository<SecondCachingRepository>(_ => { })
+            .WithMemoryCaching(opts => opts.DefaultExpiration = TimeSpan.FromHours(1));
+
+        var optionsForFirst = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        var optionsForSecond = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<SecondCachingEntity>>));
+
+        Assert.NotNull(optionsForFirst);
+        Assert.NotNull(optionsForSecond);
+    }
+
+    [Fact]
+    public void WithMemoryCaching_EntitySpecificExpirationOverridesGlobal() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithMemoryCaching(opts => opts.DefaultExpiration = TimeSpan.FromHours(1));
+
+        services.AddEntityCacheOptions<CachingTestEntity>(opts => opts.Expiration = TimeSpan.FromMinutes(5));
+
+        var provider = services.BuildServiceProvider();
+        var entityOptions = provider.GetRequiredService<IOptions<EntityCacheOptions<CachingTestEntity>>>();
+
+        Assert.NotNull(entityOptions);
+        Assert.Equal(TimeSpan.FromMinutes(5), entityOptions.Value.Expiration);
+    }
+
+    [Fact]
+    public void WithMemoryCaching_EntityOptionsRegisteredAfterBuilder_AreApplied() {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithMemoryCaching(opts => opts.DefaultExpiration = TimeSpan.FromHours(1));
+
+        var provider = services.BuildServiceProvider();
+        var entityOptions = provider.GetRequiredService<IOptions<EntityCacheOptions<CachingTestEntity>>>();
+
+        Assert.Equal(TimeSpan.FromHours(1), entityOptions.Value.Expiration);
+    }
+
+    [Fact]
+    public void AddEntityMemoryCacheFor_WithEntitySpecificOptions_ResolvesCorrectly() {
+        var services = new ServiceCollection();
+        services.AddMemoryCache();
+        services.AddEntityMemoryCacheFor<CachingTestEntity>(opts => opts.Expiration = TimeSpan.FromMinutes(10));
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<EntityCacheOptions<CachingTestEntity>>>();
+
+        Assert.Equal(TimeSpan.FromMinutes(10), options.Value.Expiration);
+        Assert.NotNull(provider.GetService<IEntityCache<CachingTestEntity>>());
+    }
+
+    [Fact]
+    public void WithMemoryCaching_WithNoExpiration_DoesNotRegisterOptions() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithMemoryCaching();
+
+        var optionsDescriptor = services.FirstOrDefault(d =>
+            d.ServiceType == typeof(IConfigureOptions<EntityCacheOptions<CachingTestEntity>>));
+        Assert.Null(optionsDescriptor);
+    }
+
+    [Fact]
+    public void WithMemoryCaching_ResolvesEntityCache_WhenProviderBuilt() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<CachingTestRepository>(_ => { })
+            .WithMemoryCaching();
+
+        services.AddMemoryCache();
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IEntityCache<CachingTestEntity>>());
+    }
+
+    public class SecondCachingEntity {
+        [Key]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+    }
+
+    public class SecondCachingRepository : IRepository<SecondCachingEntity> {
+        public ValueTask AddAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask AddRangeAsync(IEnumerable<SecondCachingEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<bool> UpdateAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask<bool> RemoveAsync(SecondCachingEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask RemoveRangeAsync(IEnumerable<SecondCachingEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<SecondCachingEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((SecondCachingEntity?)null);
+        public object? GetEntityKey(SecondCachingEntity entity) => (object?)entity.Id;
+        public ValueTask<PageResult<SecondCachingEntity>> GetPageAsync(PageRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+
+    public class CachingTestEntity {
+        [Key]
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+    }
+
+    public class CachingTestRepository : IRepository<CachingTestEntity> {
+        public ValueTask AddAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask AddRangeAsync(IEnumerable<CachingTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<bool> UpdateAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask<bool> RemoveAsync(CachingTestEntity entity, CancellationToken cancellationToken = default) => new(false);
+        public ValueTask RemoveRangeAsync(IEnumerable<CachingTestEntity> entities, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask<CachingTestEntity?> FindAsync(object key, CancellationToken cancellationToken = default) => new((CachingTestEntity?)null);
+        public object? GetEntityKey(CachingTestEntity entity) => (object?)entity.Id;
+        public ValueTask<PageResult<CachingTestEntity>> GetPageAsync(PageRequest request, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+    }
+}

--- a/test/Kista.Manager.DistributedCache.XUnit/Fixtures/PersonCacheKeyGenerator.cs
+++ b/test/Kista.Manager.DistributedCache.XUnit/Fixtures/PersonCacheKeyGenerator.cs
@@ -1,0 +1,9 @@
+using Kista.Caching;
+
+namespace Kista;
+
+public class PersonCacheKeyGenerator : IEntityCacheKeyGenerator<Person> {
+	public string[] GenerateAllKeys(Person entity) => new[] { GenerateKey(entity) };
+
+	public string GenerateKey(object key) => $"person({key})";
+}

--- a/test/Kista.Manager.DistributedCache.XUnit/GlobalUsings.cs
+++ b/test/Kista.Manager.DistributedCache.XUnit/GlobalUsings.cs
@@ -1,0 +1,5 @@
+global using Bogus;
+global using Xunit;
+global using Microsoft.Extensions.DependencyInjection;
+global using Kista;
+global using Deveel;

--- a/test/Kista.Manager.DistributedCache.XUnit/Kista.Manager.DistributedCache.XUnit.csproj
+++ b/test/Kista.Manager.DistributedCache.XUnit/Kista.Manager.DistributedCache.XUnit.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kista.Manager.DistributedCache\Kista.Manager.DistributedCache.csproj" />
+    <ProjectReference Include="..\Kista.Manager.XUnit\Kista.Manager.XUnit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Kista.Manager.DistributedCache.XUnit/Unit/DependencyInjectionTests.cs
+++ b/test/Kista.Manager.DistributedCache.XUnit/Unit/DependencyInjectionTests.cs
@@ -1,0 +1,74 @@
+using Kista.Caching;
+
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Kista;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Application")]
+[Trait("Feature", "Caching")]
+public class DependencyInjectionTests {
+    [Fact]
+    public void Should_ResolveConfiguredOptions_When_OptionsConfiguredByAction() {
+        var services = new ServiceCollection();
+        services.AddEntityCacheOptions<Person>(options => {
+            options.Expiration = TimeSpan.FromMinutes(15);
+        });
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetService<IOptions<EntityCacheOptions<Person>>>();
+
+        Assert.NotNull(options);
+        Assert.NotNull(options.Value);
+        Assert.Equal(TimeSpan.FromMinutes(15), options.Value.Expiration);
+    }
+
+    [Fact]
+    public void Should_ResolveConfiguredOptions_When_OptionsBindFromConfiguration() {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> {
+                { "EntityCacheOptions:Person:Expiration", "00:15:00" }
+            });
+        services.AddSingleton<IConfiguration>(config.Build());
+        services.AddEntityCacheOptions<Person>("EntityCacheOptions:Person");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetService<IOptions<EntityCacheOptions<Person>>>();
+
+        Assert.NotNull(options);
+        Assert.NotNull(options.Value);
+        Assert.Equal(TimeSpan.FromMinutes(15), options.Value.Expiration);
+    }
+
+    [Fact]
+    public void Should_ResolveEntityDistributedCache_When_Registered() {
+        var services = new ServiceCollection();
+        services.AddDistributedMemoryCache();
+        services.AddEntityDistributedCacheFor<Person>(options => {
+            options.Expiration = TimeSpan.FromMinutes(15);
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IEntityCache<Person>>());
+        Assert.NotNull(provider.GetService<EntityDistributedCache<Person>>());
+    }
+
+    [Fact]
+    public void Should_ResolveKeyGenerator_When_EntityCacheKeyGeneratorRegistered() {
+        var services = new ServiceCollection();
+        services.AddEntityCacheKeyGenerator<PersonCacheKeyGenerator>();
+
+        var provider = services.BuildServiceProvider();
+        var generator = provider.GetService<IEntityCacheKeyGenerator<Person>>();
+
+        Assert.NotNull(generator);
+        Assert.IsType<PersonCacheKeyGenerator>(generator);
+    }
+
+
+}

--- a/test/Kista.Manager.FusionCache.XUnit/Fixtures/PersonCacheKeyGenerator.cs
+++ b/test/Kista.Manager.FusionCache.XUnit/Fixtures/PersonCacheKeyGenerator.cs
@@ -1,0 +1,9 @@
+using Kista.Caching;
+
+namespace Kista;
+
+public class PersonCacheKeyGenerator : IEntityCacheKeyGenerator<Person> {
+	public string[] GenerateAllKeys(Person entity) => new[] { GenerateKey(entity) };
+
+	public string GenerateKey(object key) => $"person({key})";
+}

--- a/test/Kista.Manager.FusionCache.XUnit/GlobalUsings.cs
+++ b/test/Kista.Manager.FusionCache.XUnit/GlobalUsings.cs
@@ -1,0 +1,5 @@
+global using Bogus;
+global using Xunit;
+global using Microsoft.Extensions.DependencyInjection;
+global using Kista;
+global using Deveel;

--- a/test/Kista.Manager.FusionCache.XUnit/Kista.Manager.FusionCache.XUnit.csproj
+++ b/test/Kista.Manager.FusionCache.XUnit/Kista.Manager.FusionCache.XUnit.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kista.Manager.FusionCache\Kista.Manager.FusionCache.csproj" />
+    <ProjectReference Include="..\Kista.Manager.XUnit\Kista.Manager.XUnit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Kista.Manager.FusionCache.XUnit/Unit/DependencyInjectionTests.cs
+++ b/test/Kista.Manager.FusionCache.XUnit/Unit/DependencyInjectionTests.cs
@@ -1,0 +1,75 @@
+using Kista.Caching;
+
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+using ZiggyCreatures.Caching.Fusion;
+
+namespace Kista;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Application")]
+[Trait("Feature", "Caching")]
+public class DependencyInjectionTests {
+    [Fact]
+    public void Should_ResolveConfiguredOptions_When_OptionsConfiguredByAction() {
+        var services = new ServiceCollection();
+        services.AddEntityCacheOptions<Person>(options => {
+            options.Expiration = TimeSpan.FromMinutes(15);
+        });
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetService<IOptions<EntityCacheOptions<Person>>>();
+
+        Assert.NotNull(options);
+        Assert.NotNull(options.Value);
+        Assert.Equal(TimeSpan.FromMinutes(15), options.Value.Expiration);
+    }
+
+    [Fact]
+    public void Should_ResolveConfiguredOptions_When_OptionsBindFromConfiguration() {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> {
+                { "EntityCacheOptions:Person:Expiration", "00:15:00" }
+            });
+        services.AddSingleton<IConfiguration>(config.Build());
+        services.AddEntityCacheOptions<Person>("EntityCacheOptions:Person");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetService<IOptions<EntityCacheOptions<Person>>>();
+
+        Assert.NotNull(options);
+        Assert.NotNull(options.Value);
+        Assert.Equal(TimeSpan.FromMinutes(15), options.Value.Expiration);
+    }
+
+    [Fact]
+    public void Should_ResolveEntityFusionCache_When_Registered() {
+        var services = new ServiceCollection();
+        services.AddFusionCache();
+        services.AddEntityFusionCacheFor<Person>(options => {
+            options.DefaultEntryDuration = TimeSpan.FromMinutes(15);
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IEntityCache<Person>>());
+        Assert.NotNull(provider.GetService<EntityFusionCache<Person>>());
+    }
+
+    [Fact]
+    public void Should_ResolveKeyGenerator_When_EntityCacheKeyGeneratorRegistered() {
+        var services = new ServiceCollection();
+        services.AddEntityCacheKeyGenerator<PersonCacheKeyGenerator>();
+
+        var provider = services.BuildServiceProvider();
+        var generator = provider.GetService<IEntityCacheKeyGenerator<Person>>();
+
+        Assert.NotNull(generator);
+        Assert.IsType<PersonCacheKeyGenerator>(generator);
+    }
+
+
+}

--- a/test/Kista.Manager.MemoryCache.XUnit/Fixtures/PersonCacheKeyGenerator.cs
+++ b/test/Kista.Manager.MemoryCache.XUnit/Fixtures/PersonCacheKeyGenerator.cs
@@ -1,0 +1,9 @@
+using Kista.Caching;
+
+namespace Kista;
+
+public class PersonCacheKeyGenerator : IEntityCacheKeyGenerator<Person> {
+	public string[] GenerateAllKeys(Person entity) => new[] { GenerateKey(entity) };
+
+	public string GenerateKey(object key) => $"person({key})";
+}

--- a/test/Kista.Manager.MemoryCache.XUnit/GlobalUsings.cs
+++ b/test/Kista.Manager.MemoryCache.XUnit/GlobalUsings.cs
@@ -1,0 +1,5 @@
+global using Bogus;
+global using Xunit;
+global using Microsoft.Extensions.DependencyInjection;
+global using Kista;
+global using Deveel;

--- a/test/Kista.Manager.MemoryCache.XUnit/Kista.Manager.MemoryCache.XUnit.csproj
+++ b/test/Kista.Manager.MemoryCache.XUnit/Kista.Manager.MemoryCache.XUnit.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Kista.Manager\Kista.Manager.csproj" />
+    <ProjectReference Include="..\Kista.Manager.XUnit\Kista.Manager.XUnit.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Kista.Manager.MemoryCache.XUnit/Unit/DependencyInjectionTests.cs
+++ b/test/Kista.Manager.MemoryCache.XUnit/Unit/DependencyInjectionTests.cs
@@ -1,0 +1,72 @@
+using Kista.Caching;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Kista;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Application")]
+[Trait("Feature", "Caching")]
+public class DependencyInjectionTests {
+    [Fact]
+    public void Should_ResolveConfiguredOptions_When_OptionsConfiguredByAction() {
+        var services = new ServiceCollection();
+        services.AddEntityCacheOptions<Person>(options => {
+            options.Expiration = TimeSpan.FromMinutes(15);
+        });
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetService<IOptions<EntityCacheOptions<Person>>>();
+
+        Assert.NotNull(options);
+        Assert.NotNull(options.Value);
+        Assert.Equal(TimeSpan.FromMinutes(15), options.Value.Expiration);
+    }
+
+    [Fact]
+    public void Should_ResolveConfiguredOptions_When_OptionsBindFromConfiguration() {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> {
+                { "EntityCacheOptions:Person:Expiration", "00:15:00" }
+            });
+        services.AddSingleton<IConfiguration>(config.Build());
+        services.AddEntityCacheOptions<Person>("EntityCacheOptions:Person");
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetService<IOptions<EntityCacheOptions<Person>>>();
+
+        Assert.NotNull(options);
+        Assert.NotNull(options.Value);
+        Assert.Equal(TimeSpan.FromMinutes(15), options.Value.Expiration);
+    }
+
+    [Fact]
+    public void Should_ResolveEntityMemoryCache_When_Registered() {
+        var services = new ServiceCollection();
+        services.AddMemoryCache();
+        services.AddEntityMemoryCacheFor<Person>(options => {
+            options.Expiration = TimeSpan.FromMinutes(15);
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        Assert.NotNull(provider.GetService<IEntityCache<Person>>());
+        Assert.NotNull(provider.GetService<EntityMemoryCache<Person>>());
+    }
+
+    [Fact]
+    public void Should_ResolveKeyGenerator_When_EntityCacheKeyGeneratorRegistered() {
+        var services = new ServiceCollection();
+        services.AddEntityCacheKeyGenerator<PersonCacheKeyGenerator>();
+
+        var provider = services.BuildServiceProvider();
+        var generator = provider.GetService<IEntityCacheKeyGenerator<Person>>();
+
+        Assert.NotNull(generator);
+        Assert.IsType<PersonCacheKeyGenerator>(generator);
+    }
+
+
+}


### PR DESCRIPTION
This pull request introduces new distributed and FusionCache-based caching implementations for entity management, and updates the solution to include these new projects and their test counterparts. The changes provide new ways to configure and use distributed caching (such as Redis or SQL Server) and FusionCache for entity repositories, improving extensibility and flexibility in caching strategies.

**New Distributed Cache Support:**

- Added `EntityDistributedCache<TEntity>` and related extension methods in `DistributedCacheExtensions.cs` for integrating `IDistributedCache` as a backend for entity caching, with configurable expiration and key prefix options. [[1]](diffhunk://#diff-4aec2099aa4443a78cf1ed21deed03d91e6fbf93324f1bf1eea3d68df5502170R1-R145) [[2]](diffhunk://#diff-d9f7c66d06fe9ed671ef17b5b933dbb196e92b9d0bf7f499b7e706169f41a5b4R1-R145)
- Created a new project `Kista.Manager.DistributedCache` with proper dependencies and metadata for distributing the distributed cache implementation.

**New FusionCache Support:**

- Introduced `EntityFusionCache<TEntity>` for using FusionCache as the entity cache backend, supporting advanced cache options like fail-safe and eager refresh.

**Solution and Project Structure Updates:**

- Updated `Kista.sln` to include new projects: `Kista.Manager.FusionCache`, `Kista.Manager.FusionCache.XUnit`, `Kista.Manager.DistributedCache`, `Kista.Manager.DistributedCache.XUnit`, and `Kista.Manager.MemoryCache.XUnit`, and added their build configurations and project nesting. [[1]](diffhunk://#diff-ae5ad207eaefbf460fae0931f6748220338afd768b6fe589c46fc3a5f6d44b14R53-R62) [[2]](diffhunk://#diff-ae5ad207eaefbf460fae0931f6748220338afd768b6fe589c46fc3a5f6d44b14R439-R448) [[3]](diffhunk://#diff-ae5ad207eaefbf460fae0931f6748220338afd768b6fe589c46fc3a5f6d44b14R484-R488)

**Other Minor Changes:**

- Removed the `GenerateKeys` method from `EntityEasyCache_2.cs` in the EasyCaching implementation, possibly as part of a refactor or interface update.…FusionCache and DistributedCache implementations