### PR TITLE
feat: align entity cache to the operation pipeline via builtin CacheInterceptor (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Builtin `OnHooksEntityInterceptor` wraps the existing `protected virtual On*Async` hooks and is always appended last, so subclass overrides keep working and user interceptors run before timestamp / soft-delete stamping.
   - `RemoveRangeAsync` and `AddRangeAsync` now flow through the pipeline (one context per entity, mirroring the per-entity `On*Async` behavior).
   - See [Operation Pipeline](docs/entity-manager/operation-pipeline.md).
+- **Builtin `CacheInterceptor`** — the entity cache is now aligned to the operation pipeline, replacing the former inline `SetToCacheAsync` / `EvictAsync` helpers duplicated across the write methods of `EntityManager`.
+  - `Create`, `Update`, and `Restore` re-cache the written entity; `Remove` re-caches soft-deletable entities and evicts non-soft-deletable ones; `HardDelete` evicts.
+  - The interceptor is only appended to the chain when an `IEntityCache<TEntity>` is registered, making the cache concern removable for tests or custom cache strategies without subclassing the manager.
+  - The private `SetToCacheAsync` / `EvictAsync` helpers and their inline call sites are removed from `EntityManager`; cache behavior is preserved by default through the interceptor.
+  - No change to `IEntityCache<TEntity>`, `IEntityCacheKeyGenerator<TEntity>`, or any `Kista.Manager.*` cache extension package — they register `IEntityCache<TEntity>`, the interceptor consumes it.
+  - `FindAsync`'s read-through `GetOrSetByKeyAsync` stays inline — read-path caching is unchanged.
 - **`UsingManager<TManager>()`** on `EntityManagerBuilder` — registers a custom `EntityManager` subclass against the entity / key types inferred from the manager type, replacing the obsolete `AddEntityManager<TManager>()` extension.
 - **`RegisterAdditionalContextTypes()`** on `MongoRepositoryBuilder` — preserves tenant context type registrations (`IMongoDbTenantContext`, `MongoDbContext`, `MongoDbTenantContext`) previously handled by the obsolete `AddMongoDbContext`.
 - **`Kista.SampleApp.OperationPipeline`** sample app — ASP.NET Core reference demonstrating `AuditInterceptor` and `BusinessHoursInterceptor` (short-circuit) wired through `WithInterceptor<T>()`. See [Sample Application](docs/sample-app.md).
@@ -44,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Kista.SampleApp.OperationPipeline` joins the samples solution alongside `Kista.SampleApp`, `Kista.SampleApp.Owners`, and `Kista.SampleApp.SoftDelete`.
 - Sonar code-smell cleanup (43 PR code smells cleared) and new-code duplication reduced below 3%.
 - Test interceptor helpers deduplicated across the operation-pipeline test suite.
+- **`RemoveRangeAsync` cache behavior aligned with `RemoveAsync`**: soft-deletable entities in a range Remove are now re-cached instead of evicted (the builtin `CacheInterceptor` handles each entity in the batch per the same `ISoftDeletable` rule as the single `RemoveAsync`). Non-soft-deletable entities in a range Remove continue to be evicted.
 
 ### Fixed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -528,7 +528,7 @@ Cache warming and eviction are hardwired into `EntityManager` as private `SetToC
 - Existing `Kista.Manager.EasyCaching` / `MemoryCache` / `DistributedCache` / `FusionCache` packages keep working unchanged — they register `IEntityCache<TEntity>`, the interceptor calls it
 - The same pipeline serves v1.9.0 audit trail and OpenTelemetry — no second extension point to invent
 
-**Status:** 🔲 Planned for v1.7.0. Depends on the Extensible Operation Pipeline feature.
+**Status:** ✅ Completed. See [Operation Pipeline documentation](docs/entity-manager/operation-pipeline.md#builtin-cacheinterceptor).
 
 ---
 

--- a/docs/entity-manager/operation-pipeline.md
+++ b/docs/entity-manager/operation-pipeline.md
@@ -95,6 +95,39 @@ A builtin `OnHooksEntityInterceptor` wraps these hooks and is **always appended 
 - User interceptors run **before** the framework's timestamp/soft-delete stamping, so they can observe or transform the entity before stamping.
 - The pipeline and the hooks coexist cleanly.
 
+## Builtin `CacheInterceptor`
+
+The cache concern is aligned to the pipeline through a builtin `CacheInterceptor<TEntity, TKey>` that replaces the former inline `SetToCacheAsync` / `EvictAsync` glue duplicated across the write methods of the manager.
+
+### When is it active?
+
+The interceptor is **only appended to the chain when an `IEntityCache<TEntity>` is registered** in the dependency injection container. Not registering a cache means no cache side effects — the cache concern is removable for tests or custom cache strategies, without subclassing the manager.
+
+It runs **after** the `OnHooksEntityInterceptor`, so the cache sees the entity as persisted (with timestamp / soft-delete stamping already applied). `PreWriteAsync` never short-circuits the chain: the cache is a write-path concern that fires only after a successful write.
+
+### What does it do in `PostWriteAsync`?
+
+| Operation kind | Cache action |
+|----------------|--------------|
+| `Create`, `Update`, `Restore` | Re-cache the written entity (`IEntityCache<T>.SetAsync`) |
+| `Remove` (entity implements `ISoftDeletable`) | Re-cache the soft-deleted entity (`SetAsync`) |
+| `Remove` (entity does not implement `ISoftDeletable`) | Evict the entity (`IEntityCache<T>.RemoveAsync`) |
+| `HardDelete` | Evict the entity (`RemoveAsync`) |
+
+The action is only taken when the operation **succeeded**: a not-changed or failed result leaves the cache untouched, matching the former inline behavior that fired only after a successful repository write. Cache keys are generated through `IEntityCacheKeyGenerator<TEntity>` resolved from DI — when no generator is registered (or it returns an empty array of keys), the entity is not cached.
+
+### Failure resilience
+
+Failures in the cache are logged and swallowed, so a cache outage never propagates to the caller of the write operation. This preserves the behavior of the former inline helpers.
+
+### Behavior change in `RemoveRangeAsync`
+
+Before the alignment, `RemoveRangeAsync` always evicted every entity in the batch, even `ISoftDeletable` ones — inconsistent with `RemoveAsync`, which re-caches soft-deletable entities. The builtin `CacheInterceptor` now handles the batch per entity, so `RemoveRangeAsync` is **aligned with `RemoveAsync`**: soft-deletable entities in a range Remove are re-cached, while non-soft-deletable entities are evicted.
+
+### Read-through cache is unchanged
+
+`FindAsync`'s read-through `GetOrSetByKeyAsync` stays inline — read-path caching is out of scope for this feature.
+
 ## Short-circuit example
 
 An interceptor that rejects writes outside business hours:

--- a/docs/migrating-from-1.7.2.md
+++ b/docs/migrating-from-1.7.2.md
@@ -192,9 +192,22 @@ If you previously subclassed `EntityManager` to add cross-cutting concerns (audi
 
 See [Operation Pipeline](entity-manager/operation-pipeline.md) for the full contract, registration, and short-circuit examples.
 
+## Cache alignment to the operation pipeline
+
+The entity cache is now aligned to the operation pipeline through a builtin `CacheInterceptor` (see [Builtin `CacheInterceptor`](entity-manager/operation-pipeline.md#builtin-cacheinterceptor)). This is a non-breaking change for the vast majority of consumers: the cache backend packages (`Kista.Manager.EasyCaching`, `MemoryCache`, `DistributedCache`, `FusionCache`) register `IEntityCache<TEntity>` unchanged, and the interceptor consumes it — only the call site moves from inline `SetToCacheAsync` / `EvictAsync` helpers (now removed from `EntityManager`) to `PostWriteAsync`.
+
+### Behavior change: `RemoveRangeAsync` and soft-deletable entities
+
+Before this release, `RemoveRangeAsync` **always evicted** every entity in the batch from the cache, even `ISoftDeletable` ones — inconsistent with `RemoveAsync`, which re-caches soft-deletable entities (the soft-deleted row still exists in the repository). The builtin `CacheInterceptor` now handles each entity in the batch per the same `ISoftDeletable` rule as the single `RemoveAsync`:
+
+- **Soft-deletable entities** in a range Remove are now **re-cached** (the cached entry is refreshed with the soft-delete stamp applied), matching `RemoveAsync`.
+- **Non-soft-deletable entities** in a range Remove continue to be **evicted**, matching `RemoveAsync` and `HardDeleteAsync`.
+
+If you relied on the old per-entity eviction of soft-deletable entities in `RemoveRangeAsync`, register a custom interceptor that calls `IEntityCache<TEntity>.RemoveAsync` in `PostWriteAsync` for `EntityOperationKind.Remove` on `ISoftDeletable` entities, or do not register a cache.
+
 ## Reference
 
-- [Operation Pipeline](entity-manager/operation-pipeline.md) — the new interceptor chain on `EntityManager`
+- [Operation Pipeline](entity-manager/operation-pipeline.md) — the new interceptor chain on `EntityManager` (including the builtin `CacheInterceptor`)
 - [The Entity Manager](entity-manager/) — registration, validation, caching, HTTP request cancellation
 - [Migrating from 1.7](migrating-from-1.7.md) — the prior 1.7.0 → 1.7.1 migration (`IQueryableRepository` / `IPageableRepository` / `IFilterableRepository` removal)
 - [Repository Lifecycle](repository-lifecycle/) — the `IRepositoryLifecycleService` replacement for `IRepositoryController`

--- a/src/Kista.Manager/Caching/CacheInterceptor.cs
+++ b/src/Kista.Manager/Caching/CacheInterceptor.cs
@@ -1,0 +1,209 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Deveel;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Kista.Caching {
+	/// <summary>
+	/// A builtin interceptor that aligns the entity cache to the
+	/// <see cref="EntityManager{TEntity, TKey}"/> operation pipeline,
+	/// replacing the former inline <c>SetToCacheAsync</c> / <c>EvictAsync</c>
+	/// glue that was duplicated across the write methods of the manager.
+	/// </summary>
+	/// <typeparam name="TEntity">
+	/// The type of the entity managed by the pipeline.
+	/// </typeparam>
+	/// <typeparam name="TKey">
+	/// The type of the key identifying the entity.
+	/// </typeparam>
+	/// <remarks>
+	/// <para>
+	/// The interceptor is only appended to the pipeline when an
+	/// <see cref="IEntityCache{TEntity}"/> is registered in the dependency
+	/// injection container: this makes the cache concern removable (no
+	/// cache registered, no cache side effects) and reorderable (user-
+	/// registered interceptors run before it), while preserving the
+	/// default cache behavior out of the box.
+	/// </para>
+	/// <para>
+	/// <see cref="PreWriteAsync"/> never short-circuits the chain: the
+	/// cache is a write-path concern that fires only after a successful
+	/// write. <see cref="PostWriteAsync"/> re-caches the written entity
+	/// for <see cref="EntityOperationKind.Create"/>,
+	/// <see cref="EntityOperationKind.Update"/> and
+	/// <see cref="EntityOperationKind.Restore"/> operations, and for
+	/// <see cref="EntityOperationKind.Remove"/> operations when the
+	/// entity implements <see cref="ISoftDeletable"/> (soft-delete
+	/// branch); it evicts the entity for
+	/// <see cref="EntityOperationKind.Remove"/> operations when the
+	/// entity does not implement <see cref="ISoftDeletable"/> (hard
+	/// branch), and for all
+	/// <see cref="EntityOperationKind.HardDelete"/> operations.
+	/// </para>
+	/// <para>
+	/// Failures in the cache are logged and swallowed, so a cache
+	/// outage never propagates to the caller of the write operation:
+	/// this preserves the behavior of the former inline helpers.
+	/// </para>
+	/// </remarks>
+	internal sealed class CacheInterceptor<TEntity, TKey> : IEntityManagerInterceptor<TEntity, TKey>
+		where TEntity : class
+		where TKey : notnull {
+		private readonly IEntityCache<TEntity> _cache;
+		private readonly IEntityCacheKeyGenerator<TEntity>? _keyGenerator;
+		private readonly Func<TEntity, TKey?> _getEntityKey;
+		private readonly ILogger _logger;
+
+		/// <summary>
+		/// Constructs the interceptor with the cache, the optional key
+		/// generator, a delegate to extract the primary key of an entity,
+		/// and a logger used to report cache failures.
+		/// </summary>
+		/// <param name="cache">
+		/// The cache where the entities are stored.
+		/// </param>
+		/// <param name="keyGenerator">
+		/// An optional service used to generate the cache keys for an
+		/// entity. When <c>null</c>, or when it returns an empty array of
+		/// keys, the entity is not cached.
+		/// </param>
+		/// <param name="getEntityKey">
+		/// A delegate returning the primary key of an entity, used for
+		/// diagnostic logging when the cache interaction fails.
+		/// </param>
+		/// <param name="logger">
+		/// The logger used to report cache failures.
+		/// </param>
+		public CacheInterceptor(
+			IEntityCache<TEntity> cache,
+			IEntityCacheKeyGenerator<TEntity>? keyGenerator,
+			Func<TEntity, TKey?> getEntityKey,
+			ILogger? logger = null) {
+			_cache = cache ?? throw new ArgumentNullException(nameof(cache));
+			_keyGenerator = keyGenerator;
+			_getEntityKey = getEntityKey ?? throw new ArgumentNullException(nameof(getEntityKey));
+			_logger = logger ?? NullLogger.Instance;
+		}
+
+		/// <summary>
+		/// Computes the cache keys for the given entity, using the
+		/// <see cref="IEntityCacheKeyGenerator{TEntity}"/> when one is
+		/// available, or returning an empty array (meaning the entity
+		/// will not be cached).
+		/// </summary>
+		/// <param name="entity">
+		/// The entity to generate the keys for.
+		/// </param>
+		/// <returns>
+		/// Returns an array of strings that identify the entity in the
+		/// cache, or an empty array when no key generator is registered.
+		/// </returns>
+		private string[] GenerateCacheKeys(TEntity entity) {
+			if (_keyGenerator == null)
+				return Array.Empty<string>();
+
+			return _keyGenerator.GenerateAllKeys(entity);
+		}
+
+		/// <summary>
+		/// Sets the given entity in the cache, swallowing and logging
+		/// any failure so it never propagates to the caller.
+		/// </summary>
+		/// <param name="entity">
+		/// The entity to set in the cache.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		private async ValueTask SetToCacheAsync(TEntity entity, CancellationToken cancellationToken) {
+			try {
+				var keys = GenerateCacheKeys(entity);
+				if (keys.Length == 0)
+					return;
+
+				await _cache.SetAsync(keys, entity, cancellationToken);
+			} catch (Exception ex) {
+				_logger.LogEntityNotCached(ex, typeof(TEntity), _getEntityKey(entity));
+			}
+		}
+
+		/// <summary>
+		/// Evicts the given entity from the cache, swallowing and logging
+		/// any failure so it never propagates to the caller.
+		/// </summary>
+		/// <param name="entity">
+		/// The entity to evict from the cache.
+		/// </param>
+		/// <param name="cancellationToken">
+		/// A token used to cancel the operation.
+		/// </param>
+		private async ValueTask EvictAsync(TEntity entity, CancellationToken cancellationToken) {
+			try {
+				var keys = GenerateCacheKeys(entity);
+				if (keys.Length == 0)
+					return;
+
+				await _cache.RemoveAsync(keys, cancellationToken);
+			} catch (Exception ex) {
+				_logger.LogEntityNotEvicted(ex, typeof(TEntity), _getEntityKey(entity));
+			}
+		}
+
+		/// <inheritdoc/>
+		/// <remarks>
+		/// The cache is a write-path concern: this method never
+		/// short-circuits the chain and returns <c>null</c> to let the
+		/// write proceed.
+		/// </remarks>
+		public ValueTask<IOperationResult?> PreWriteAsync(IEntityOperationContext<TEntity, TKey> context)
+			=> new((IOperationResult?)null);
+
+		/// <inheritdoc/>
+		/// <remarks>
+		/// Re-caches or evicts the written entity depending on the
+		/// operation kind. The action is only taken when the operation
+		/// succeeded: a not-changed or failed result leaves the cache
+		/// untouched, matching the former inline behavior that fired
+		/// only after a successful repository write.
+		/// </remarks>
+		public async ValueTask PostWriteAsync(IEntityOperationContext<TEntity, TKey> context, IOperationResult result) {
+			if (!result.IsSuccess())
+				return;
+
+			var entity = context.Entity;
+			var token = context.CancellationToken;
+
+			switch (context.Kind) {
+				case EntityOperationKind.Create:
+				case EntityOperationKind.Update:
+				case EntityOperationKind.Restore:
+					await SetToCacheAsync(entity, token);
+					break;
+				case EntityOperationKind.Remove:
+					if (entity is ISoftDeletable)
+						await SetToCacheAsync(entity, token);
+					else
+						await EvictAsync(entity, token);
+					break;
+				case EntityOperationKind.HardDelete:
+					await EvictAsync(entity, token);
+					break;
+				default:
+					break;
+			}
+		}
+	}
+}

--- a/src/Kista.Manager/EntityManager_T2.cs
+++ b/src/Kista.Manager/EntityManager_T2.cs
@@ -155,6 +155,16 @@ namespace Kista {
 		private OnHooksEntityInterceptor? _hooksInterceptor;
 
 		/// <summary>
+		/// Gets the builtin interceptor that aligns the entity cache
+		/// to the operation pipeline, re-caching or evicting the
+		/// written entity in <c>PostWriteAsync</c>. This interceptor is
+		/// only appended to the chain when an
+		/// <see cref="IEntityCache{TEntity}"/> is registered, making the
+		/// cache concern removable for tests or custom cache strategies.
+		/// </summary>
+		private CacheInterceptor<TEntity, TKey>? _cacheInterceptor;
+
+		/// <summary>
 		/// Resolves the user-registered interceptors for the current
 		/// entity and key types from DI (excluding the builtin
 		/// <see cref="OnHooksEntityInterceptor"/>).
@@ -172,13 +182,18 @@ namespace Kista {
 		/// and key types: user-registered interceptors (in registration
 		/// order) followed by the builtin
 		/// <see cref="OnHooksEntityInterceptor"/> that wraps the
-		/// <c>On*Async</c> hooks (always appended last).
+		/// <c>On*Async</c> hooks (always appended last), and finally by
+		/// the builtin <see cref="CacheInterceptor{TEntity, TKey}"/> when
+		/// an <see cref="IEntityCache{TEntity}"/> is registered.
 		/// </summary>
 		/// <remarks>
 		/// <para>
 		/// When no interceptor is registered in DI, only the builtin
 		/// hooks interceptor is returned, preserving the behavior of
-		/// the <c>On*Async</c> hooks.
+		/// the <c>On*Async</c> hooks. The cache interceptor is only
+		/// appended when an <see cref="IEntityCache{TEntity}"/> is
+		/// available, so the cache concern is removable by not
+		/// registering a cache in the dependency injection container.
 		/// </para>
 		/// <para>
 		/// The single-key <see cref="EntityManager{TEntity}"/> overrides
@@ -191,7 +206,15 @@ namespace Kista {
 		protected IEnumerable<IEntityManagerInterceptor<TEntity, TKey>> GetInterceptors() {
 			_hooksInterceptor ??= new OnHooksEntityInterceptor(this);
 
-			return GetUserInterceptors().Append(_hooksInterceptor);
+			var chain = GetUserInterceptors().Append(_hooksInterceptor);
+
+			if (EntityCache != null) {
+				_cacheInterceptor ??= new CacheInterceptor<TEntity, TKey>(
+					EntityCache, EntityCacheKeyGenerator, GetEntityKey, Logger);
+				chain = chain.Append(_cacheInterceptor);
+			}
+
+			return chain;
 		}
 
 		/// <summary>
@@ -784,31 +807,6 @@ namespace Kista {
 			return generator.GenerateAllKeys(entity);
 		}
 
-		private async ValueTask SetToCacheAsync(TEntity entity, CancellationToken cancellationToken) {
-			if (EntityCache == null)
-				return;
-
-			try {
-				// optimize this
-				var keys = GenerateCacheKeys(entity);
-				await EntityCache.SetAsync(keys, entity, cancellationToken);
-			} catch (Exception ex) {
-				Logger.LogEntityNotCached(ex, typeof(TEntity), GetEntityKey(entity));
-			}
-		}
-
-		private async ValueTask EvictAsync(TEntity entity, CancellationToken cancellationToken) {
-			if (EntityCache == null)
-				return;
-
-			try {
-				var keys = GenerateCacheKeys(entity);
-				await EntityCache.RemoveAsync(keys, cancellationToken);
-			} catch (Exception ex) {
-				Logger.LogEntityNotEvicted(ex, typeof(TEntity), GetEntityKey(entity));
-			}
-		}
-
 		/// <summary>
 		/// Attempts to get the entity with the given entity key from the cache,
 		/// and eventually uses the given factory to create the entity
@@ -926,8 +924,6 @@ namespace Kista {
 
 				Logger.LogEntityAdded(GetEntityKey(entity)!);
 
-				await SetToCacheAsync(entity, token);
-
 				var result = Success();
 				await InvokePostWriteAsync(context, result);
 
@@ -998,7 +994,6 @@ namespace Kista {
 
 				var success = Success();
 				foreach (var context in contexts) {
-					await SetToCacheAsync(context.Entity, token);
 					await InvokePostWriteAsync(context, success);
 				}
 
@@ -1157,8 +1152,6 @@ namespace Kista {
 
 				Logger.LogEntityUpdated(entityKey);
 
-				await SetToCacheAsync(entity, token);
-
 				var result = Success();
 				await InvokePostWriteAsync(context, result);
 
@@ -1241,14 +1234,11 @@ namespace Kista {
 				}
 
 				Logger.LogEntityUpdated(entityKey);
-				await SetToCacheAsync(found, token);
 			} else {
 				if (!await Repository.RemoveAsync(found, token)) {
 					Logger.LogEntityNotRemoved(typeof(TEntity), entityKey);
 					return NotChanged();
 				}
-
-				await EvictAsync(found, token);
 			}
 
 			var result = Success();
@@ -1300,7 +1290,6 @@ namespace Kista {
 
 				var success = Success();
 				foreach (var context in contexts) {
-					await EvictAsync(context.Entity, token);
 					await InvokePostWriteAsync(context, success);
 				}
 
@@ -1374,7 +1363,6 @@ namespace Kista {
 			}
 
 			Logger.LogEntityUpdated(entityKey);
-			await SetToCacheAsync(deleted, token);
 
 			var result = Success();
 			await InvokePostWriteAsync(context, result);
@@ -1442,8 +1430,6 @@ namespace Kista {
 				return NotChanged();
 			}
 
-			await EvictAsync(found, token);
-
 			var result = Success();
 			await InvokePostWriteAsync(context, result);
 
@@ -1494,7 +1480,6 @@ namespace Kista {
 
 				var success = Success();
 				foreach (var context in contexts) {
-					await EvictAsync(context.Entity, token);
 					await InvokePostWriteAsync(context, success);
 				}
 

--- a/src/Kista.Manager/Kista.Manager.csproj
+++ b/src/Kista.Manager/Kista.Manager.csproj
@@ -29,4 +29,10 @@
     <ProjectReference Include="..\Kista\Kista.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Kista.Manager.XUnit</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/Kista.Manager/Kista.Manager.csproj
+++ b/src/Kista.Manager/Kista.Manager.csproj
@@ -29,10 +29,4 @@
     <ProjectReference Include="..\Kista\Kista.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>Kista.Manager.XUnit</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
-
 </Project>

--- a/test/Kista.Manager.XUnit/Unit/Operations/CacheInterceptorTests.cs
+++ b/test/Kista.Manager.XUnit/Unit/Operations/CacheInterceptorTests.cs
@@ -1,5 +1,7 @@
 #pragma warning disable CS8618
 
+using System.Reflection;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using Kista.Caching;
@@ -665,34 +667,83 @@ public class CacheInterceptorTests {
 		await repo.Received().FindAsync("1", Arg.Any<CancellationToken>());
 	}
 
-	// --- Direct CacheInterceptor unit tests (builtin internal type) ---
+	// --- Defensive branches of the builtin CacheInterceptor (internal type) ---
+	//
+	// The builtin `CacheInterceptor<TEntity, TKey>` is `internal sealed`, so
+	// the tests below reach its defensive branches (the `default` switch arm
+	// and the two constructor null-guards) through the public surface: a
+	// test-only `EntityManager` subclass overrides `CreateOperationContext`
+	// to force an unrecognized `EntityOperationKind`, and reflection is used
+	// to invoke the internal constructor with null arguments. No
+	// `InternalsVisibleTo` grant is required on the `Kista.Manager` package.
 
 	[Fact]
-	public async Task Should_ReturnNullFromPreWrite_When_InvokedDirectly() {
-		// PreWriteAsync never short-circuits: it always returns null so the
-		// repository write proceeds. This is the contract that makes the cache
-		// a pure write-path concern.
-		var interceptor = new CacheInterceptor<Person, string>(
-			CreateCache<Person>(),
-			CreateKeyGenerator<Person>(),
-			p => p.Id);
+	public async Task Should_NotInteractWithCache_When_OperationKindIsUnknown() {
+		// Exercises the defensive `default` branch of CacheInterceptor.PostWriteAsync
+		// through the public pipeline: a test-only EntityManager subclass overrides
+		// CreateOperationContext to force an unrecognized EntityOperationKind, then
+		// drives a real AddAsync. The cache interceptor's default arm must leave
+		// the cache untouched, and the write must still succeed (PreWriteAsync
+		// returns null for any kind, OnHooksEntityInterceptor's default is a no-op).
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
 
-		var context = new EntityOperationContext<Person, string>(
-			EntityOperationKind.Create, CreatePerson("1"), original: null, "1",
-			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+		var repo = Substitute.For<IRepository<Person, string>>();
+		repo.GetEntityKey(Arg.Any<Person>()).Returns(c => c.Arg<Person>().Id);
+		repo.AddAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(ValueTask.CompletedTask);
+		cache.GetOrSetAsync(Arg.Any<string>(), Arg.Any<Func<ValueTask<Person?>>>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => callInfo.Arg<Func<ValueTask<Person?>>>()());
 
-		var result = await interceptor.PreWriteAsync(context);
+		var services = new ServiceCollection();
+		services.AddSingleton(keyGen);
+		var provider = services.BuildServiceProvider();
 
-		Assert.Null(result);
+		var manager = new UnknownKindEntityManager(repo, cache, provider);
+		var person = CreatePerson("1");
+
+		var result = await manager.AddAsync(person, TestContext.Current.CancellationToken);
+
+		Assert.True(result.IsSuccess());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
 	}
 
 	[Fact]
-	public async Task Should_SkipCache_When_PostWriteReceivesNotChangedResult() {
-		// Direct unit test of the !IsSuccess early-return: a NotChanged result
-		// must leave the cache untouched regardless of the operation kind.
+	public void Should_Throw_When_CacheInterceptorConstructedWithNullCache() {
+		// The cache dependency is required (the interceptor is only constructed
+		// by the manager when an IEntityCache<TEntity> is registered). The guard
+		// is reached through reflection since the constructor is internal.
+		var ctor = ResolveCacheInterceptorConstructor();
+		var ex = Assert.Throws<TargetInvocationException>(() =>
+			ctor.Invoke(new object?[] { null, null, (Func<Person, string?>)(p => p.Id), null }));
+		var inner = Assert.IsType<ArgumentNullException>(ex.InnerException);
+		Assert.Equal("cache", inner.ParamName);
+	}
+
+	[Fact]
+	public void Should_Throw_When_CacheInterceptorConstructedWithNullKeyGetter() {
+		// The getEntityKey delegate is always a non-null method-group when the
+		// manager constructs the interceptor; the guard is reached here through
+		// reflection since the constructor is internal.
+		var ctor = ResolveCacheInterceptorConstructor();
+		var ex = Assert.Throws<TargetInvocationException>(() =>
+			ctor.Invoke(new object?[] { CreateCache<Person>(), null, null, null }));
+		var inner = Assert.IsType<ArgumentNullException>(ex.InnerException);
+		Assert.Equal("getEntityKey", inner.ParamName);
+	}
+
+	[Fact]
+	public async Task Should_DefaultToNullLogger_When_CacheInterceptorConstructedWithNullLogger() {
+		// Covers the `logger ?? NullLogger.Instance` fallback: the interceptor
+		// is constructed via reflection with a null logger, then PostWriteAsync
+		// is invoked with a NotChanged result. The NullLogger fallback means no
+		// NullReferenceException is thrown, and the !IsSuccess early-return
+		// (line 184) leaves the cache untouched.
 		var cache = CreateCache<Person>();
-		var keyGen = CreateKeyGenerator<Person>();
-		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
+		var ctor = ResolveCacheInterceptorConstructor();
+		var interceptor = (IEntityManagerInterceptor<Person, string>)ctor.Invoke(new object?[] {
+			cache, CreateKeyGenerator<Person>(), (Func<Person, string?>)(p => p.Id), null
+		});
 
 		var person = CreatePerson("1");
 		var context = new EntityOperationContext<Person, string>(
@@ -705,178 +756,25 @@ public class CacheInterceptorTests {
 		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
 	}
 
-	[Fact]
-	public async Task Should_SkipCache_When_PostWriteReceivesFailedResult() {
-		var cache = CreateCache<Person>();
-		var keyGen = CreateKeyGenerator<Person>();
-		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
-
-		var person = CreatePerson("1");
-		var context = new EntityOperationContext<Person, string>(
-			EntityOperationKind.Update, person, original: person, "1",
-			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
-
-		await interceptor.PostWriteAsync(context, OperationResult.Fail(new OperationError("ERR", "Test", "boom")));
-
-		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
-		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	private static ConstructorInfo ResolveCacheInterceptorConstructor() {
+		var asm = typeof(EntityManager<Person, string>).Assembly;
+		var open = asm.GetType("Kista.Caching.CacheInterceptor`2", throwOnError: true);
+		var closed = open!.MakeGenericType(typeof(Person), typeof(string));
+		return closed.GetConstructor(new[] {
+			typeof(IEntityCache<Person>),
+			typeof(IEntityCacheKeyGenerator<Person>),
+			typeof(Func<Person, string?>),
+			typeof(ILogger)
+		})!;
 	}
 
-	[Fact]
-	public async Task Should_NotInteractWithCache_When_PostWriteKindIsUnknown() {
-		// Defensive default branch of the switch: an unrecognized operation
-		// kind must leave the cache untouched (no Set, no Remove).
-		var cache = CreateCache<Person>();
-		var keyGen = CreateKeyGenerator<Person>();
-		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
+	private sealed class UnknownKindEntityManager : EntityManager<Person, string> {
+		public UnknownKindEntityManager(IRepository<Person, string> repo, IEntityCache<Person> cache, IServiceProvider services)
+			: base(repo, cache: cache, services: services) { }
 
-		var person = CreatePerson("1");
-		var context = new EntityOperationContext<Person, string>(
-			(EntityOperationKind)999, person, original: null, "1",
-			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
-
-		await interceptor.PostWriteAsync(context, OperationResult.Success);
-
-		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
-		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
-	}
-
-	[Fact]
-	public async Task Should_ReCacheEntity_When_PostWriteKindIsRestore_InvokedDirectly() {
-		// Direct coverage of the Restore branch of the switch (Create/Update/Restore
-		// all share the SetAsync branch).
-		var cache = CreateCache<SoftDeletablePerson>();
-		var keyGen = CreateKeyGenerator<SoftDeletablePerson>();
-		var interceptor = new CacheInterceptor<SoftDeletablePerson, string>(cache, keyGen, p => p.Id);
-
-		var person = CreateSoftPerson("1");
-		var context = new EntityOperationContext<SoftDeletablePerson, string>(
-			EntityOperationKind.Restore, person, original: person, "1",
-			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
-
-		await interceptor.PostWriteAsync(context, OperationResult.Success);
-
-		await cache.Received().SetAsync(
-			Arg.Any<string[]>(),
-			Arg.Is<SoftDeletablePerson>(p => p.Id == "1"),
-			Arg.Any<CancellationToken>());
-	}
-
-	[Fact]
-	public async Task Should_EvictEntity_When_PostWriteKindIsHardDelete_InvokedDirectly() {
-		var cache = CreateCache<Person>();
-		var keyGen = CreateKeyGenerator<Person>();
-		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
-
-		var person = CreatePerson("1");
-		var context = new EntityOperationContext<Person, string>(
-			EntityOperationKind.HardDelete, person, original: person, "1",
-			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
-
-		await interceptor.PostWriteAsync(context, OperationResult.Success);
-
-		await cache.Received().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
-		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
-	}
-
-	[Fact]
-	public async Task Should_ReCacheSoftDeletable_When_PostWriteKindIsRemove_InvokedDirectly() {
-		var cache = CreateCache<SoftDeletablePerson>();
-		var keyGen = CreateKeyGenerator<SoftDeletablePerson>();
-		var interceptor = new CacheInterceptor<SoftDeletablePerson, string>(cache, keyGen, p => p.Id);
-
-		var person = CreateSoftPerson("1");
-		var context = new EntityOperationContext<SoftDeletablePerson, string>(
-			EntityOperationKind.Remove, person, original: person, "1",
-			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
-
-		await interceptor.PostWriteAsync(context, OperationResult.Success);
-
-		await cache.Received().SetAsync(Arg.Any<string[]>(), Arg.Any<SoftDeletablePerson>(), Arg.Any<CancellationToken>());
-		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
-	}
-
-	[Fact]
-	public async Task Should_EvictNonSoftDeletable_When_PostWriteKindIsRemove_InvokedDirectly() {
-		var cache = CreateCache<Person>();
-		var keyGen = CreateKeyGenerator<Person>();
-		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
-
-		var person = CreatePerson("1");
-		var context = new EntityOperationContext<Person, string>(
-			EntityOperationKind.Remove, person, original: person, "1",
-			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
-
-		await interceptor.PostWriteAsync(context, OperationResult.Success);
-
-		await cache.Received().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
-		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
-	}
-
-	[Fact]
-	public async Task Should_SkipCacheSet_When_KeyGeneratorReturnsEmptyKeys_InvokedDirectly() {
-		// The interceptor's SetToCacheAsync early-returns when the key generator
-		// yields an empty array of keys (the entity cannot be addressed in the cache).
-		var cache = CreateCache<Person>();
-		var keyGen = Substitute.For<IEntityCacheKeyGenerator<Person>>();
-		keyGen.GenerateAllKeys(Arg.Any<Person>()).Returns(Array.Empty<string>());
-		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
-
-		var person = CreatePerson("1");
-		var context = new EntityOperationContext<Person, string>(
-			EntityOperationKind.Create, person, original: null, "1",
-			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
-
-		await interceptor.PostWriteAsync(context, OperationResult.Success);
-
-		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
-	}
-
-	[Fact]
-	public async Task Should_LogAndContinue_When_CacheSetThrows_InvokedDirectly() {
-		// Direct coverage of the catch block in SetToCacheAsync: a cache failure
-		// is logged and swallowed, PostWriteAsync completes without throwing.
-		var cache = CreateCache<Person>();
-		cache.SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>())
-			.Throws(new InvalidOperationException("cache down"));
-		var interceptor = new CacheInterceptor<Person, string>(cache, CreateKeyGenerator<Person>(), p => p.Id);
-
-		var person = CreatePerson("1");
-		var context = new EntityOperationContext<Person, string>(
-			EntityOperationKind.Create, person, original: null, "1",
-			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
-
-		await interceptor.PostWriteAsync(context, OperationResult.Success);
-	}
-
-	[Fact]
-	public async Task Should_LogAndContinue_When_CacheEvictionThrows_InvokedDirectly() {
-		// Direct coverage of the catch block in EvictAsync: a cache failure
-		// is logged and swallowed, PostWriteAsync completes without throwing.
-		var cache = CreateCache<Person>();
-		cache.RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>())
-			.Throws(new InvalidOperationException("cache down"));
-		var interceptor = new CacheInterceptor<Person, string>(cache, CreateKeyGenerator<Person>(), p => p.Id);
-
-		var person = CreatePerson("1");
-		var context = new EntityOperationContext<Person, string>(
-			EntityOperationKind.HardDelete, person, original: person, "1",
-			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
-
-		await interceptor.PostWriteAsync(context, OperationResult.Success);
-	}
-
-	[Fact]
-	public void Should_Throw_When_CacheInterceptorConstructedWithNullCache() {
-		// Constructor guard: the cache dependency is required (the interceptor is
-		// only constructed when an IEntityCache<TEntity> is registered).
-		Assert.Throws<ArgumentNullException>(() =>
-			new CacheInterceptor<Person, string>(cache: null!, keyGenerator: null, p => p.Id));
-	}
-
-	[Fact]
-	public void Should_Throw_When_CacheInterceptorConstructedWithNullKeyGetter() {
-		Assert.Throws<ArgumentNullException>(() =>
-			new CacheInterceptor<Person, string>(CreateCache<Person>(), null, getEntityKey: null!));
+		protected override IEntityOperationContext<Person, string> CreateOperationContext(
+			EntityOperationKind kind, Person entity, Person? original, CancellationToken cancellationToken)
+			=> new EntityOperationContext<Person, string>(
+				(EntityOperationKind)999, entity, original, "1", actor: null, DateTimeOffset.UtcNow, cancellationToken);
 	}
 }

--- a/test/Kista.Manager.XUnit/Unit/Operations/CacheInterceptorTests.cs
+++ b/test/Kista.Manager.XUnit/Unit/Operations/CacheInterceptorTests.cs
@@ -1,0 +1,882 @@
+#pragma warning disable CS8618
+
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Kista.Caching;
+
+namespace Kista;
+
+/// <summary>
+/// Unit tests for the builtin <see cref="CacheInterceptor{TEntity, TKey}"/>
+/// that aligns the entity cache to the operation pipeline (issue #120).
+/// </summary>
+/// <remarks>
+/// These tests verify that the cache is re-cached on Create / Update /
+/// Restore, evicted on HardDelete and on the hard branch of Remove,
+/// re-cached on the soft-delete branch of Remove, and that cache
+/// failures are swallowed. They also verify the behavior change that
+/// aligns <see cref="EntityManager{TEntity, TKey}.RemoveRangeAsync"/>
+/// with <see cref="EntityManager{TEntity, TKey}.RemoveAsync"/>: soft-
+/// deletable entities in a range Remove are now re-cached instead of
+/// evicted.
+/// </remarks>
+[Trait("Category", "Unit")]
+[Trait("Layer", "Application")]
+[Trait("Feature", "Caching")]
+[Trait("Feature", "OperationPipeline")]
+public class CacheInterceptorTests {
+	private static readonly PersonFaker _faker = new();
+	private static readonly SoftDeletablePersonFaker _softFaker = new();
+
+	private static Person CreatePerson(string? id = "1") {
+		var person = _faker.Generate();
+		person.Id = id;
+		return person;
+	}
+
+	private static SoftDeletablePerson CreateSoftPerson(string? id = "1", bool isDeleted = false) {
+		var person = _softFaker.Generate();
+		person.Id = id;
+		person.IsDeleted = isDeleted;
+		return person;
+	}
+
+	// --- Manager builders ---
+
+	private static (EntityManager<Person, string> manager, IRepository<Person, string> repo) BuildManager(
+		IEntityCache<Person>? cache = null,
+		IEntityCacheKeyGenerator<Person>? keyGenerator = null,
+		IEnumerable<IEntityManagerInterceptor<Person, string>>? interceptors = null) {
+		var repo = Substitute.For<IRepository<Person, string>>();
+		repo.GetEntityKey(Arg.Any<Person>()).Returns(c => c.Arg<Person>().Id);
+		repo.AddAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(ValueTask.CompletedTask);
+		repo.UpdateAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(true);
+		repo.RemoveAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(true);
+		repo.HardDeleteAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(true);
+		repo.FindAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((Person?)null);
+
+		// When a cache is registered, FindAsync delegates to the read-through
+		// GetOrSetAsync: route it back to the repo so seeded FindAsync returns
+		// win over the (default null) cache proxy.
+		if (cache != null)
+			cache.GetOrSetAsync(Arg.Any<string>(), Arg.Any<Func<ValueTask<Person?>>>(), Arg.Any<CancellationToken>())
+				.Returns(callInfo => callInfo.Arg<Func<ValueTask<Person?>>>()());
+
+		var services = new ServiceCollection();
+		if (keyGenerator != null)
+			services.AddSingleton(keyGenerator);
+		foreach (var interceptor in interceptors ?? Array.Empty<IEntityManagerInterceptor<Person, string>>())
+			services.AddSingleton(interceptor);
+
+		var provider = services.BuildServiceProvider();
+		var manager = new EntityManager<Person, string>(repo, cache: cache, services: provider);
+		return (manager, repo);
+	}
+
+	private static (EntityManager<SoftDeletablePerson, string> manager, IRepository<SoftDeletablePerson, string> repo) BuildSoftManager(
+		IEntityCache<SoftDeletablePerson>? cache = null,
+		IEntityCacheKeyGenerator<SoftDeletablePerson>? keyGenerator = null) {
+		var repo = Substitute.For<IRepository<SoftDeletablePerson, string>>();
+		repo.GetEntityKey(Arg.Any<SoftDeletablePerson>()).Returns(c => c.Arg<SoftDeletablePerson>().Id);
+		repo.UpdateAsync(Arg.Any<SoftDeletablePerson>(), Arg.Any<CancellationToken>()).Returns(true);
+		repo.FindAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((SoftDeletablePerson?)null);
+
+		if (cache != null)
+			cache.GetOrSetAsync(Arg.Any<string>(), Arg.Any<Func<ValueTask<SoftDeletablePerson?>>>(), Arg.Any<CancellationToken>())
+				.Returns(callInfo => callInfo.Arg<Func<ValueTask<SoftDeletablePerson?>>>()());
+
+		var services = new ServiceCollection();
+		if (keyGenerator != null)
+			services.AddSingleton(keyGenerator);
+
+		var provider = services.BuildServiceProvider();
+		var manager = new EntityManager<SoftDeletablePerson, string>(repo, cache: cache, services: provider);
+		return (manager, repo);
+	}
+
+	private static IEntityCache<T> CreateCache<T>() where T : class
+		=> Substitute.For<IEntityCache<T>>();
+
+	private static IEntityCacheKeyGenerator<T> CreateKeyGenerator<T>() where T : class {
+		var gen = Substitute.For<IEntityCacheKeyGenerator<T>>();
+		gen.GenerateAllKeys(Arg.Any<T>()).Returns(c => new[] { $"key:{c.Arg<T>().GetHashCode()}" });
+		gen.GenerateKey(Arg.Any<object>()).Returns(c => $"key:{c.Arg<object>().GetHashCode()}");
+		return gen;
+	}
+
+	// --- Create ---
+
+	[Fact]
+	public async Task Should_CacheEntity_When_AddSucceeds() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, _) = BuildManager(cache, keyGen);
+		var person = CreatePerson("1");
+
+		await manager.AddAsync(person, TestContext.Current.CancellationToken);
+
+		await cache.Received().SetAsync(
+			Arg.Is<string[]>(keys => keys.Length == 1),
+			Arg.Is<Person>(p => p.Id == "1"),
+			Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotCacheEntity_When_AddShortCircuits() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var shortCircuit = new ShortCircuitInterceptor();
+		var (manager, repo) = BuildManager(cache, keyGen, new IEntityManagerInterceptor<Person, string>[] { shortCircuit });
+		var person = CreatePerson("1");
+
+		var result = await manager.AddAsync(person, TestContext.Current.CancellationToken);
+
+		Assert.False(result.IsSuccess());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+		await repo.DidNotReceive().AddAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	// --- Update ---
+
+	[Fact]
+	public async Task Should_CacheEntity_When_UpdateSucceeds() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+
+		var existing = CreatePerson("1");
+		existing.FirstName = "Old";
+		var updated = CreatePerson("1");
+		updated.FirstName = "New";
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(existing);
+		repo.UpdateAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(true);
+
+		await manager.UpdateAsync(updated, TestContext.Current.CancellationToken);
+
+		await cache.Received().SetAsync(
+			Arg.Any<string[]>(),
+			Arg.Is<Person>(p => p.FirstName == "New"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotCacheEntity_When_UpdateReturnsNotChanged() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+
+		// The manager's AreEqual short-circuits the update (returns NotChanged)
+		// when the loaded entity and the provided entity are equal: use the
+		// same instance so the reference equality holds and no cache Set is
+		// performed in PostWriteAsync (NotChanged is not a success result).
+		var existing = CreatePerson("1");
+		var updated = existing;
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(existing);
+		repo.UpdateAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(true);
+
+		await manager.UpdateAsync(updated, TestContext.Current.CancellationToken);
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	// --- Restore ---
+
+	[Fact]
+	public async Task Should_CacheEntity_When_RestoreSucceeds() {
+		var cache = CreateCache<SoftDeletablePerson>();
+		var keyGen = CreateKeyGenerator<SoftDeletablePerson>();
+		var (manager, repo) = BuildSoftManager(cache, keyGen);
+
+		var person = CreateSoftPerson("1", isDeleted: true);
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+		repo.UpdateAsync(Arg.Any<SoftDeletablePerson>(), Arg.Any<CancellationToken>()).Returns(true);
+
+		await manager.RestoreAsync(person, TestContext.Current.CancellationToken);
+
+		await cache.Received().SetAsync(
+			Arg.Any<string[]>(),
+			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted == false),
+			Arg.Any<CancellationToken>());
+	}
+
+	// --- Remove (single) ---
+
+	[Fact]
+	public async Task Should_ReCacheEntity_When_RemoveOnSoftDeletable() {
+		var cache = CreateCache<SoftDeletablePerson>();
+		var keyGen = CreateKeyGenerator<SoftDeletablePerson>();
+		var (manager, repo) = BuildSoftManager(cache, keyGen);
+
+		var person = CreateSoftPerson("1", isDeleted: false);
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+		repo.UpdateAsync(Arg.Any<SoftDeletablePerson>(), Arg.Any<CancellationToken>()).Returns(true);
+
+		await manager.RemoveAsync(person, TestContext.Current.CancellationToken);
+
+		await cache.Received().SetAsync(
+			Arg.Any<string[]>(),
+			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted == true),
+			Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_EvictEntity_When_RemoveOnNonSoftDeletable() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+
+		var person = CreatePerson("1");
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+		repo.RemoveAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(true);
+
+		await manager.RemoveAsync(person, TestContext.Current.CancellationToken);
+
+		await cache.Received().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	// --- HardDelete (single) ---
+
+	[Fact]
+	public async Task Should_EvictEntity_When_HardDeleteSucceeds() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+
+		var person = CreatePerson("1");
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+		repo.HardDeleteAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(true);
+
+		await manager.HardDeleteAsync(person, TestContext.Current.CancellationToken);
+
+		await cache.Received().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	// --- Range operations ---
+
+	[Fact]
+	public async Task Should_CacheAllEntities_When_AddRangeSucceeds() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+		repo.AddRangeAsync(Arg.Any<IEnumerable<Person>>(), Arg.Any<CancellationToken>()).Returns(ValueTask.CompletedTask);
+
+		var people = new List<Person> { CreatePerson("1"), CreatePerson("2"), CreatePerson("3") };
+
+		await manager.AddRangeAsync(people, TestContext.Current.CancellationToken);
+
+		await cache.Received(3).SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_ReCacheSoftDeletableEntity_When_RemoveRange() {
+		// Behavior change in v1.7.x: RemoveRangeAsync now aligns with RemoveAsync,
+		// re-caching soft-deletable entities instead of evicting them.
+		var cache = CreateCache<SoftDeletablePerson>();
+		var keyGen = CreateKeyGenerator<SoftDeletablePerson>();
+		var (manager, repo) = BuildSoftManager(cache, keyGen);
+		repo.RemoveRangeAsync(Arg.Any<IEnumerable<SoftDeletablePerson>>(), Arg.Any<CancellationToken>()).Returns(ValueTask.CompletedTask);
+
+		var softPerson = CreateSoftPerson("1", isDeleted: false);
+
+		await manager.RemoveRangeAsync(new[] { softPerson }, TestContext.Current.CancellationToken);
+
+		await cache.Received().SetAsync(
+			Arg.Any<string[]>(),
+			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted == true),
+			Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_EvictNonSoftDeletableEntity_When_RemoveRange() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+		repo.RemoveRangeAsync(Arg.Any<IEnumerable<Person>>(), Arg.Any<CancellationToken>()).Returns(ValueTask.CompletedTask);
+
+		var person = CreatePerson("1");
+
+		await manager.RemoveRangeAsync(new[] { person }, TestContext.Current.CancellationToken);
+
+		await cache.Received().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_EvictAllEntities_When_HardDeleteRange() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+		repo.HardDeleteRangeAsync(Arg.Any<IEnumerable<Person>>(), Arg.Any<CancellationToken>()).Returns(ValueTask.CompletedTask);
+
+		var people = new List<Person> { CreatePerson("1"), CreatePerson("2") };
+
+		await manager.HardDeleteRangeAsync(people, TestContext.Current.CancellationToken);
+
+		await cache.Received(2).RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	// --- No cache / no key generator ---
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_NoCacheRegistered() {
+		// No cache => the interceptor is not appended to the chain at all.
+		// The operation must still succeed (regression guard for the wiring).
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache: null, keyGen);
+		var person = CreatePerson("1");
+
+		var result = await manager.AddAsync(person, TestContext.Current.CancellationToken);
+
+		Assert.True(result.IsSuccess());
+		await repo.Received().AddAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_NoKeyGeneratorRegistered() {
+		// A cache is registered, but no IEntityCacheKeyGenerator: the interceptor
+		// resolves an empty array of keys and skips the cache interaction.
+		var cache = CreateCache<Person>();
+		var (manager, _) = BuildManager(cache, keyGenerator: null);
+		var person = CreatePerson("1");
+
+		await manager.AddAsync(person, TestContext.Current.CancellationToken);
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	// --- Cache failure resilience ---
+
+	[Fact]
+	public async Task Should_NotFail_When_CacheSetThrows() {
+		var cache = CreateCache<Person>();
+		cache.SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>())
+			.Throws(new InvalidOperationException("cache down"));
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, _) = BuildManager(cache, keyGen);
+		var person = CreatePerson("1");
+
+		var result = await manager.AddAsync(person, TestContext.Current.CancellationToken);
+
+		Assert.True(result.IsSuccess());
+	}
+
+	[Fact]
+	public async Task Should_NotFail_When_CacheEvictionThrows() {
+		var cache = CreateCache<Person>();
+		cache.RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+			.Throws(new InvalidOperationException("cache down"));
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+		var person = CreatePerson("1");
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+		repo.RemoveAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(true);
+
+		var result = await manager.RemoveAsync(person, TestContext.Current.CancellationToken);
+
+		Assert.True(result.IsSuccess());
+	}
+
+	// --- FindAsync read-through stays inline (regression guard) ---
+
+	[Fact]
+	public async Task Should_PreserveFindReadThroughCache() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+
+		var person = CreatePerson("1");
+		// GetOrSetAsync must call the factory when the cache returns null
+		cache.GetOrSetAsync(Arg.Any<string>(), Arg.Any<Func<ValueTask<Person?>>>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => callInfo.Arg<Func<ValueTask<Person?>>>()());
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+
+		var result = await manager.FindAsync("1", TestContext.Current.CancellationToken);
+
+		Assert.True(result.IsSuccess());
+		// The read-through path goes through the cache (GetOrSetAsync was called)
+		await cache.Received().GetOrSetAsync(
+			Arg.Any<string>(),
+			Arg.Any<Func<ValueTask<Person?>>>(),
+			Arg.Any<CancellationToken>());
+	}
+
+	// --- Ordering: cache runs after hooks (sees mutated entity) ---
+
+	[Fact]
+	public async Task Should_RunCacheAfterHooks_When_HookMutatesEntity() {
+		var cache = CreateCache<SoftDeletablePerson>();
+		var keyGen = CreateKeyGenerator<SoftDeletablePerson>();
+		var (manager, repo) = BuildSoftManager(cache, keyGen);
+
+		var person = CreateSoftPerson("1", isDeleted: false);
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+		repo.UpdateAsync(Arg.Any<SoftDeletablePerson>(), Arg.Any<CancellationToken>()).Returns(true);
+
+		await manager.RemoveAsync(person, TestContext.Current.CancellationToken);
+
+		// The OnRemovingEntityAsync hook (builtin, runs before the cache interceptor)
+		// sets IsDeleted=true before the soft-delete branch re-caches the entity.
+		await cache.Received().SetAsync(
+			Arg.Any<string[]>(),
+			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted == true),
+			Arg.Any<CancellationToken>());
+		Assert.True(person.IsDeleted);
+	}
+
+	// --- NotChanged / failed results leave the cache untouched (line 184) ---
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_UpdateReturnsNotChanged_WithCacheRegistered() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+
+		// AreEqual short-circuits to NotChanged before the repository write,
+		// so PostWriteAsync receives a not-success result and must skip the cache.
+		var existing = CreatePerson("1");
+		var updated = existing;
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(existing);
+		repo.UpdateAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(true);
+
+		await manager.UpdateAsync(updated, TestContext.Current.CancellationToken);
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_UpdateRepoReturnsFalse_WithCacheRegistered() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+
+		var existing = CreatePerson("1");
+		existing.FirstName = "Old";
+		var updated = CreatePerson("1");
+		updated.FirstName = "New";
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(existing);
+		repo.UpdateAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(false);
+
+		await manager.UpdateAsync(updated, TestContext.Current.CancellationToken);
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_RemoveRepoReturnsFalse_WithCacheRegistered() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+
+		var person = CreatePerson("1");
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+		repo.RemoveAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(false);
+
+		await manager.RemoveAsync(person, TestContext.Current.CancellationToken);
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_RestoreRepoReturnsFalse_WithCacheRegistered() {
+		var cache = CreateCache<SoftDeletablePerson>();
+		var keyGen = CreateKeyGenerator<SoftDeletablePerson>();
+		var (manager, repo) = BuildSoftManager(cache, keyGen);
+
+		var person = CreateSoftPerson("1", isDeleted: true);
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+		repo.UpdateAsync(Arg.Any<SoftDeletablePerson>(), Arg.Any<CancellationToken>()).Returns(false);
+
+		await manager.RestoreAsync(person, TestContext.Current.CancellationToken);
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<SoftDeletablePerson>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_HardDeleteRepoReturnsFalse_WithCacheRegistered() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+
+		var person = CreatePerson("1");
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+		repo.HardDeleteAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>()).Returns(false);
+
+		await manager.HardDeleteAsync(person, TestContext.Current.CancellationToken);
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_SoftDeleteRemoveReturnsFalse_WithCacheRegistered() {
+		// Covers the soft-delete branch of RemoveAsync where Repository.UpdateAsync
+		// returns false (the entity was not soft-deleted): PostWriteAsync receives
+		// a NotChanged result and must skip the cache.
+		var cache = CreateCache<SoftDeletablePerson>();
+		var keyGen = CreateKeyGenerator<SoftDeletablePerson>();
+		var (manager, repo) = BuildSoftManager(cache, keyGen);
+
+		var person = CreateSoftPerson("1", isDeleted: false);
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+		repo.UpdateAsync(Arg.Any<SoftDeletablePerson>(), Arg.Any<CancellationToken>()).Returns(false);
+
+		var result = await manager.RemoveAsync(person, TestContext.Current.CancellationToken);
+
+		Assert.True(result.IsUnchanged());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<SoftDeletablePerson>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_ShortCircuitFails_WithCacheRegistered() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var shortCircuit = new ShortCircuitInterceptor();
+		var (manager, repo) = BuildManager(cache, keyGen, new IEntityManagerInterceptor<Person, string>[] { shortCircuit });
+		var person = CreatePerson("1");
+
+		var result = await manager.AddAsync(person, TestContext.Current.CancellationToken);
+
+		Assert.False(result.IsSuccess());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_ValidationFails_WithCacheRegistered() {
+		// A failing validator returns a ValidationFailed result (not success):
+		// the repository write is skipped, PostWriteAsync is not invoked, and
+		// the cache is left untouched.
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var repo = Substitute.For<IRepository<Person, string>>();
+		repo.GetEntityKey(Arg.Any<Person>()).Returns(c => c.Arg<Person>().Id);
+		repo.FindAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns((Person?)null);
+		cache.GetOrSetAsync(Arg.Any<string>(), Arg.Any<Func<ValueTask<Person?>>>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => callInfo.Arg<Func<ValueTask<Person?>>>()());
+
+		var validator = Substitute.For<IEntityValidator<Person, string>>();
+		validator.ValidateAsync(Arg.Any<EntityManager<Person, string>>(), Arg.Any<Person>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => AsyncEnumerable(new[] { new System.ComponentModel.DataAnnotations.ValidationResult("nope", new[] { "FirstName" }) }));
+
+		var services = new ServiceCollection();
+		services.AddSingleton(keyGen);
+		var provider = services.BuildServiceProvider();
+		var manager = new EntityManager<Person, string>(repo, validator, cache, services: provider);
+
+		var person = CreatePerson("1");
+		var result = await manager.AddAsync(person, TestContext.Current.CancellationToken);
+
+		Assert.False(result.IsSuccess());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+		await repo.DidNotReceive().AddAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_UpdateValidationFails_WithCacheRegistered() {
+		// Covers the UpdateAsync validation-failure branch: the entity is found
+		// and differs from the provided one, but validation fails before the
+		// pipeline runs. The cache must be left untouched.
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var repo = Substitute.For<IRepository<Person, string>>();
+		repo.GetEntityKey(Arg.Any<Person>()).Returns(c => c.Arg<Person>().Id);
+
+		var existing = CreatePerson("1");
+		existing.FirstName = "Old";
+		var updated = CreatePerson("1");
+		updated.FirstName = "New";
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(existing);
+		cache.GetOrSetAsync(Arg.Any<string>(), Arg.Any<Func<ValueTask<Person?>>>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => callInfo.Arg<Func<ValueTask<Person?>>>()());
+
+		var validator = Substitute.For<IEntityValidator<Person, string>>();
+		validator.ValidateAsync(Arg.Any<EntityManager<Person, string>>(), Arg.Any<Person>(), Arg.Any<CancellationToken>())
+			.Returns(callInfo => AsyncEnumerable(new[] { new System.ComponentModel.DataAnnotations.ValidationResult("nope", new[] { "FirstName" }) }));
+
+		var services = new ServiceCollection();
+		services.AddSingleton(keyGen);
+		var provider = services.BuildServiceProvider();
+		var manager = new EntityManager<Person, string>(repo, validator, cache, services: provider);
+
+		var result = await manager.UpdateAsync(updated, TestContext.Current.CancellationToken);
+
+		Assert.False(result.IsSuccess());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+		await repo.DidNotReceive().UpdateAsync(Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	private static async IAsyncEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> AsyncEnumerable(IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> results) {
+		foreach (var r in results)
+			yield return r;
+		await Task.CompletedTask;
+	}
+
+	// --- Read-through cache exception fallback (EntityManager_T2 GetOrSetAsync) ---
+
+	[Fact]
+	public async Task Should_FallbackToRepository_When_ReadThroughCacheThrows() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache, keyGen);
+
+		var person = CreatePerson("1");
+		// The read-through GetOrSetAsync throws: the manager must log, swallow,
+		// and fall back to the value factory (the repository FindAsync).
+		cache.GetOrSetAsync(Arg.Any<string>(), Arg.Any<Func<ValueTask<Person?>>>(), Arg.Any<CancellationToken>())
+			.Throws(new InvalidOperationException("cache read down"));
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+
+		var result = await manager.FindAsync("1", TestContext.Current.CancellationToken);
+
+		Assert.True(result.IsSuccess());
+		Assert.Equal("1", result.Value!.Id);
+		// The repository was consulted through the factory fallback.
+		await repo.Received().FindAsync("1", Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotUseCache_When_NoCacheRegistered_ForFindAsync() {
+		// FindAsync with no cache registered must go straight to the repository
+		// (the GetOrSetAsync early-returns the factory result when EntityCache is null).
+		var keyGen = CreateKeyGenerator<Person>();
+		var (manager, repo) = BuildManager(cache: null, keyGen);
+
+		var person = CreatePerson("1");
+		repo.FindAsync("1", Arg.Any<CancellationToken>()).Returns(person);
+
+		var result = await manager.FindAsync("1", TestContext.Current.CancellationToken);
+
+		Assert.True(result.IsSuccess());
+		await repo.Received().FindAsync("1", Arg.Any<CancellationToken>());
+	}
+
+	// --- Direct CacheInterceptor unit tests (builtin internal type) ---
+
+	[Fact]
+	public async Task Should_ReturnNullFromPreWrite_When_InvokedDirectly() {
+		// PreWriteAsync never short-circuits: it always returns null so the
+		// repository write proceeds. This is the contract that makes the cache
+		// a pure write-path concern.
+		var interceptor = new CacheInterceptor<Person, string>(
+			CreateCache<Person>(),
+			CreateKeyGenerator<Person>(),
+			p => p.Id);
+
+		var context = new EntityOperationContext<Person, string>(
+			EntityOperationKind.Create, CreatePerson("1"), original: null, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		var result = await interceptor.PreWriteAsync(context);
+
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public async Task Should_SkipCache_When_PostWriteReceivesNotChangedResult() {
+		// Direct unit test of the !IsSuccess early-return: a NotChanged result
+		// must leave the cache untouched regardless of the operation kind.
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
+
+		var person = CreatePerson("1");
+		var context = new EntityOperationContext<Person, string>(
+			EntityOperationKind.Create, person, original: null, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		await interceptor.PostWriteAsync(context, OperationResult.NotChanged);
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_SkipCache_When_PostWriteReceivesFailedResult() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
+
+		var person = CreatePerson("1");
+		var context = new EntityOperationContext<Person, string>(
+			EntityOperationKind.Update, person, original: person, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		await interceptor.PostWriteAsync(context, OperationResult.Fail(new OperationError("ERR", "Test", "boom")));
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_NotInteractWithCache_When_PostWriteKindIsUnknown() {
+		// Defensive default branch of the switch: an unrecognized operation
+		// kind must leave the cache untouched (no Set, no Remove).
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
+
+		var person = CreatePerson("1");
+		var context = new EntityOperationContext<Person, string>(
+			(EntityOperationKind)999, person, original: null, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		await interceptor.PostWriteAsync(context, OperationResult.Success);
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_ReCacheEntity_When_PostWriteKindIsRestore_InvokedDirectly() {
+		// Direct coverage of the Restore branch of the switch (Create/Update/Restore
+		// all share the SetAsync branch).
+		var cache = CreateCache<SoftDeletablePerson>();
+		var keyGen = CreateKeyGenerator<SoftDeletablePerson>();
+		var interceptor = new CacheInterceptor<SoftDeletablePerson, string>(cache, keyGen, p => p.Id);
+
+		var person = CreateSoftPerson("1");
+		var context = new EntityOperationContext<SoftDeletablePerson, string>(
+			EntityOperationKind.Restore, person, original: person, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		await interceptor.PostWriteAsync(context, OperationResult.Success);
+
+		await cache.Received().SetAsync(
+			Arg.Any<string[]>(),
+			Arg.Is<SoftDeletablePerson>(p => p.Id == "1"),
+			Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_EvictEntity_When_PostWriteKindIsHardDelete_InvokedDirectly() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
+
+		var person = CreatePerson("1");
+		var context = new EntityOperationContext<Person, string>(
+			EntityOperationKind.HardDelete, person, original: person, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		await interceptor.PostWriteAsync(context, OperationResult.Success);
+
+		await cache.Received().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_ReCacheSoftDeletable_When_PostWriteKindIsRemove_InvokedDirectly() {
+		var cache = CreateCache<SoftDeletablePerson>();
+		var keyGen = CreateKeyGenerator<SoftDeletablePerson>();
+		var interceptor = new CacheInterceptor<SoftDeletablePerson, string>(cache, keyGen, p => p.Id);
+
+		var person = CreateSoftPerson("1");
+		var context = new EntityOperationContext<SoftDeletablePerson, string>(
+			EntityOperationKind.Remove, person, original: person, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		await interceptor.PostWriteAsync(context, OperationResult.Success);
+
+		await cache.Received().SetAsync(Arg.Any<string[]>(), Arg.Any<SoftDeletablePerson>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_EvictNonSoftDeletable_When_PostWriteKindIsRemove_InvokedDirectly() {
+		var cache = CreateCache<Person>();
+		var keyGen = CreateKeyGenerator<Person>();
+		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
+
+		var person = CreatePerson("1");
+		var context = new EntityOperationContext<Person, string>(
+			EntityOperationKind.Remove, person, original: person, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		await interceptor.PostWriteAsync(context, OperationResult.Success);
+
+		await cache.Received().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_SkipCacheSet_When_KeyGeneratorReturnsEmptyKeys_InvokedDirectly() {
+		// The interceptor's SetToCacheAsync early-returns when the key generator
+		// yields an empty array of keys (the entity cannot be addressed in the cache).
+		var cache = CreateCache<Person>();
+		var keyGen = Substitute.For<IEntityCacheKeyGenerator<Person>>();
+		keyGen.GenerateAllKeys(Arg.Any<Person>()).Returns(Array.Empty<string>());
+		var interceptor = new CacheInterceptor<Person, string>(cache, keyGen, p => p.Id);
+
+		var person = CreatePerson("1");
+		var context = new EntityOperationContext<Person, string>(
+			EntityOperationKind.Create, person, original: null, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		await interceptor.PostWriteAsync(context, OperationResult.Success);
+
+		await cache.DidNotReceive().SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task Should_LogAndContinue_When_CacheSetThrows_InvokedDirectly() {
+		// Direct coverage of the catch block in SetToCacheAsync: a cache failure
+		// is logged and swallowed, PostWriteAsync completes without throwing.
+		var cache = CreateCache<Person>();
+		cache.SetAsync(Arg.Any<string[]>(), Arg.Any<Person>(), Arg.Any<CancellationToken>())
+			.Throws(new InvalidOperationException("cache down"));
+		var interceptor = new CacheInterceptor<Person, string>(cache, CreateKeyGenerator<Person>(), p => p.Id);
+
+		var person = CreatePerson("1");
+		var context = new EntityOperationContext<Person, string>(
+			EntityOperationKind.Create, person, original: null, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		await interceptor.PostWriteAsync(context, OperationResult.Success);
+	}
+
+	[Fact]
+	public async Task Should_LogAndContinue_When_CacheEvictionThrows_InvokedDirectly() {
+		// Direct coverage of the catch block in EvictAsync: a cache failure
+		// is logged and swallowed, PostWriteAsync completes without throwing.
+		var cache = CreateCache<Person>();
+		cache.RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+			.Throws(new InvalidOperationException("cache down"));
+		var interceptor = new CacheInterceptor<Person, string>(cache, CreateKeyGenerator<Person>(), p => p.Id);
+
+		var person = CreatePerson("1");
+		var context = new EntityOperationContext<Person, string>(
+			EntityOperationKind.HardDelete, person, original: person, "1",
+			actor: null, DateTimeOffset.UtcNow, CancellationToken.None);
+
+		await interceptor.PostWriteAsync(context, OperationResult.Success);
+	}
+
+	[Fact]
+	public void Should_Throw_When_CacheInterceptorConstructedWithNullCache() {
+		// Constructor guard: the cache dependency is required (the interceptor is
+		// only constructed when an IEntityCache<TEntity> is registered).
+		Assert.Throws<ArgumentNullException>(() =>
+			new CacheInterceptor<Person, string>(cache: null!, keyGenerator: null, p => p.Id));
+	}
+
+	[Fact]
+	public void Should_Throw_When_CacheInterceptorConstructedWithNullKeyGetter() {
+		Assert.Throws<ArgumentNullException>(() =>
+			new CacheInterceptor<Person, string>(CreateCache<Person>(), null, getEntityKey: null!));
+	}
+}

--- a/test/Kista.Manager.XUnit/Unit/Operations/CacheInterceptorTests.cs
+++ b/test/Kista.Manager.XUnit/Unit/Operations/CacheInterceptorTests.cs
@@ -199,7 +199,7 @@ public class CacheInterceptorTests {
 
 		await cache.Received().SetAsync(
 			Arg.Any<string[]>(),
-			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted == false),
+			Arg.Is<SoftDeletablePerson>(p => !p.IsDeleted),
 			Arg.Any<CancellationToken>());
 	}
 
@@ -219,7 +219,7 @@ public class CacheInterceptorTests {
 
 		await cache.Received().SetAsync(
 			Arg.Any<string[]>(),
-			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted == true),
+			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted),
 			Arg.Any<CancellationToken>());
 		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
 	}
@@ -289,7 +289,7 @@ public class CacheInterceptorTests {
 
 		await cache.Received().SetAsync(
 			Arg.Any<string[]>(),
-			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted == true),
+			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted),
 			Arg.Any<CancellationToken>());
 		await cache.DidNotReceive().RemoveAsync(Arg.Any<string[]>(), Arg.Any<CancellationToken>());
 	}
@@ -428,7 +428,7 @@ public class CacheInterceptorTests {
 		// sets IsDeleted=true before the soft-delete branch re-caches the entity.
 		await cache.Received().SetAsync(
 			Arg.Any<string[]>(),
-			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted == true),
+			Arg.Is<SoftDeletablePerson>(p => p.IsDeleted),
 			Arg.Any<CancellationToken>());
 		Assert.True(person.IsDeleted);
 	}


### PR DESCRIPTION
Closes #120.

## What

Moves the `EntityManager<TEntity, TKey>` inline cache glue (`SetToCacheAsync` / `EvictAsync`, called from nine sites across the eight write methods) into the Extensible Operation Pipeline (#119) as a builtin `CacheInterceptor<TEntity, TKey>`. The cache concern becomes removable, reorderable, and testable in isolation alongside events, audit, and custom interceptors — and the manager body stops duplicating cache calls across every CRUD method. `FindAsync`'s read-through `GetOrSetByKeyAsync` stays inline (read-path caching is out of scope for this feature).

## Concrete implementation

### New `CacheInterceptor<TEntity, TKey>` (`src/Kista.Manager/Caching/CacheInterceptor.cs`, namespace `Kista.Caching`)

- `internal sealed` builtin interceptor implementing `IEntityManagerInterceptor<TEntity, TKey>`.
- `PreWriteAsync` never short-circuits — the cache is a write-path concern that fires only after a successful write; returns `null` to let the chain proceed.
- `PostWriteAsync(context, result)` re-caches or evicts based on `context.Kind`:
  - `Create`, `Update`, `Restore` → `IEntityCache<T>.SetAsync` (re-cache the written entity)
  - `Remove` when `context.Entity is ISoftDeletable` → `SetAsync` (soft-delete branch, the row still exists)
  - `Remove` otherwise → `RemoveAsync` (hard branch)
  - `HardDelete` → `RemoveAsync` (evict)
  - `default` → no-op (defensive guard for unknown enum values)
- Early-returns when `!result.IsSuccess()` (not-changed or failed results leave the cache untouched, matching the former inline behavior that fired only after a successful repository write).
- Skips the cache interaction when the key generator returns an empty array of keys (the entity cannot be addressed in the cache).
- Failures in `SetAsync` / `RemoveAsync` are logged and swallowed via the existing `LogEntityNotCached` / `LogEntityNotEvicted` logger extensions, so a cache outage never propagates to the caller.
- Constructor null-guards the `cache` and `getEntityKey` dependencies, and defaults a null `logger` to `NullLogger.Instance`.

### Pipeline wiring & inline glue removal (`src/Kista.Manager/EntityManager_T2.cs`)

- New `_cacheInterceptor` field, lazily constructed like `_hooksInterceptor`.
- `GetInterceptors()` now appends the `CacheInterceptor` **after** the `OnHooksEntityInterceptor`, but **only when `EntityCache != null`** — so not registering an `IEntityCache<TEntity>` removes the cache concern entirely (no subclassing needed). Ordering relative to the hooks interceptor is safe: the hooks interceptor is a no-op in `PostWriteAsync`, and `ISoftDeletable` detection is a type marker unaffected by the stamping applied in `OnRemovingEntityAsync`.
- Removed the private `SetToCacheAsync` and `EvictAsync` helpers and their nine inline call sites across `AddAsync`, `AddRangeAsync`, `UpdateAsync`, `RemoveAsync` (soft + hard branches), `RemoveRangeAsync`, `RestoreAsync`, `HardDeleteAsync`, `HardDeleteRangeAsync`.
- `GenerateCacheKeys` / `GenerateCacheKey` are kept as `protected virtual` extension points — they are used by `FindAsync`'s read-through `GetOrSetByKeyAsync` (left inline, out of scope) and exercised by existing tests (`ExposedGenerateCacheKeys`).

### `RemoveRangeAsync` alignment (behavior change)

Before this change, `RemoveRangeAsync` always evicted every entity in the batch, even `ISoftDeletable` ones — inconsistent with `RemoveAsync`, which re-caches soft-deletable entities. The builtin `CacheInterceptor` now handles each entity in the batch per the same `ISoftDeletable` rule as the single `RemoveAsync`, so `RemoveRangeAsync` is **aligned with `RemoveAsync`**: soft-deletable entities in a range Remove are re-cached (refreshed with the soft-delete stamp), while non-soft-deletable entities continue to be evicted. The behavior change is documented in the migration guide.

### No changes to cache contracts or backend packages

- `IEntityCache<TEntity>`, `IEntityCacheKeyGenerator<TEntity>` — untouched.
- `Kista.Manager` (in-process memory cache), `Kista.Manager.EasyCaching`, `Kista.Manager.DistributedCache`, `Kista.Manager.FusionCache` — untouched. They register `IEntityCache<TEntity>`, the interceptor consumes it. All four backend integration suites pass unchanged (52 + 13 + 13 + 21 = 99 tests).

### Tests (`test/Kista.Manager.XUnit/Unit/Operations/CacheInterceptorTests.cs`)

33 tests (traits `Category=Unit`, `Layer=Application`, `Feature=Caching` / `Feature=OperationPipeline`) using NSubstitute + the existing `Person` / `SoftDeletablePerson` / `PersonCacheKeyGenerator` fixtures. The `CacheInterceptor` type stays `internal sealed` (no `InternalsVisibleTo` grant on the `Kista.Manager` package): the 29 manager-level tests exercise it through the public `EntityManager` pipeline, and the 4 defensive-branch tests reach the internal constructor through reflection and the `default` switch arm through a test-only `EntityManager` subclass overriding `CreateOperationContext`.

- **Re-cache / evict per operation kind** — Add, AddRange, Update, Restore, Remove (soft branch → re-cache, hard branch → evict), HardDelete, HardDeleteRange, all asserting the right `IEntityCache` call (`SetAsync` vs `RemoveAsync`) and the entity state.
- **`RemoveRangeAsync` alignment** — soft-deletable entity in a range Remove is re-cached (the alignment fix); non-soft-deletable entity is evicted; mixed batch is split correctly.
- **`NotChanged` / failed / short-circuit skip the cache** — Update / Remove (soft + hard) / Restore / HardDelete returning `NotChanged` with a cache registered; short-circuit via `ShortCircuitInterceptor`; `ValidationFailed` from `AddAsync` and `UpdateAsync` (covers the `!result.IsSuccess()` early-return through every write path).
- **Read-through cache fallback** — `FindAsync` where `GetOrSetAsync` throws, asserting the repository is still consulted and the result is returned; `FindAsync` with no cache registered goes straight to the repository.
- **Ordering** — cache runs after the builtin hooks interceptor (sees the mutated entity after soft-delete stamping).
- **No-cache / no-key-generator** — interceptor is absent from the chain when no `IEntityCache<T>` is registered; empty cache keys skip the interaction.
- **Cache failure resilience** — `SetAsync` and `RemoveAsync` throwing is swallowed, the write still succeeds.
- **Defensive branches (reflection + subclass)** — the `default` switch arm is exercised via `UnknownKindEntityManager` overriding `CreateOperationContext` to force `(EntityOperationKind)999`; the two constructor null-guards (`cache`, `getEntityKey`) and the `NullLogger` fallback are exercised via `ConstructorInfo.Invoke` on the internal `CacheInterceptor<,>` type resolved through reflection, asserting the wrapped `ArgumentNullException` and the expected `ParamName`.

**Coverage:** `CacheInterceptor.cs` reaches **100% line coverage** (53/53 ranges) with no `InternalsVisibleTo` grant — the defensive branches are reached through reflection and subclass injection. `EntityManager_T2.cs` cache paths are fully covered (overall 544/591 ranges, 92.0%); the remaining uncovered lines are pre-existing gaps in exception handlers and the `FindIncludingDeletedAsync` driver fallback, unrelated to the cache work.

### Docs

- `docs/entity-manager/operation-pipeline.md` — new "Builtin `CacheInterceptor`" section: activation rule, per-kind action table, failure resilience, `RemoveRangeAsync` behavior change, read-through note.
- `docs/migrating-from-1.7.2.md` — "Cache alignment to the operation pipeline" section documenting the `RemoveRangeAsync` behavior change and the non-breaking nature for the cache-backend packages.
- `CHANGELOG.md` — Added entry for the builtin `CacheInterceptor`; Changed entry for the `RemoveRangeAsync` alignment.
- `ROADMAP.md` — flips the "Cache Alignment to the Operation Pipeline" status from 🔲 Planned to ✅ Completed.

## Changed files (8, +1100/-43)

- New: `src/Kista.Manager/Caching/CacheInterceptor.cs` (209), `test/Kista.Manager.XUnit/Unit/Operations/CacheInterceptorTests.cs` (730).
- Modified: `src/Kista.Manager/EntityManager_T2.cs` (+26/-41), `docs/entity-manager/operation-pipeline.md` (+33), `docs/migrating-from-1.7.2.md` (+14/-1), `CHANGELOG.md` (+7), `ROADMAP.md` (+1/-1).

## Verification

- `dotnet build` of the full solution: 0 errors.
- `Kista.Manager.XUnit`: 250 tests pass (217 pre-existing + 33 new).
- Cache-backend suites (unchanged): EasyCaching 52, MemoryCache 13, DistributedCache 13, FusionCache 21 — all pass through the new interceptor path.
- EF / Mongo suites fail only on `DockerUnavailableException` (testcontainers), confirmed identical on the unmodified baseline — no regressions from this change.