### PR TITLE
Security & Performance Review — Critical, High, Medium, and Low Findings

### DIFF
--- a/.github/workflows/reusable-pipeline.yml
+++ b/.github/workflows/reusable-pipeline.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore -p:TargetFrameworks=${{ matrix.target-framework }}
 
+      - name: Audit vulnerable packages
+        run: dotnet list package --vulnerable --include-transitive || true
+
       - name: Build
         run: dotnet build --no-restore -c Release -f ${{ matrix.target-framework }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,14 +29,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - No change to `IEntityCache<TEntity>`, `IEntityCacheKeyGenerator<TEntity>`, or any `Kista.Manager.*` cache backend package — only the call site moves from inline helpers to `PostWriteAsync`.
   - See [Builtin `CacheInterceptor`](docs/entity-manager/operation-pipeline.md#builtin-cacheinterceptor).
 - **`Migrating from 1.7.3`** guide — covers the `RemoveRangeAsync` cache-behavior change and the removal of the inline `SetToCacheAsync` / `EvictAsync` helpers. See [Migrating from 1.7.3](docs/migrating-from-1.7.3.md).
+- **`KistaParsingConfig`** (`Kista.DynamicLinq`) — a hardened `ParsingConfig` that blocks the `new` operator (`DisallowNewKeyword = true`) and fully-qualified type casts (`SupportCastingToFullyQualifiedTypeAsString = false`), closing remote-code-execution vectors when Dynamic LINQ expression strings originate from untrusted input. See [Dynamic LINQ Security](docs/filtering/dynamic-linq-security.md).
+
+### Security
+
+- **[Breaking] `AddHttpUserAccessor<TKey>` default chain is now claim-only** (`Kista.Owners`) — the query-string (`?user_id=`) and route (`userId`) fallback strategies have been removed from the default registration to prevent owner-scope impersonation by unauthenticated clients. Consumers who need the old behavior must explicitly opt in via `AddHttpUserAccessor<TKey>(b => b.AddClaim().AddQueryString().AddRoute())`. The query-string and route strategies are client-controlled and must only be enabled behind a trusted gateway.
+- **[Breaking] Write paths verify ownership** (`Kista.Owners`) — `UpdateAsync`, `RemoveAsync`, and `RemoveRangeAsync` on `UserScopedRepositoryDecorator` now fetch the persisted entity and verify that its owner matches the current user before forwarding to the inner repository. An `UnauthorizedAccessException` is thrown on mismatch or when the entity cannot be found. Previously these methods forwarded directly with no owner check (IDOR on writes).
+- **[Breaking] `UserScopingOptions.ThrowWhenUserNotSet` defaults to `true`** (`Kista.Owners`) — the decorator now fails closed by default: when no user identity is resolvable, operations throw `InvalidOperationException` instead of silently returning empty results. The XML doc previously documented `true` as the default while the actual default was `false`; the code now matches the documentation. Set `ThrowWhenUserNotSet = false` to restore the fail-open behavior.
 
 ### Changed
 
 - **`RemoveRangeAsync` cache behavior aligned with `RemoveAsync`**: soft-deletable entities in a range Remove are now re-cached (the cached entry is refreshed with the soft-delete stamp applied) instead of evicted, matching the single `RemoveAsync`; non-soft-deletable entities in a range Remove continue to be evicted.
+- **`FilterExpression` and `DynamicLinqFilter` now use `KistaParsingConfig`** instead of `ParsingConfig.Default` — the `new` operator and fully-qualified type casts in expression strings are blocked. Legitimate filters (property access, comparisons, boolean logic) are unaffected.
 
 ### Fixed
 
-- None.
+- **`UserScopingOptions.ThrowWhenUserNotSet` XML doc corrected** — the documentation claimed the default was `true` while the actual default was `false`; the default is now `true` and the documentation is accurate.
 
 ### Chores
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Deveel.Results" Version="1.2.2" />
 
     <!-- Dynamic LINQ -->
-    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />
+    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.3" />
 
     <!-- MongoDB ecosystem -->
     <PackageVersion Include="MongoFramework" Version="0.29.0" />

--- a/docs/filtering/dynamic-linq-security.md
+++ b/docs/filtering/dynamic-linq-security.md
@@ -1,0 +1,66 @@
+# Dynamic LINQ Security
+
+`Kista.DynamicLinq` bridges string-based filter expressions with the strongly-typed
+LINQ expression-tree API used by repository drivers. When the expression string
+originates from an untrusted source (e.g. an API client), Dynamic LINQ is a potential
+remote-code-execution (RCE) surface.
+
+## Hardened Parsing Configuration
+
+Kista parses every expression string with [`KistaParsingConfig`][kpc], a hardened
+[`ParsingConfig`][pc] that closes the most dangerous vectors:
+
+| Option | Value | Blocks |
+|---|---|---|
+| `DisallowNewKeyword` | `true` | The `new` operator — prevents `new System.Diagnostics.Process()` and similar instantiations of arbitrary types. |
+| `SupportCastingToFullyQualifiedTypeAsString` | `false` | Fully-qualified type casts — prevents `(System.Diagnostics.Process) null`. |
+
+Static method calls to arbitrary types (e.g. `System.IO.File.Exists("x")`) are blocked
+by the default `IDynamicLinqCustomTypeProvider`, which restricts type resolution to the
+`System` namespace enums and a small set of primitives.
+
+## Defense-in-Depth, Not a Sandbox
+
+`KistaParsingConfig` is **defense-in-depth**, not a complete sandbox. It blocks the
+known RCE vectors, but:
+
+- It does not restrict which **properties** of the entity can be referenced — an
+  attacker can still read any public property of `TEntity` in the filter.
+- It does not restrict **operators** — an attacker can craft computationally expensive
+  expressions (e.g. deeply nested boolean trees) to consume CPU.
+- Future versions of `System.Linq.Dynamic.Core` may introduce new vectors that
+  `KistaParsingConfig` does not cover.
+
+## Application-Level Allow-List
+
+If your expression strings come from untrusted input, you **must** additionally apply
+an application-level allow-list before constructing a `DynamicLinqFilter`:
+
+1. **Restrict fields** — parse the expression with your own grammar and reject any
+   field name that is not in an explicit allow-list for the entity type.
+2. **Restrict operators** — reject expressions that contain operators outside the
+   permitted set (`==`, `!=`, `>`, `<`, `>=`, `<=`, `&&`, `||`, `Contains`, `StartsWith`).
+3. **Bound length** — reject expressions longer than a reasonable limit (e.g. 1024
+   characters) to prevent CPU-exhaustion attacks.
+4. **Never** pass raw client input as the expression string without validation.
+
+## Example: Safe Usage
+
+```csharp
+// GOOD: expression string is built by the application from validated parameters
+var filter = new DynamicLinqFilter($"x.Status == \"{status}\"");
+
+// GOOD: expression string comes from a trusted configuration source
+var filter = new DynamicLinqFilter(config.FilterExpression);
+
+// BAD: expression string comes directly from an API client without validation
+var filter = new DynamicLinqFilter(request.Body.FilterExpression); // RCE/DoS risk
+```
+
+## See Also
+
+- [Filter Expressions](filter-cache.md)
+- [System.Linq.Dynamic.Core Security](https://github.com/zzzprojects/System.Linq.Dynamic.Core)
+
+[kpc]: ../../api/Kista.DynamicLinq.KistaParsingConfig.yml
+[pc]: https://github.com/zzzprojects/System.Linq.Dynamic.Core

--- a/docs/user-entities/user-identifier-resolution.md
+++ b/docs/user-entities/user-identifier-resolution.md
@@ -32,13 +32,26 @@ builder.Services.AddUserAccessor<string>(b => {
 });
 ```
 
-**HTTP application with fallback chain:**
+**HTTP application (secure default — claim only):**
+
+```csharp
+builder.Services.AddHttpUserAccessor<string>();
+// Resolves exclusively from the "sub" claim of the authenticated ClaimsPrincipal.
+// Unauthenticated requests yield no user identity (fail-closed).
+```
+
+**HTTP application with explicit fallback chain (opt-in, advanced):**
+
+> **Security warning:** The query-string and route fallbacks are <b>client-controlled</b>.
+> Enabling them allows any caller to impersonate another user by appending
+> <c>?user_id=&lt;victim&gt;</c> or crafting a route. Only enable these strategies behind a
+> trusted gateway or an authorization layer that validates the resolved identity.
 
 ```csharp
 builder.Services.AddHttpUserAccessor<string>(b => {
     b.AddClaim("sub");              // Try JWT "sub" claim first
-    b.AddQueryString("user_id");    // Fallback to query string
-    b.AddRoute("userId");           // Fallback to route value
+    b.AddQueryString("user_id");    // Fallback to query string (UNSAFE without gateway)
+    b.AddRoute("userId");           // Fallback to route value   (UNSAFE without gateway)
 });
 ```
 

--- a/src/Kista.DynamicLinq/BoundedCache.cs
+++ b/src/Kista.DynamicLinq/BoundedCache.cs
@@ -19,7 +19,7 @@ namespace Kista {
 	/// </summary>
 	/// <typeparam name="TValue">The type of value stored in the cache.</typeparam>
 	public abstract class BoundedCache<TValue> {
-		private readonly SemaphoreSlim _semaphore = new(1, 1);
+		private readonly ReaderWriterLockSlim _lock = new();
 		private readonly Dictionary<string, LinkedListNode<CacheEntry>> _map;
 		private readonly LinkedList<CacheEntry> _order;
 		private readonly int _maxCapacity;
@@ -96,11 +96,17 @@ namespace Kista {
 		protected bool TryGetCore(string key, out TValue? value) {
 			ArgumentNullException.ThrowIfNull(key);
 
-			_semaphore.Wait();
+			_lock.EnterUpgradeableReadLock();
 			try {
 				if (_map.TryGetValue(key, out var node)) {
-					_order.Remove(node);
-					_order.AddFirst(node);
+					// Promote to MRU — requires write lock.
+					_lock.EnterWriteLock();
+					try {
+						_order.Remove(node);
+						_order.AddFirst(node);
+					} finally {
+						_lock.ExitWriteLock();
+					}
 					Interlocked.Increment(ref _hits);
 					value = node.Value.Value;
 					return true;
@@ -110,7 +116,7 @@ namespace Kista {
 				value = default;
 				return false;
 			} finally {
-				_semaphore.Release();
+				_lock.ExitUpgradeableReadLock();
 			}
 		}
 
@@ -125,11 +131,19 @@ namespace Kista {
 			ArgumentNullException.ThrowIfNull(key);
 			ArgumentNullException.ThrowIfNull(value);
 
-			_semaphore.Wait();
+			_lock.EnterWriteLock();
 			try {
 				if (_map.TryGetValue(key, out var existingNode)) {
+					// Update-in-place: reuse the existing node to avoid allocating
+					// a new CacheEntry + LinkedListNode on every cache update.
 					_order.Remove(existingNode);
-				} else if (_map.Count >= _maxCapacity) {
+					existingNode.Value = existingNode.Value with { Value = value };
+					_order.AddFirst(existingNode);
+					_map[key] = existingNode;
+					return;
+				}
+
+				if (_map.Count >= _maxCapacity) {
 					var lruNode = _order.Last;
 					if (lruNode != null) {
 						_order.RemoveLast();
@@ -141,7 +155,7 @@ namespace Kista {
 				var newNode = _order.AddFirst(entry);
 				_map[key] = newNode;
 			} finally {
-				_semaphore.Release();
+				_lock.ExitWriteLock();
 			}
 		}
 
@@ -149,12 +163,12 @@ namespace Kista {
 		/// Removes all entries from the cache. Does not reset the <see cref="Statistics"/> counters.
 		/// </summary>
 		public void Clear() {
-			_semaphore.Wait();
+			_lock.EnterWriteLock();
 			try {
 				_map.Clear();
 				_order.Clear();
 			} finally {
-				_semaphore.Release();
+				_lock.ExitWriteLock();
 			}
 		}
 	}

--- a/src/Kista.DynamicLinq/DynamicLinqFilter.cs
+++ b/src/Kista.DynamicLinq/DynamicLinqFilter.cs
@@ -31,6 +31,15 @@ namespace Kista {
 	/// For example: <c>"x.FirstName == \"John\" &amp;&amp; x.Age > 18"</c>.
 	/// </para>
 	/// <para>
+	/// <b>Security.</b> Kista parses expression strings with a hardened
+	/// <see cref="KistaParsingConfig"/> that blocks the <c>new</c> operator and
+	/// fully-qualified type casts. This is defense-in-depth, not a complete sandbox:
+	/// if the expression string originates from untrusted input (e.g. an API client),
+	/// you must additionally apply an application-level allow-list of permitted fields
+	/// and operators before constructing a <see cref="DynamicLinqFilter"/>. Never pass
+	/// raw client input as the expression string without validation.
+	/// </para>
+	/// <para>
 	/// When an <see cref="IExpressionCache"/> is provided via the constructor, the
 	/// <see cref="AsLambda{TEntity}"/> method will cache parsed expressions to avoid
 	/// re-parsing the same expression string on subsequent calls. This is particularly

--- a/src/Kista.DynamicLinq/FilterExpression.cs
+++ b/src/Kista.DynamicLinq/FilterExpression.cs
@@ -64,7 +64,7 @@ namespace Kista {
 		public static Expression<Func<T, bool>> AsLambda<T>(string paramName, string expression) {
 			try {
 				var paramExp = new[] { Expression.Parameter(typeof(T), paramName) };
-				var exp = DynamicExpressionParser.ParseLambda(ParsingConfig.Default, paramExp, typeof(bool), expression);
+				var exp = DynamicExpressionParser.ParseLambda(KistaParsingConfig.Instance, paramExp, typeof(bool), expression);
 
 				if (exp.ReturnType != typeof(bool))
 					throw new InvalidOperationException("The resulting expression is not a filter");
@@ -214,7 +214,7 @@ namespace Kista {
 					parameters[i] = Expression.Parameter(paramType, paramName);
 				}
 
-				var exp = DynamicExpressionParser.ParseLambda(ParsingConfig.Default, parameters, typeof(bool), expression);
+				var exp = DynamicExpressionParser.ParseLambda(KistaParsingConfig.Instance, parameters, typeof(bool), expression);
 
 				if (exp.ReturnType != typeof(bool))
 					throw new InvalidOperationException("The resulting expression is not a filter");

--- a/src/Kista.DynamicLinq/KistaParsingConfig.cs
+++ b/src/Kista.DynamicLinq/KistaParsingConfig.cs
@@ -1,0 +1,75 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq.Dynamic.Core;
+
+namespace Kista {
+	/// <summary>
+	/// A hardened <see cref="ParsingConfig"/> used by Kista when parsing Dynamic LINQ
+	/// expression strings, designed to reduce the risk of remote code execution when
+	/// expression strings originate from untrusted input (e.g. API clients).
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// <b>Security note.</b> The default <see cref="ParsingConfig.Default"/> permits the
+	/// <c>new</c> operator and fully-qualified type casts, which allows an attacker who
+	/// controls the expression string to instantiate arbitrary types
+	/// (e.g. <c>new System.Diagnostics.Process()</c>) or cast to them, leading to remote
+	/// code execution. <see cref="KistaParsingConfig"/> closes these vectors by:
+	/// </para>
+	/// <list type="bullet">
+	///   <item><c>DisallowNewKeyword = true</c> — blocks the <c>new</c> operator entirely.</item>
+	///   <item><c>SupportCastingToFullyQualifiedTypeAsString = false</c> — blocks fully-qualified type casts.</item>
+	/// </list>
+	/// <para>
+	/// Static method calls to arbitrary types (e.g. <c>System.IO.File.Exists(...)</c>) are
+	/// blocked by the default <c>IDynamicLinqCustomTypeProvider</c>, which restricts type
+	/// resolution to the <c>System</c> namespace enums and a small set of primitives.
+	/// </para>
+	/// <para>
+	/// <b>This is defense-in-depth, not a complete sandbox.</b> If your expression strings
+	/// come from untrusted input, you must additionally apply an application-level allow-list
+	/// of permitted fields and operators before passing the string to
+	/// <see cref="FilterExpression"/> or <see cref="DynamicLinqFilter"/>. Never accept raw
+	/// expression strings from clients without validation.
+	/// </para>
+	/// </remarks>
+	public static class KistaParsingConfig {
+		private static readonly ParsingConfig _instance = CreateHardenedConfig();
+
+		/// <summary>
+		/// Gets the shared hardened <see cref="ParsingConfig"/> instance used by Kista.
+		/// </summary>
+		/// <value>
+		/// A <see cref="ParsingConfig"/> with <see cref="ParsingConfig.DisallowNewKeyword"/>
+		/// set to <c>true</c> and <see cref="ParsingConfig.SupportCastingToFullyQualifiedTypeAsString"/>
+		/// set to <c>false</c>.
+		/// </value>
+		public static ParsingConfig Instance => _instance;
+
+		private static ParsingConfig CreateHardenedConfig() {
+			var config = new ParsingConfig {
+				// Block the `new` operator — prevents instantiation of arbitrary types
+				// (e.g. `new System.Diagnostics.Process()`).
+				DisallowNewKeyword = true,
+
+				// Block fully-qualified type casts — prevents casting to arbitrary types
+				// by their fully-qualified string name.
+				SupportCastingToFullyQualifiedTypeAsString = false,
+			};
+
+			return config;
+		}
+	}
+}

--- a/src/Kista.EntityFramework/EfQueryNormalizer.cs
+++ b/src/Kista.EntityFramework/EfQueryNormalizer.cs
@@ -55,27 +55,25 @@ namespace Kista {
 			public static StartsWithToLikeVisitor Instance { get; } = new StartsWithToLikeVisitor();
 
 			protected override Expression VisitMethodCall(MethodCallExpression node) {
-				if (node.Method.Name == nameof(string.StartsWith)
-					&& node.Object?.Type == typeof(string)
-					&& node.Arguments.Count == 1
-					&& node.Arguments[0].Type == typeof(string)) {
-					var instance = Visit(node.Object)
-						?? throw new InvalidOperationException("StartsWith instance cannot be null.");
-					var value = Visit(node.Arguments[0])
-						?? throw new InvalidOperationException("StartsWith argument cannot be null.");
+			if (node.Method.Name == nameof(string.StartsWith)
+				&& node.Object?.Type == typeof(string)
+				&& node.Arguments.Count == 1
+				&& node.Arguments[0].Type == typeof(string)) {
+				var instance = Visit(node.Object)
+					?? throw new InvalidOperationException("StartsWith instance cannot be null.");
+				var value = Visit(node.Arguments[0])
+					?? throw new InvalidOperationException("StartsWith argument cannot be null.");
 
-					var pattern = Expression.Call(StringConcatMethod, value, Expression.Constant("%"));
-					var functions = Expression.Property(null, FunctionsProperty);
-					var like = Expression.Call(LikeMethod, functions, instance, pattern);
-
-					var instanceNotNull = Expression.NotEqual(instance, Expression.Constant(null, typeof(string)));
-					var valueNotNull = Expression.NotEqual(value, Expression.Constant(null, typeof(string)));
-
-					return Expression.AndAlso(instanceNotNull, Expression.AndAlso(valueNotNull, like));
-				}
-
-				return base.VisitMethodCall(node);
+				var pattern = Expression.Call(StringConcatMethod, value, Expression.Constant("%"));
+				var functions = Expression.Property(null, FunctionsProperty);
+				// Emit bare LIKE — SQL LIKE is NULL-safe (NULL LIKE x yields NULL / false),
+				// so the explicit null-checks are redundant and can prevent the provider
+				// from using the index on the LIKE prefix.
+				return Expression.Call(LikeMethod, functions, instance, pattern);
 			}
+
+			return base.VisitMethodCall(node);
+		}
 		}
 	}
 }

--- a/src/Kista.EntityFramework/EntityRepository_T2.cs
+++ b/src/Kista.EntityFramework/EntityRepository_T2.cs
@@ -624,9 +624,9 @@ namespace Kista
 			// instead of calling Local.FirstOrDefault (O(N)) per entity → O(N²).
 			var trackedByKey = new Dictionary<TKey, TEntity>();
 			foreach (var local in Entities.Local) {
-				var localKey = GetEntityKey(local);
-				if (localKey != null && !EqualityComparer<TKey>.Default.Equals(localKey, default))
-					trackedByKey[localKey] = local;
+			var localKey = GetEntityKey(local);
+			if (!KeyHelper.IsNull(localKey) && !EqualityComparer<TKey>.Default.Equals(localKey, default))
+				trackedByKey[localKey] = local;
 			}
 
 			foreach (var item in entities) {
@@ -879,7 +879,7 @@ namespace Kista
 			if (trackedByKey != null) {
 				trackedByKey.TryGetValue(entityId, out tracked);
 			} else {
-				tracked = Entities.Local.FirstOrDefault(x => EqualityComparer<TKey>.Default.Equals(GetEntityKey(x)!, entityId));
+				tracked = Entities.Local.FirstOrDefault(x => EqualityComparer<TKey>.Default.Equals(GetEntityKey(x), entityId));
 			}
 			if (tracked != null)
 				return Context.Entry(tracked);
@@ -930,7 +930,7 @@ namespace Kista
 					if (items.Count < request.Size) {
 						totalCount = request.Offset + items.Count;
 					} else {
-						totalCount = (int) await querySet.CountAsync(cancellationToken);
+						totalCount = await querySet.CountAsync(cancellationToken);
 					}
 
 					return new PageQueryResult<TEntity>(pageQuery, totalCount, items);
@@ -949,7 +949,7 @@ namespace Kista
 				if (allItems.Count < request.Size) {
 					allTotalCount = request.Offset + allItems.Count;
 				} else {
-					allTotalCount = (int) await allQuerySet.CountAsync(cancellationToken);
+					allTotalCount = await allQuerySet.CountAsync(cancellationToken);
 				}
 
 				return new PageResult<TEntity>(request, allTotalCount, allItems);

--- a/src/Kista.EntityFramework/EntityRepository_T2.cs
+++ b/src/Kista.EntityFramework/EntityRepository_T2.cs
@@ -115,6 +115,20 @@ namespace Kista
 		/// Returns the <see cref="IQueryable{T}"/> produced by
 		/// <see cref="Entities"/>.AsQueryable().
 		/// </returns>
+		/// <remarks>
+		/// <para>
+		/// <b>Include / AsSplitQuery guardrail.</b> When a subclass overrides
+		/// this method or the query to add <c>Include</c> / <c>ThenInclude</c>
+		/// for multi-navigation entities, EF Core produces a cartesian product
+		/// that can cause severe performance degradation. Always chain
+		/// <c>.AsSplitQuery()</c> after any <c>Include</c> call to avoid the
+		/// cartesian explosion:
+		/// <code>
+		/// protected override IQueryable&lt;TEntity&gt; Queryable() =>
+		///     Entities.Include(e => e.Related).AsSplitQuery();
+		/// </code>
+		/// </para>
+		/// </remarks>
 		protected override IQueryable<TEntity> Queryable() => Entities.AsQueryable();
 
 		/// <summary>
@@ -142,6 +156,15 @@ namespace Kista
 		/// applied here; <see cref="SoftDeleteMode.IncludeDeleted"/> and
 		/// <see cref="SoftDeleteMode.OnlyDeleted"/> call
 		/// <c>IgnoreQueryFilters()</c> to surface soft-deleted records.
+		/// </para>
+		/// <para>
+		/// <b>Multi-tenant warning.</b> When using <c>Kista.EntityFramework.MultiTenant</c>
+		/// with a shared tenant database, Finbuckle.MultiTenant applies tenant
+		/// isolation via a global query filter. Calling <c>IgnoreQueryFilters()</c>
+		/// (as <c>IncludeDeleted</c> and <c>OnlyDeleted</c> do) also removes the
+		/// tenant filter, potentially exposing cross-tenant data. Ensure that any
+		/// query using these modes includes an explicit tenant-scoped predicate
+		/// when operating in a shared-database multi-tenant configuration.
 		/// </para>
 		/// </remarks>
 		protected override IQueryable<TEntity> ApplySoftDeleteMode(IQueryable<TEntity> queryable, IQueryOptions? options) {
@@ -802,26 +825,26 @@ namespace Kista
 			}
 		}
 
-		/// <inheritdoc/>
+	/// <inheritdoc/>
 		public virtual async ValueTask<TEntity?> FindOriginalAsync(TKey key, CancellationToken cancellationToken = default) {
-			ThrowIfDisposed();
+		ThrowIfDisposed();
 
-			try {
-				var result = await Entities.FindAsync(new object?[] { ConvertEntityKey(key) }, cancellationToken);
-				if (result == null)
-					return result;
+		try {
+			var result = await Entities.FindAsync(new object?[] { ConvertEntityKey(key) }, cancellationToken);
+			if (result == null)
+				return result;
 
-				var entry = Context.Entry(result);
-				
-				// find a way to get the original values
-				//      of related entities...
+			var entry = Context.Entry(result);
+			
+			// find a way to get the original values
+			//      of related entities...
 
-				return (TEntity) entry.OriginalValues.ToObject();
-			} catch (Exception ex) {
-				Logger.LogUnknownError(ex, typeof(TEntity));
-				throw new RepositoryException("Unable to find an entity int he repository because of an error", ex);
-			}
+			return (TEntity) entry.OriginalValues.ToObject();
+		} catch (Exception ex) {
+			Logger.LogUnknownError(ex, typeof(TEntity));
+			throw new RepositoryException("Unable to find an entity int he repository because of an error", ex);
 		}
+	}
 
 		/// <inheritdoc/>
 		protected override async ValueTask<IReadOnlyList<TEntity>> FindAllAsync(IQuery query, CancellationToken cancellationToken = default) {

--- a/src/Kista.EntityFramework/EntityRepository_T2.cs
+++ b/src/Kista.EntityFramework/EntityRepository_T2.cs
@@ -152,6 +152,19 @@ namespace Kista
 			};
 		}
 
+		/// <summary>
+		/// Determines whether the query should return tracked entities based
+		/// on the <see cref="IQueryOptions.TrackEntities"/> flag.
+		/// </summary>
+		/// <param name="options">The query options, or <c>null</c> for defaults.</param>
+		/// <returns>
+		/// <c>true</c> if entities should be tracked; <c>false</c> (default)
+		/// for <c>AsNoTracking</c> read paths.
+		/// </returns>
+		private static bool ShouldTrackEntities(IQueryOptions? options) {
+			return options?.TrackEntities == true;
+		}
+
 		/// <inheritdoc />
 		protected override bool IsQueryable => true;
 
@@ -513,6 +526,15 @@ namespace Kista
 			try {
 				var now = ResolveSystemTime().UtcNow;
 
+				// Build an O(1) lookup from the change tracker's Local entries once,
+				// instead of calling Local.FirstOrDefault (O(N)) per entity → O(N²).
+				var trackedByKey = new Dictionary<TKey, TEntity>();
+				foreach (var local in Entities.Local) {
+					var localKey = GetEntityKey(local);
+					if (localKey != null && !EqualityComparer<TKey>.Default.Equals(localKey, default))
+						trackedByKey[localKey] = local;
+				}
+
 				foreach (var item in entities) {
 					var entityId = GetEntityKey(item);
 					if (EqualityComparer<TKey>.Default.Equals(entityId, default))
@@ -520,7 +542,7 @@ namespace Kista
 
 					var entry = Context.Entry(item);
 					if (entry.State == EntityState.Detached) {
-						entry = ResolveEntryForEntityKey(item, entityId);
+						entry = ResolveEntryForEntityKey(item, entityId, trackedByKey);
 					}
 
 					if (item is ISoftDeletable softDeletable) {
@@ -548,6 +570,15 @@ namespace Kista
 			ThrowIfDisposed();
 
 			try {
+				// Build an O(1) lookup from the change tracker's Local entries once,
+				// instead of calling Local.FirstOrDefault (O(N)) per entity → O(N²).
+				var trackedByKey = new Dictionary<TKey, TEntity>();
+				foreach (var local in Entities.Local) {
+					var localKey = GetEntityKey(local);
+					if (localKey != null && !EqualityComparer<TKey>.Default.Equals(localKey, default))
+						trackedByKey[localKey] = local;
+				}
+
 				foreach (var item in entities) {
 					var entityId = GetEntityKey(item);
 					if (EqualityComparer<TKey>.Default.Equals(entityId, default))
@@ -555,7 +586,7 @@ namespace Kista
 
 					var entry = Context.Entry(item);
 					if (entry.State == EntityState.Detached) {
-						entry = ResolveEntryForEntityKey(item, entityId);
+						entry = ResolveEntryForEntityKey(item, entityId, trackedByKey);
 					}
 
 					entry.State = EntityState.Deleted;
@@ -716,6 +747,8 @@ namespace Kista
 			try {
 				InitializeFilter(query.Filter);
 				var queryable = ApplySoftDeleteMode(Queryable(), query.Options);
+				if (!ShouldTrackEntities(query.Options))
+					queryable = queryable.AsNoTracking();
 				var result = EfQueryNormalizer.Normalize(query.Apply(queryable));
 
 				return await result.FirstOrDefaultAsync(cancellationToken);
@@ -772,6 +805,8 @@ namespace Kista
 			try {
 				InitializeFilter(query.Filter);
 				var queryable = ApplySoftDeleteMode(Queryable(), query.Options);
+				if (!ShouldTrackEntities(query.Options))
+					queryable = queryable.AsNoTracking();
 				var result = EfQueryNormalizer.Normalize(query.Apply(queryable));
 				return await result.ToListAsync(cancellationToken);
 			} catch (Exception ex) {
@@ -787,8 +822,13 @@ namespace Kista
 			return EfQueryNormalizer.Normalize(filter.Apply(query));
 		}
 
-		private EntityEntry<TEntity> ResolveEntryForEntityKey(TEntity entity, TKey entityId) {
-			var tracked = Entities.Local.FirstOrDefault(x => EqualityComparer<TKey>.Default.Equals(GetEntityKey(x)!, entityId));
+		private EntityEntry<TEntity> ResolveEntryForEntityKey(TEntity entity, TKey entityId, Dictionary<TKey, TEntity>? trackedByKey = null) {
+			TEntity? tracked = null;
+			if (trackedByKey != null) {
+				trackedByKey.TryGetValue(entityId, out tracked);
+			} else {
+				tracked = Entities.Local.FirstOrDefault(x => EqualityComparer<TKey>.Default.Equals(GetEntityKey(x)!, entityId));
+			}
 			if (tracked != null)
 				return Context.Entry(tracked);
 
@@ -823,25 +863,42 @@ namespace Kista
 			try {
 				if (request is PageQuery<TEntity> pageQuery) {
 					var queryable = ApplySoftDeleteMode(Queryable(), pageQuery.Options);
+					if (!ShouldTrackEntities(pageQuery.Options))
+						queryable = queryable.AsNoTracking();
 					var querySet = EfQueryNormalizer.Normalize(pageQuery.ApplyQuery(queryable));
-					var totalCount = await querySet.CountAsync(cancellationToken);
 
 					var items = await querySet
 						.Skip(request.Offset)
 						.Take(request.Size)
 						.ToListAsync(cancellationToken);
 
+					// Skip the CountAsync round-trip for partial pages: if the page
+					// is not full, the total count is implied (offset + items.Count).
+					int totalCount;
+					if (items.Count < request.Size) {
+						totalCount = request.Offset + items.Count;
+					} else {
+						totalCount = (int) await querySet.CountAsync(cancellationToken);
+					}
+
 					return new PageQueryResult<TEntity>(pageQuery, totalCount, items);
 				}
 
 				var allQueryable = ApplySoftDeleteMode(Queryable(), null);
+				allQueryable = allQueryable.AsNoTracking();
 				var allQuerySet = EfQueryNormalizer.Normalize(allQueryable);
-				var allTotalCount = await allQuerySet.CountAsync(cancellationToken);
 
 				var allItems = await allQuerySet
 					.Skip(request.Offset)
 					.Take(request.Size)
 					.ToListAsync(cancellationToken);
+
+				int allTotalCount;
+				if (allItems.Count < request.Size) {
+					allTotalCount = request.Offset + allItems.Count;
+				} else {
+					allTotalCount = (int) await allQuerySet.CountAsync(cancellationToken);
+				}
 
 				return new PageResult<TEntity>(request, allTotalCount, allItems);
 			} catch (Exception ex) {

--- a/src/Kista.EntityFramework/EntityRepository_T2.cs
+++ b/src/Kista.EntityFramework/EntityRepository_T2.cs
@@ -65,6 +65,7 @@ namespace Kista
 				throw new NotSupportedException("The repository does not support entities with composite primary keys");
 
 			PrimaryKey = entityKey;
+			_primaryKeyGetter = PrimaryKey.Properties[0].GetGetter().GetClrValue;
 		}
 
 		/// <summary>
@@ -82,15 +83,22 @@ namespace Kista
 		/// <inheritdoc />
 		protected override IServiceProvider? Services { get; }
 
-		/// <summary>
-		/// Gets a reference to the primary key of the entity.
-		/// </summary>
-		protected IKey PrimaryKey { get; }
+	/// <summary>
+	/// Gets a reference to the primary key of the entity.
+	/// </summary>
+	protected IKey PrimaryKey { get; }
 
-		/// <summary>
-		/// Gets the logger used by the repository.
-		/// </summary>
-		protected ILogger Logger { get; }
+	/// <summary>
+	/// Cached getter for the single primary-key property, avoiding
+	/// <c>PrimaryKey.Properties.ToList()</c> allocation on every
+	/// <see cref="GetEntityKey"/> call.
+	/// </summary>
+	private readonly Func<TEntity, object?> _primaryKeyGetter;
+
+	/// <summary>
+	/// Gets the logger used by the repository.
+	/// </summary>
+	protected ILogger Logger { get; }
 
 		/// <summary>
 		/// Gets the <see cref="DbSet{TEntity}"/> used by the repository to access the data.
@@ -284,15 +292,10 @@ namespace Kista
 
 		/// <inheritdoc/>
 		protected override TKey? GetEntityKey(TEntity entity) {
-			ArgumentNullException.ThrowIfNull(entity);
+		ArgumentNullException.ThrowIfNull(entity);
 
-			var props = PrimaryKey.Properties.ToList();
-			if (props.Count > 1)
-				throw new RepositoryException($"The entity '{typeof(TEntity)}' has more than one property has primary key");
-
-			var getter = props[0].GetGetter();
-			return (TKey?) getter.GetClrValue(entity);
-		}
+		return (TKey?) _primaryKeyGetter(entity);
+	}
 
 		/// <summary>
 		/// A method that is invoked when an entity is 
@@ -337,19 +340,39 @@ namespace Kista
 
 		/// <inheritdoc/>
 		public override async ValueTask AddRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
-			ThrowIfDisposed();
+		ThrowIfDisposed();
 
-			try {
-				var toAdd = entities.Select(OnAddingEntity).ToList();
+		try {
+			// Apply OnAddingEntity lazily without force-materializing into an
+			// intermediate List when the projection is the identity (the default).
+			var toAdd = OnAddingEntityIsIdentity
+				? entities
+				: entities.Select(OnAddingEntity);
 
-				await Entities.AddRangeAsync(toAdd, cancellationToken);
+			await Entities.AddRangeAsync(toAdd, cancellationToken);
 
-				await Context.SaveChangesAsync(true, cancellationToken);
-			} catch (Exception ex) {
-				Logger.LogUnknownError(ex, typeof(TEntity));
-				throw new RepositoryException("Unknown error while trying to add a range of entities to the repository", ex);
-			}
+			await Context.SaveChangesAsync(true, cancellationToken);
+		} catch (Exception ex) {
+			Logger.LogUnknownError(ex, typeof(TEntity));
+			throw new RepositoryException("Unknown error while trying to add a range of entities to the repository", ex);
 		}
+	}
+
+	/// <summary>
+	/// Gets a value indicating whether <see cref="OnAddingEntity"/> is the
+	/// identity function (default), allowing <see cref="AddRangeAsync"/> to
+	// skip the intermediate <c>.Select(...).ToList()</c> materialization.
+	/// </summary>
+	private static bool OnAddingEntityIsIdentity {
+		get {
+			var method = typeof(EntityRepository<TEntity, TKey>)
+				.GetMethod(nameof(OnAddingEntity), System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public)
+				?.GetBaseDefinition();
+
+			// The base implementation is declared on EntityRepository itself.
+			return method?.DeclaringType == typeof(EntityRepository<TEntity, TKey>);
+		}
+	}
 
 		/// <inheritdoc/>
 		public override async ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {

--- a/src/Kista.EntityFramework/EntityRepository_T2.cs
+++ b/src/Kista.EntityFramework/EntityRepository_T2.cs
@@ -570,39 +570,7 @@ namespace Kista
 		/// </param>
 		protected virtual async ValueTask SoftDeleteRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken) {
 			try {
-				var now = ResolveSystemTime().UtcNow;
-
-				// Build an O(1) lookup from the change tracker's Local entries once,
-				// instead of calling Local.FirstOrDefault (O(N)) per entity → O(N²).
-				var trackedByKey = new Dictionary<TKey, TEntity>();
-				foreach (var local in Entities.Local) {
-					var localKey = GetEntityKey(local);
-					if (localKey != null && !EqualityComparer<TKey>.Default.Equals(localKey, default))
-						trackedByKey[localKey] = local;
-				}
-
-				foreach (var item in entities) {
-					var entityId = GetEntityKey(item);
-					if (EqualityComparer<TKey>.Default.Equals(entityId, default))
-						throw new RepositoryException("One of the entities has no primary key configured");
-
-					var entry = Context.Entry(item);
-					if (entry.State == EntityState.Detached) {
-						entry = ResolveEntryForEntityKey(item, entityId, trackedByKey);
-					}
-
-					if (item is ISoftDeletable softDeletable) {
-						softDeletable.IsDeleted = true;
-						softDeletable.DeletedAtUtc = now;
-					}
-
-					if (!ReferenceEquals(entry.Entity, item))
-						entry.CurrentValues.SetValues(item);
-
-					entry.State = EntityState.Modified;
-				}
-
-				await Context.SaveChangesAsync(true, cancellationToken);
+				await ApplyRangeStateAsync(entities, EntityState.Modified, stampSoftDelete: true, cancellationToken);
 			} catch (DbUpdateConcurrencyException ex) {
 				throw new RepositoryException("One or more entities were not found in the repository", ex);
 			} catch (DbUpdateException ex) {
@@ -616,35 +584,73 @@ namespace Kista
 			ThrowIfDisposed();
 
 			try {
-				// Build an O(1) lookup from the change tracker's Local entries once,
-				// instead of calling Local.FirstOrDefault (O(N)) per entity → O(N²).
-				var trackedByKey = new Dictionary<TKey, TEntity>();
-				foreach (var local in Entities.Local) {
-					var localKey = GetEntityKey(local);
-					if (localKey != null && !EqualityComparer<TKey>.Default.Equals(localKey, default))
-						trackedByKey[localKey] = local;
-				}
-
-				foreach (var item in entities) {
-					var entityId = GetEntityKey(item);
-					if (EqualityComparer<TKey>.Default.Equals(entityId, default))
-						throw new RepositoryException("One of the entities has no primary key configured");
-
-					var entry = Context.Entry(item);
-					if (entry.State == EntityState.Detached) {
-						entry = ResolveEntryForEntityKey(item, entityId, trackedByKey);
-					}
-
-					entry.State = EntityState.Deleted;
-				}
-
-				await Context.SaveChangesAsync(true, cancellationToken);
+				await ApplyRangeStateAsync(entities, EntityState.Deleted, stampSoftDelete: false, cancellationToken);
 			} catch (DbUpdateConcurrencyException ex) {
 				throw new RepositoryException("One or more entities were not found in the repository", ex);
 			} catch (Exception ex) {
 				Logger.LogUnknownError(ex, typeof(TEntity));
 				throw new RepositoryException("Unknown error while trying to remove a range of entities from the repository", ex);
 			}
+		}
+
+		/// <summary>
+		/// Shared core of <see cref="SoftDeleteRangeAsync"/> and
+		/// <see cref="HardDeleteRangeAsync"/>: builds an O(1) lookup from the
+		/// change tracker's local entries, resolves a tracked entry for each
+		/// entity (attaching by key when detached), optionally stamps
+		/// <see cref="ISoftDeletable"/> fields, assigns the target
+		/// <paramref name="state"/> to every entry, and persists the batch.
+		/// </summary>
+		/// <param name="entities">The entities to delete (soft or hard).</param>
+		/// <param name="state">
+		/// The target <see cref="EntityState"/> —
+		/// <see cref="EntityState.Modified"/> for soft-delete,
+		/// <see cref="EntityState.Deleted"/> for hard-delete.
+		/// </param>
+		/// <param name="stampSoftDelete">
+		/// When <c>true</c>, sets <see cref="ISoftDeletable.IsDeleted"/> and
+		/// <see cref="ISoftDeletable.DeletedAtUtc"/> on each soft-deletable entity.
+		/// </param>
+		/// <param name="cancellationToken">A token to cancel the operation.</param>
+		private async ValueTask ApplyRangeStateAsync(
+			IEnumerable<TEntity> entities,
+			EntityState state,
+			bool stampSoftDelete,
+			CancellationToken cancellationToken) {
+
+			var now = stampSoftDelete ? ResolveSystemTime().UtcNow : DateTimeOffset.MinValue;
+
+			// Build an O(1) lookup from the change tracker's Local entries once,
+			// instead of calling Local.FirstOrDefault (O(N)) per entity → O(N²).
+			var trackedByKey = new Dictionary<TKey, TEntity>();
+			foreach (var local in Entities.Local) {
+				var localKey = GetEntityKey(local);
+				if (localKey != null && !EqualityComparer<TKey>.Default.Equals(localKey, default))
+					trackedByKey[localKey] = local;
+			}
+
+			foreach (var item in entities) {
+				var entityId = GetEntityKey(item);
+				if (EqualityComparer<TKey>.Default.Equals(entityId, default))
+					throw new RepositoryException("One of the entities has no primary key configured");
+
+				var entry = Context.Entry(item);
+				if (entry.State == EntityState.Detached) {
+					entry = ResolveEntryForEntityKey(item, entityId, trackedByKey);
+				}
+
+				if (stampSoftDelete && item is ISoftDeletable softDeletable) {
+					softDeletable.IsDeleted = true;
+					softDeletable.DeletedAtUtc = now;
+				}
+
+				if (!ReferenceEquals(entry.Entity, item))
+					entry.CurrentValues.SetValues(item);
+
+				entry.State = state;
+			}
+
+			await Context.SaveChangesAsync(true, cancellationToken);
 		}
 
 		/// <summary>

--- a/src/Kista.EntityFramework/EntityRepository_T2.cs
+++ b/src/Kista.EntityFramework/EntityRepository_T2.cs
@@ -924,14 +924,11 @@ namespace Kista
 						.Take(request.Size)
 						.ToListAsync(cancellationToken);
 
-					// Skip the CountAsync round-trip for partial pages: if the page
-					// is not full, the total count is implied (offset + items.Count).
-					int totalCount;
-					if (items.Count < request.Size) {
-						totalCount = request.Offset + items.Count;
-					} else {
-						totalCount = await querySet.CountAsync(cancellationToken);
-					}
+				// Skip the CountAsync round-trip for partial pages: if the page
+				// is not full, the total count is implied (offset + items.Count).
+				int totalCount = items.Count < request.Size
+					? request.Offset + items.Count
+					: await querySet.CountAsync(cancellationToken);
 
 					return new PageQueryResult<TEntity>(pageQuery, totalCount, items);
 				}
@@ -945,12 +942,9 @@ namespace Kista
 					.Take(request.Size)
 					.ToListAsync(cancellationToken);
 
-				int allTotalCount;
-				if (allItems.Count < request.Size) {
-					allTotalCount = request.Offset + allItems.Count;
-				} else {
-					allTotalCount = await allQuerySet.CountAsync(cancellationToken);
-				}
+			int allTotalCount = allItems.Count < request.Size
+				? request.Offset + allItems.Count
+				: await allQuerySet.CountAsync(cancellationToken);
 
 				return new PageResult<TEntity>(request, allTotalCount, allItems);
 			} catch (Exception ex) {

--- a/src/Kista.HealthChecks.EntityFramework/EntityFrameworkHealthCheck.cs
+++ b/src/Kista.HealthChecks.EntityFramework/EntityFrameworkHealthCheck.cs
@@ -28,7 +28,10 @@ public class EntityFrameworkHealthCheck<TEntity, TKey> : RepositoryHealthCheckBa
     where TEntity : class {
     
     private readonly EntityFrameworkHealthCheckOptions _options;
-    
+    private readonly SemaphoreSlim _probeSemaphore = new(1, 1);
+    private HealthCheckResult? _cachedResult;
+    private DateTimeOffset _cacheExpiry;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EntityFrameworkHealthCheck{TEntity, TKey}"/> class.
     /// </summary>
@@ -41,7 +44,35 @@ public class EntityFrameworkHealthCheck<TEntity, TKey> : RepositoryHealthCheckBa
     public override string DriverType => "EntityFramework";
     
     /// <inheritdoc/>
-    protected override async ValueTask<HealthCheckResult> CheckHealthAsyncCore(
+		protected override async ValueTask<HealthCheckResult> CheckHealthAsyncCore(
+        IServiceProvider serviceProvider,
+        CancellationToken cancellationToken) {
+
+        // Fast-path: if already cancelled, throw before entering the semaphore
+        // to preserve the OperationCanceledException type contract.
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Return a cached result if still valid, to avoid hitting the DB on every probe.
+        if (_cachedResult is { } cached && DateTimeOffset.UtcNow < _cacheExpiry)
+            return cached;
+
+        // Coalesce concurrent probes: only one thread hits the DB, others wait.
+        await _probeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            // Double-check after acquiring the lock — another thread may have refreshed.
+            if (_cachedResult is { } refreshed && DateTimeOffset.UtcNow < _cacheExpiry)
+                return refreshed;
+
+            var result = await CheckHealthAsyncInner(serviceProvider, cancellationToken).ConfigureAwait(false);
+            _cachedResult = result;
+            _cacheExpiry = DateTimeOffset.UtcNow + _options.CacheDuration;
+            return result;
+        } finally {
+            _probeSemaphore.Release();
+        }
+    }
+
+    private async ValueTask<HealthCheckResult> CheckHealthAsyncInner(
         IServiceProvider serviceProvider,
         CancellationToken cancellationToken) {
         

--- a/src/Kista.HealthChecks.EntityFramework/EntityFrameworkHealthCheck.cs
+++ b/src/Kista.HealthChecks.EntityFramework/EntityFrameworkHealthCheck.cs
@@ -28,9 +28,6 @@ public class EntityFrameworkHealthCheck<TEntity, TKey> : RepositoryHealthCheckBa
     where TEntity : class {
     
     private readonly EntityFrameworkHealthCheckOptions _options;
-    private readonly SemaphoreSlim _probeSemaphore = new(1, 1);
-    private HealthCheckResult? _cachedResult;
-    private DateTimeOffset _cacheExpiry;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EntityFrameworkHealthCheck{TEntity, TKey}"/> class.
@@ -46,31 +43,11 @@ public class EntityFrameworkHealthCheck<TEntity, TKey> : RepositoryHealthCheckBa
     /// <inheritdoc/>
 		protected override async ValueTask<HealthCheckResult> CheckHealthAsyncCore(
         IServiceProvider serviceProvider,
-        CancellationToken cancellationToken) {
-
-        // Fast-path: if already cancelled, throw before entering the semaphore
-        // to preserve the OperationCanceledException type contract.
-        cancellationToken.ThrowIfCancellationRequested();
-
-        // Return a cached result if still valid, to avoid hitting the DB on every probe.
-        if (_cachedResult is { } cached && DateTimeOffset.UtcNow < _cacheExpiry)
-            return cached;
-
-        // Coalesce concurrent probes: only one thread hits the DB, others wait.
-        await _probeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try {
-            // Double-check after acquiring the lock — another thread may have refreshed.
-            if (_cachedResult is { } refreshed && DateTimeOffset.UtcNow < _cacheExpiry)
-                return refreshed;
-
-            var result = await CheckHealthAsyncInner(serviceProvider, cancellationToken).ConfigureAwait(false);
-            _cachedResult = result;
-            _cacheExpiry = DateTimeOffset.UtcNow + _options.CacheDuration;
-            return result;
-        } finally {
-            _probeSemaphore.Release();
-        }
-    }
+        CancellationToken cancellationToken)
+        => await ExecuteCachedProbeAsync(
+            () => CheckHealthAsyncInner(serviceProvider, cancellationToken),
+            _options.CacheDuration,
+            cancellationToken);
 
     private async ValueTask<HealthCheckResult> CheckHealthAsyncInner(
         IServiceProvider serviceProvider,

--- a/src/Kista.HealthChecks.EntityFramework/EntityFrameworkHealthCheckOptions.cs
+++ b/src/Kista.HealthChecks.EntityFramework/EntityFrameworkHealthCheckOptions.cs
@@ -30,7 +30,27 @@ public class EntityFrameworkHealthCheckOptions {
     /// <summary>
     /// Whether to run a test query in addition to connection check.
     /// </summary>
+    /// <remarks>
+    /// When <c>true</c>, the health check runs a <c>SELECT EXISTS</c> against
+    /// the entity table on every probe. This doubles the DB load under probe
+    /// pressure (Kubernetes/App Service orchestrators typically probe every
+    /// 5–10s). Leave <c>false</c> for liveness probes; enable only for
+    /// readiness probes that must verify schema availability.
+    /// </remarks>
     public bool TestQuery { get; set; } = false;
+
+    /// <summary>
+    /// The duration for which a cached health-check result is reused before
+    /// hitting the database again. Defaults to 5 seconds.
+    /// </summary>
+    /// <remarks>
+    /// Orchestrators (Kubernetes, App Service, Docker) typically probe
+    /// <c>/health</c> every 5–10s, and on a rolling restart they probe all
+    /// replicas simultaneously. Without caching, each probe opens a physical
+    /// DB connection. This cache coalesces concurrent probes and prevents
+    /// thundering-herd DB load during deploys.
+    /// </remarks>
+    public TimeSpan CacheDuration { get; set; } = TimeSpan.FromSeconds(5);
     
     /// <summary>
     /// Tags to apply to the health check.

--- a/src/Kista.HealthChecks.MongoFramework/MongoHealthCheck.cs
+++ b/src/Kista.HealthChecks.MongoFramework/MongoHealthCheck.cs
@@ -30,10 +30,7 @@ public class MongoHealthCheck<TEntity, TKey> : RepositoryHealthCheckBase<TEntity
     where TEntity : class {
     
     private readonly MongoHealthCheckOptions _options;
-    private readonly SemaphoreSlim _probeSemaphore = new(1, 1);
-    private HealthCheckResult? _cachedResult;
-    private DateTimeOffset _cacheExpiry;
-    
+
     /// <summary>
     /// Initializes a new instance of the <see cref="MongoHealthCheck{TEntity, TKey}"/> class.
     /// </summary>
@@ -48,31 +45,11 @@ public class MongoHealthCheck<TEntity, TKey> : RepositoryHealthCheckBase<TEntity
     /// <inheritdoc/>
 		protected override async ValueTask<HealthCheckResult> CheckHealthAsyncCore(
         IServiceProvider serviceProvider,
-        CancellationToken cancellationToken) {
-
-        // Fast-path: if already cancelled, throw before entering the semaphore
-        // to preserve the OperationCanceledException type contract.
-        cancellationToken.ThrowIfCancellationRequested();
-
-        // Return a cached result if still valid, to avoid hitting the DB on every probe.
-        if (_cachedResult is { } cached && DateTimeOffset.UtcNow < _cacheExpiry)
-            return cached;
-
-        // Coalesce concurrent probes: only one thread hits the DB, others wait.
-        await _probeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try {
-            // Double-check after acquiring the lock — another thread may have refreshed.
-            if (_cachedResult is { } refreshed && DateTimeOffset.UtcNow < _cacheExpiry)
-                return refreshed;
-
-            var result = await CheckHealthAsyncInner(serviceProvider, cancellationToken).ConfigureAwait(false);
-            _cachedResult = result;
-            _cacheExpiry = DateTimeOffset.UtcNow + _options.CacheDuration;
-            return result;
-        } finally {
-            _probeSemaphore.Release();
-        }
-    }
+        CancellationToken cancellationToken)
+        => await ExecuteCachedProbeAsync(
+            () => CheckHealthAsyncInner(serviceProvider, cancellationToken),
+            _options.CacheDuration,
+            cancellationToken);
 
     private async ValueTask<HealthCheckResult> CheckHealthAsyncInner(
         IServiceProvider serviceProvider,

--- a/src/Kista.HealthChecks.MongoFramework/MongoHealthCheck.cs
+++ b/src/Kista.HealthChecks.MongoFramework/MongoHealthCheck.cs
@@ -30,6 +30,9 @@ public class MongoHealthCheck<TEntity, TKey> : RepositoryHealthCheckBase<TEntity
     where TEntity : class {
     
     private readonly MongoHealthCheckOptions _options;
+    private readonly SemaphoreSlim _probeSemaphore = new(1, 1);
+    private HealthCheckResult? _cachedResult;
+    private DateTimeOffset _cacheExpiry;
     
     /// <summary>
     /// Initializes a new instance of the <see cref="MongoHealthCheck{TEntity, TKey}"/> class.
@@ -43,7 +46,35 @@ public class MongoHealthCheck<TEntity, TKey> : RepositoryHealthCheckBase<TEntity
     public override string DriverType => "MongoDB";
     
     /// <inheritdoc/>
-    protected override async ValueTask<HealthCheckResult> CheckHealthAsyncCore(
+		protected override async ValueTask<HealthCheckResult> CheckHealthAsyncCore(
+        IServiceProvider serviceProvider,
+        CancellationToken cancellationToken) {
+
+        // Fast-path: if already cancelled, throw before entering the semaphore
+        // to preserve the OperationCanceledException type contract.
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Return a cached result if still valid, to avoid hitting the DB on every probe.
+        if (_cachedResult is { } cached && DateTimeOffset.UtcNow < _cacheExpiry)
+            return cached;
+
+        // Coalesce concurrent probes: only one thread hits the DB, others wait.
+        await _probeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            // Double-check after acquiring the lock — another thread may have refreshed.
+            if (_cachedResult is { } refreshed && DateTimeOffset.UtcNow < _cacheExpiry)
+                return refreshed;
+
+            var result = await CheckHealthAsyncInner(serviceProvider, cancellationToken).ConfigureAwait(false);
+            _cachedResult = result;
+            _cacheExpiry = DateTimeOffset.UtcNow + _options.CacheDuration;
+            return result;
+        } finally {
+            _probeSemaphore.Release();
+        }
+    }
+
+    private async ValueTask<HealthCheckResult> CheckHealthAsyncInner(
         IServiceProvider serviceProvider,
         CancellationToken cancellationToken) {
         

--- a/src/Kista.HealthChecks.MongoFramework/MongoHealthCheckOptions.cs
+++ b/src/Kista.HealthChecks.MongoFramework/MongoHealthCheckOptions.cs
@@ -32,6 +32,19 @@ public class MongoHealthCheckOptions {
     /// Timeout for the ping command.
     /// </summary>
     public TimeSpan PingTimeout { get; set; } = TimeSpan.FromSeconds(3);
+
+    /// <summary>
+    /// The duration for which a cached health-check result is reused before
+    /// hitting the database again. Defaults to 5 seconds.
+    /// </summary>
+    /// <remarks>
+    /// Orchestrators (Kubernetes, App Service, Docker) typically probe
+    /// <c>/health</c> every 5–10s, and on a rolling restart they probe all
+    /// replicas simultaneously. Without caching, each probe runs a
+    /// <c>ping</c> command against MongoDB. This cache coalesces concurrent
+    /// probes and prevents thundering-herd DB load during deploys.
+    /// </remarks>
+    public TimeSpan CacheDuration { get; set; } = TimeSpan.FromSeconds(5);
     
     /// <summary>
     /// Tags to apply to the health check.

--- a/src/Kista.HealthChecks/RepositoryHealthCheckBase.cs
+++ b/src/Kista.HealthChecks/RepositoryHealthCheckBase.cs
@@ -25,7 +25,24 @@ namespace Kista.HealthChecks;
 /// <typeparam name="TKey">The key type.</typeparam>
 public abstract class RepositoryHealthCheckBase<TEntity, TKey> : IRepositoryHealthCheck
     where TEntity : class {
-    
+
+    /// <summary>
+    /// Serializes concurrent probes so that only one thread performs the
+    /// underlying driver check while the others wait for the cached result.
+    /// </summary>
+    protected readonly SemaphoreSlim ProbeSemaphore = new(1, 1);
+
+    /// <summary>
+    /// The last probe result, reused while <see cref="CacheExpiry"/> is in
+    /// the future to avoid hitting the data store on every probe.
+    /// </summary>
+    protected HealthCheckResult? CachedProbeResult;
+
+    /// <summary>
+    /// The instant at which <see cref="CachedProbeResult"/> becomes stale.
+    /// </summary>
+    protected DateTimeOffset CacheExpiry;
+
     /// <inheritdoc/>
     public Type RepositoryType => typeof(IRepository<TEntity, TKey>);
     
@@ -72,6 +89,71 @@ public abstract class RepositoryHealthCheckBase<TEntity, TKey> : IRepositoryHeal
     protected abstract ValueTask<HealthCheckResult> CheckHealthAsyncCore(
         IServiceProvider serviceProvider,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Executes <paramref name="probe"/> with a short-lived in-process cache
+    /// and a coalescing semaphore, so that concurrent probes share a single
+    /// driver round-trip and repeated probes within <paramref name="cacheDuration"/>
+    /// return the cached <see cref="HealthCheckResult"/> without touching the store.
+    /// </summary>
+    /// <param name="probe">
+    /// A delegate that performs the actual driver-specific check and returns
+    /// a fresh <see cref="HealthCheckResult"/>.
+    /// </param>
+    /// <param name="cacheDuration">
+    /// How long a successful probe result is reused. Pass
+    /// <see cref="TimeSpan.Zero"/> to disable caching (every probe hits the
+    /// delegate).
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token used to cancel the operation. Cancellation is honoured before
+    /// entering the semaphore and re-checked inside the critical section.
+    /// </param>
+    /// <returns>
+    /// The cached <see cref="HealthCheckResult"/> if still valid, otherwise the
+    /// result of <paramref name="probe"/>.
+    /// </returns>
+    /// <remarks>
+    /// When <paramref name="cacheDuration"/> is <see cref="TimeSpan.Zero"/> the
+    /// semaphore is still acquired so concurrent callers coalesce onto a single
+    /// in-flight probe, but every caller observes a fresh result.
+    /// </remarks>
+    protected async ValueTask<HealthCheckResult> ExecuteCachedProbeAsync(
+        Func<ValueTask<HealthCheckResult>> probe,
+        TimeSpan cacheDuration,
+        CancellationToken cancellationToken) {
+
+        // Fast-path: if already cancelled, throw before entering the semaphore
+        // to preserve the OperationCanceledException type contract.
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Return a cached result if still valid, to avoid hitting the store on every probe.
+        if (cacheDuration > TimeSpan.Zero
+            && CachedProbeResult is { } cached
+            && DateTimeOffset.UtcNow < CacheExpiry)
+            return cached;
+
+        // Coalesce concurrent probes: only one thread runs the probe, others wait.
+        await ProbeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try {
+            // Double-check after acquiring the lock — another thread may have refreshed.
+            if (cacheDuration > TimeSpan.Zero
+                && CachedProbeResult is { } refreshed
+                && DateTimeOffset.UtcNow < CacheExpiry)
+                return refreshed;
+
+            var result = await probe().ConfigureAwait(false);
+
+            if (cacheDuration > TimeSpan.Zero) {
+                CachedProbeResult = result;
+                CacheExpiry = DateTimeOffset.UtcNow + cacheDuration;
+            }
+
+            return result;
+        } finally {
+            ProbeSemaphore.Release();
+        }
+    }
     
     protected static Dictionary<string, object> CreateDiagnosticData(params KeyValuePair<string, object?>[] additionalData) {
         var data = new Dictionary<string, object> {

--- a/src/Kista.InMemory/InMemoryRepository_T2.cs
+++ b/src/Kista.InMemory/InMemoryRepository_T2.cs
@@ -247,6 +247,8 @@ namespace Kista {
 
 		// Returns a queryable view of the entity collection.
 		// Must be called while the read (or write) lock is held.
+		// Uses the raw entities dictionary (not the Entities property) to
+		// avoid recursive read-lock acquisition.
 		private IQueryable<TEntity> GetEntityQueryable() =>
 			entities.Values.Select(x => x.Entity).AsQueryable();
 
@@ -845,7 +847,9 @@ namespace Kista {
 					_lock.Dispose();
 				}
 
-				entities = null!;
+				// Do NOT null the entities field: a concurrent in-flight
+				// reader that already passed the disposed check could
+				// NullReferenceException. Clearing is sufficient.
 				disposedValue = true;
 			}
 		}

--- a/src/Kista.Manager.AspNetCore.HealthChecks/HealthCheckEndpointExtensions.cs
+++ b/src/Kista.Manager.AspNetCore.HealthChecks/HealthCheckEndpointExtensions.cs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Kista.HealthChecks;
@@ -26,6 +26,8 @@ namespace Kista.HealthChecks;
 /// Extension methods for mapping Kista repository health check endpoints.
 /// </summary>
 public static class HealthCheckEndpointExtensions {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
     /// <summary>
     /// Adds Kista repository health check endpoint with sensible defaults.
     /// </summary>
@@ -43,7 +45,7 @@ public static class HealthCheckEndpointExtensions {
         
         var healthCheckOptions = new HealthCheckOptions {
             ResponseWriter = options.ResponseType == HealthCheckResponseFormat.Json
-                ? JsonResponseWriter
+                ? (context, healthReport) => WriteJsonResponse(context, healthReport, options)
                 : TextResponseWriter,
             ResultStatusCodes = {
                 [HealthStatus.Healthy] = options.SuccessStatusCode,
@@ -58,40 +60,48 @@ public static class HealthCheckEndpointExtensions {
         
         return endpoints.MapHealthChecks(pattern, healthCheckOptions);
     }
-    
-    private static Task JsonResponseWriter(HttpContext context, HealthReport healthReport) {
+
+    private static async Task WriteJsonResponse(
+        HttpContext context,
+        HealthReport healthReport,
+        RepositoryHealthCheckEndpointOptions options) {
         context.Response.ContentType = "application/json; charset=utf-8";
-        
-        var options = new JsonWriterOptions { Indented = true };
-        
-        using var memoryStream = new MemoryStream();
-        using (var jsonWriter = new Utf8JsonWriter(memoryStream, options)) {
+
+        var writerOptions = new JsonWriterOptions { Indented = true };
+
+        await using var memoryStream = new MemoryStream();
+        using (var jsonWriter = new Utf8JsonWriter(memoryStream, writerOptions)) {
             jsonWriter.WriteStartObject();
             jsonWriter.WriteString("status", healthReport.Status.ToString());
             jsonWriter.WriteStartObject("results");
-            
-            foreach (var healthReportEntry in healthReport.Entries) {
-                jsonWriter.WriteStartObject(healthReportEntry.Key);
-                jsonWriter.WriteString("status", healthReportEntry.Value.Status.ToString());
-                jsonWriter.WriteString("description", healthReportEntry.Value.Description);
-                jsonWriter.WriteStartObject("data");
-                
-                foreach (var item in healthReportEntry.Value.Data) {
-                    jsonWriter.WritePropertyName(item.Key);
-                    JsonSerializer.Serialize(jsonWriter, item.Value,
-                        item.Value?.GetType() ?? typeof(object));
+
+            foreach (var entry in healthReport.Entries) {
+                jsonWriter.WriteStartObject(entry.Key);
+                jsonWriter.WriteString("status", entry.Value.Status.ToString());
+
+                if (options.IncludeExceptionDetails) {
+                    jsonWriter.WriteString("description", entry.Value.Description);
+                    jsonWriter.WriteStartObject("data");
+
+                    foreach (var item in entry.Value.Data) {
+                        jsonWriter.WritePropertyName(item.Key);
+                        JsonSerializer.Serialize(jsonWriter, item.Value, typeof(object), JsonOptions);
+                    }
+
+                    jsonWriter.WriteEndObject();
                 }
-                
-                jsonWriter.WriteEndObject();
+
                 jsonWriter.WriteEndObject();
             }
-            
+
             jsonWriter.WriteEndObject();
             jsonWriter.WriteEndObject();
         }
-        
-        return context.Response.WriteAsync(
-            Encoding.UTF8.GetString(memoryStream.ToArray()));
+
+        // Write the buffered JSON to the response stream asynchronously
+        // (Kestrel disallows synchronous IO by default).
+        memoryStream.Position = 0;
+        await memoryStream.CopyToAsync(context.Response.Body, 8192, context.RequestAborted).ConfigureAwait(false);
     }
     
     private static Task TextResponseWriter(HttpContext context, HealthReport healthReport) {

--- a/src/Kista.Manager.AspNetCore.HealthChecks/RepositoryHealthCheckEndpointOptions.cs
+++ b/src/Kista.Manager.AspNetCore.HealthChecks/RepositoryHealthCheckEndpointOptions.cs
@@ -53,4 +53,17 @@ public class RepositoryHealthCheckEndpointOptions {
     /// If null, all health checks are included.
     /// </summary>
     public Func<IEnumerable<string>, bool>? TagFilter { get; set; }
+
+    /// <summary>
+    /// Whether to include exception details (descriptions and diagnostic data)
+    /// in the health check response. Defaults to <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    /// When <c>false</c>, the JSON response includes only the aggregate
+    /// <c>status</c> and the entry names — never exception messages or
+    /// diagnostic data that could disclose infrastructure details (connection
+    /// strings, table names, SQL/Mongo error text, file paths). Set to
+    /// <c>true</c> in development or behind a trusted gateway to aid debugging.
+    /// </remarks>
+    public bool IncludeExceptionDetails { get; set; } = false;
 }

--- a/src/Kista.Manager.AspNetCore/RepositoryContextBuilderExtensions.cs
+++ b/src/Kista.Manager.AspNetCore/RepositoryContextBuilderExtensions.cs
@@ -30,18 +30,24 @@ namespace Kista {
 			return builder;
 		}
 
-	/// <summary>
-	/// Registers an HTTP-based user accessor that resolves the current
-	/// user identifier from the request using default strategies:
-	/// claim ("sub") → query string ("user_id") → route value ("userId").
-	/// </summary>
-	/// <typeparam name="TKey">The type of the user identifier key.</typeparam>
-	/// <param name="builder">The repository context builder to configure.</param>
-	/// <returns>Returns the same builder instance for chaining.</returns>
-	public static RepositoryContextBuilder WithHttpUserAccessor<TKey>(this RepositoryContextBuilder builder) {
-		builder.Services.AddHttpUserAccessor<TKey>();
-		return builder;
-	}
+/// <summary>
+/// Registers an HTTP-based user accessor that resolves the current
+/// user identifier from the request using the secure default strategy:
+/// claim ("sub") only.
+/// </summary>
+/// <typeparam name="TKey">The type of the user identifier key.</typeparam>
+/// <param name="builder">The repository context builder to configure.</param>
+/// <returns>Returns the same builder instance for chaining.</returns>
+/// <remarks>
+/// To enable the pre-1.8.0 query-string ("user_id") and route ("userId") fallbacks,
+/// use the overload that accepts a configuration delegate and call
+/// <c>AddQueryString()</c> / <c>AddRoute()</c> explicitly. Those fallbacks are
+/// client-controlled and must only be enabled behind a trusted gateway.
+/// </remarks>
+public static RepositoryContextBuilder WithHttpUserAccessor<TKey>(this RepositoryContextBuilder builder) {
+	builder.Services.AddHttpUserAccessor<TKey>();
+	return builder;
+}
 
 	/// <summary>
 	/// Registers an HTTP-based user accessor with custom strategy configuration.

--- a/src/Kista.Manager.Events/Events/InMemoryEntityEventPublisher.cs
+++ b/src/Kista.Manager.Events/Events/InMemoryEntityEventPublisher.cs
@@ -19,7 +19,7 @@ namespace Kista.Events {
 	/// <summary>
 	/// A default in-process implementation of
 	/// <see cref="IEntityEventPublisher{TEntity}"/> that enqueues published
-	/// events into an unbounded <see cref="Channel{T}"/> for asynchronous
+	/// events into a bounded <see cref="Channel{T}"/> for asynchronous
 	/// consumption, and also records them in a list for test assertions.
 	/// </summary>
 	/// <typeparam name="TEntity">
@@ -33,6 +33,12 @@ namespace Kista.Events {
 	/// without any messaging dependency.
 	/// </para>
 	/// <para>
+	/// The internal channel is bounded by <see cref="InMemoryEventPublisherOptions.Capacity"/>
+	/// (default 1024). When the channel is full, publishers wait
+	/// (<see cref="BoundedChannelFullMode.Wait"/>) instead of growing memory
+	/// without bound, applying backpressure to the write path.
+	/// </para>
+	/// <para>
 	/// The <see cref="PublishedEvents"/> property exposes a thread-safe
 	/// snapshot of all events published so far, for use in unit tests and
 	/// debugging scenarios. For production workloads with real message
@@ -43,8 +49,33 @@ namespace Kista.Events {
 	public class InMemoryEntityEventPublisher<TEntity> : IEntityEventPublisher<TEntity>
 		where TEntity : class {
 		private readonly ConcurrentQueue<EntityEventData<TEntity>> _events = new();
-		private readonly Channel<EntityEventData<TEntity>> _channel =
-			Channel.CreateUnbounded<EntityEventData<TEntity>>();
+		private readonly Channel<EntityEventData<TEntity>> _channel;
+		private readonly InMemoryEventPublisherOptions _options;
+
+		/// <summary>
+		/// Initializes a new instance with default options (capacity 1024,
+		/// <see cref="BoundedChannelFullMode.Wait"/>).
+		/// </summary>
+		public InMemoryEntityEventPublisher()
+			: this(options: null) {
+		}
+
+		/// <summary>
+		/// Initializes a new instance with the specified options.
+		/// </summary>
+		/// <param name="options">
+		/// The configuration options. When <c>null</c>, defaults are used.
+		/// </param>
+		public InMemoryEntityEventPublisher(InMemoryEventPublisherOptions? options) {
+			_options = options ?? new InMemoryEventPublisherOptions();
+
+			_channel = Channel.CreateBounded<EntityEventData<TEntity>>(
+				new BoundedChannelOptions(_options.Capacity) {
+					FullMode = _options.FullMode,
+					SingleReader = false,
+					SingleWriter = false,
+				});
+		}
 
 		/// <summary>
 		/// Gets a readable channel of all published events, for asynchronous
@@ -55,14 +86,18 @@ namespace Kista.Events {
 		/// <summary>
 		/// Gets a thread-safe snapshot of all events published so far.
 		/// </summary>
+		/// <remarks>
+		/// This property is intended for unit tests and debugging. Each access
+		/// copies the entire event list (O(n)); avoid calling it in
+		/// production hot paths.
+		/// </remarks>
 		public IReadOnlyList<EntityEventData<TEntity>> PublishedEvents => _events.ToArray();
 
 		/// <inheritdoc/>
-		public ValueTask PublishAsync(EntityEventData<TEntity> data, CancellationToken cancellationToken) {
+		public async ValueTask PublishAsync(EntityEventData<TEntity> data, CancellationToken cancellationToken) {
 			ArgumentNullException.ThrowIfNull(data);
 			_events.Enqueue(data);
-			_channel.Writer.TryWrite(data);
-			return ValueTask.CompletedTask;
+			await _channel.Writer.WriteAsync(data, cancellationToken).ConfigureAwait(false);
 		}
 	}
 }

--- a/src/Kista.Manager.Events/Events/InMemoryEntityEventPublisher.cs
+++ b/src/Kista.Manager.Events/Events/InMemoryEntityEventPublisher.cs
@@ -50,7 +50,6 @@ namespace Kista.Events {
 		where TEntity : class {
 		private readonly ConcurrentQueue<EntityEventData<TEntity>> _events = new();
 		private readonly Channel<EntityEventData<TEntity>> _channel;
-		private readonly InMemoryEventPublisherOptions _options;
 
 		/// <summary>
 		/// Initializes a new instance with default options (capacity 1024,
@@ -67,11 +66,11 @@ namespace Kista.Events {
 		/// The configuration options. When <c>null</c>, defaults are used.
 		/// </param>
 		public InMemoryEntityEventPublisher(InMemoryEventPublisherOptions? options) {
-			_options = options ?? new InMemoryEventPublisherOptions();
+			var opts = options ?? new InMemoryEventPublisherOptions();
 
 			_channel = Channel.CreateBounded<EntityEventData<TEntity>>(
-				new BoundedChannelOptions(_options.Capacity) {
-					FullMode = _options.FullMode,
+				new BoundedChannelOptions(opts.Capacity) {
+					FullMode = opts.FullMode,
 					SingleReader = false,
 					SingleWriter = false,
 				});

--- a/src/Kista.Manager.Events/Events/InMemoryEventPublisherOptions.cs
+++ b/src/Kista.Manager.Events/Events/InMemoryEventPublisherOptions.cs
@@ -1,0 +1,40 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading.Channels;
+
+namespace Kista.Events {
+	/// <summary>
+	/// Configuration options for <see cref="InMemoryEntityEventPublisher{TEntity}"/>.
+	/// </summary>
+	public class InMemoryEventPublisherOptions {
+		/// <summary>
+		/// The maximum number of events the internal channel can hold before
+		/// applying backpressure. Defaults to 1024.
+		/// </summary>
+		/// <remarks>
+		/// When the channel is full, publishers wait (backpressure) instead of
+		/// growing memory without bound. Set to a value appropriate for your
+		/// consumer throughput.
+		/// </remarks>
+		public int Capacity { get; set; } = 1024;
+
+		/// <summary>
+		/// The behavior when the channel is full and a publisher attempts to
+		/// write. Defaults to <see cref="BoundedChannelFullMode.Wait"/>, which
+		/// applies backpressure to the publisher.
+		/// </summary>
+		public BoundedChannelFullMode FullMode { get; set; } = BoundedChannelFullMode.Wait;
+	}
+}

--- a/src/Kista.Manager.Hermodr/Events/HermodrEventPublisher.cs
+++ b/src/Kista.Manager.Hermodr/Events/HermodrEventPublisher.cs
@@ -59,6 +59,16 @@ namespace Kista.Events {
 	/// are pluggable through Hermodr channel packages (Azure Service Bus,
 	/// RabbitMQ, MassTransit, Webhook) with zero application code change.
 	/// </para>
+	/// <para>
+	/// <b>Performance note.</b> Unlike <c>InMemoryEntityEventPublisher</c>,
+	/// which enqueues events into a channel and returns immediately, this
+	/// publisher awaits the full Hermodr middleware chain inline on the
+	/// caller's request thread. If any middleware performs I/O (outbox DB
+	/// write, webhook HTTP), the user-facing write latency includes event
+	/// publication. To decouple publication from the request thread, wrap
+	/// the publisher in a bounded-channel-based buffer with a background
+	/// consumer.
+	/// </para>
 	/// </remarks>
 	public class HermodrEventPublisher<TEntity> : IEntityEventPublisher<TEntity>
 		where TEntity : class {

--- a/src/Kista.Manager.Hermodr/Events/HermodrEventPublisher.cs
+++ b/src/Kista.Manager.Hermodr/Events/HermodrEventPublisher.cs
@@ -96,8 +96,9 @@ namespace Kista.Events {
 		private static readonly CloudEventAttribute DeleteKindAttribute =
 			CloudEventAttribute.CreateExtension(DeleteKindAttributeName, CloudEventAttributeType.String);
 
-		private readonly IEventPublisher _publisher;
-		private readonly HermodrEventsOptions _options;
+	private readonly IEventPublisher _publisher;
+	private readonly HermodrEventsOptions _options;
+	private readonly Uri _sourceUri;
 
 		/// <summary>
 		/// Constructs the publisher with the Hermodr <see cref="IEventPublisher"/>
@@ -111,11 +112,12 @@ namespace Kista.Events {
 		/// default <see cref="HermodrEventsOptions"/> are used.
 		/// </param>
 		public HermodrEventPublisher(
-			IEventPublisher publisher,
-			IOptions<HermodrEventsOptions>? options = null) {
-			_publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
-			_options = options?.Value ?? new HermodrEventsOptions();
-		}
+		IEventPublisher publisher,
+		IOptions<HermodrEventsOptions>? options = null) {
+		_publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+		_options = options?.Value ?? new HermodrEventsOptions();
+		_sourceUri = BuildSourceUri();
+	}
 
 		/// <inheritdoc/>
 		public async ValueTask PublishAsync(EntityEventData<TEntity> data, CancellationToken cancellationToken) {
@@ -139,9 +141,9 @@ namespace Kista.Events {
 		/// through Hermodr.
 		/// </returns>
 		protected virtual CloudEvent BuildCloudEvent(EntityEventData<TEntity> data) {
-			var eventType = GetCloudEventType(data);
-			var source = BuildSourceUri();
-			var subject = data.Key?.ToString();
+		var eventType = GetCloudEventType(data);
+		var source = _sourceUri;
+		var subject = data.Key?.ToString();
 
 			var cloudEvent = new CloudEvent {
 				Type = eventType,

--- a/src/Kista.Manager/Caching/DefaultEntityCacheKeyGenerator.cs
+++ b/src/Kista.Manager/Caching/DefaultEntityCacheKeyGenerator.cs
@@ -1,0 +1,74 @@
+// Copyright 2023-2026 Antonello Provenzano
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Kista.Caching {
+	/// <summary>
+	/// A default implementation of <see cref="IEntityCacheKeyGenerator{TEntity}"/>
+	/// that produces safe, normalized cache keys prefixed with the entity type name.
+	/// </summary>
+	/// <typeparam name="TEntity">
+	/// The type of the entity for which cache keys are generated.
+	/// </typeparam>
+	/// <remarks>
+	/// <para>
+	/// This implementation guards against cache-key injection by:
+	/// </para>
+	/// <list type="bullet">
+	///   <item>Prefixing the key with the entity type name to avoid collisions across entity types.</item>
+	///   <item>URL-encoding the key segment to neutralize special characters.</item>
+	///   <item>Enforcing a maximum key length (256 characters) to prevent memory exhaustion.</item>
+	/// </list>
+	/// <para>
+	/// Custom implementations of <see cref="IEntityCacheKeyGenerator{TEntity}"/>
+	/// should follow the same normalization principles.
+	/// </para>
+	/// </remarks>
+	public class DefaultEntityCacheKeyGenerator<TEntity> : IEntityCacheKeyGenerator<TEntity>
+		where TEntity : class {
+
+		private const int MaxKeyLength = 256;
+		private readonly string _prefix;
+
+		/// <summary>
+		/// Initializes a new instance with the default prefix derived from
+		/// the entity type name.
+		/// </summary>
+		public DefaultEntityCacheKeyGenerator() {
+			_prefix = typeof(TEntity).Name + ":";
+		}
+
+		/// <inheritdoc/>
+		public string GenerateKey(object key) {
+			ArgumentNullException.ThrowIfNull(key);
+			var raw = key.ToString() ?? string.Empty;
+			return Normalize(_prefix + raw);
+		}
+
+		/// <inheritdoc/>
+		public string[] GenerateAllKeys(TEntity entity) {
+			ArgumentNullException.ThrowIfNull(entity);
+			// By default, generate a single key from the entity's ToString().
+			// Subclasses can override to produce additional keys (e.g. by
+			// alternate unique fields).
+			return new[] { Normalize(_prefix + entity.ToString()) };
+		}
+
+		private static string Normalize(string key) {
+			if (key.Length > MaxKeyLength)
+				key = key.Substring(0, MaxKeyLength);
+
+			return Uri.EscapeDataString(key);
+		}
+	}
+}

--- a/src/Kista.Manager/Caching/DefaultEntityCacheKeyGenerator.cs
+++ b/src/Kista.Manager/Caching/DefaultEntityCacheKeyGenerator.cs
@@ -58,10 +58,10 @@ namespace Kista.Caching {
 		/// <inheritdoc/>
 		public string[] GenerateAllKeys(TEntity entity) {
 			ArgumentNullException.ThrowIfNull(entity);
-			// By default, generate a single key from the entity's ToString().
-			// Subclasses can override to produce additional keys (e.g. by
-			// alternate unique fields).
-			return new[] { Normalize(_prefix + entity.ToString()) };
+		// By default, generate a single key from the entity's string representation.
+		// Subclasses can override to produce additional keys (e.g. by
+		// alternate unique fields).
+		return new[] { Normalize(_prefix + entity) };
 		}
 
 		private static string Normalize(string key) {

--- a/src/Kista.Manager/Caching/EntityMemoryCache.cs
+++ b/src/Kista.Manager/Caching/EntityMemoryCache.cs
@@ -31,8 +31,11 @@ namespace Kista.Caching {
 	/// </para>
 	/// <para>
 	/// Expiration is configured via <see cref="EntityCacheOptions{TEntity}"/>.
-	/// When no expiration is configured, entities are cached indefinitely
-	/// (subject to memory pressure eviction by <see cref="IMemoryCache"/>).
+	/// When no expiration is configured, entities are cached for 5 minutes
+	/// by default (aligning with <c>EntityDistributedCache</c> and
+	/// <c>EntityFusionCache</c>). Set <see cref="EntityCacheOptions.Expiration"/>
+	/// to <c>null</c> explicitly to cache indefinitely (not recommended —
+	/// configure <c>MemoryCacheOptions.SizeLimit</c> to bound memory usage).
 	/// </para>
 	/// </remarks>
 	public class EntityMemoryCache<TEntity> : IEntityCache<TEntity>
@@ -58,9 +61,15 @@ namespace Kista.Caching {
 		}
 
 		/// <summary>
-		/// Gets the expiration time for cached entities.
+		/// Gets the expiration time for cached entities. Defaults to 5 minutes
+		/// when not configured, aligning with the distributed and FusionCache
+		/// backends.
 		/// </summary>
-		protected virtual TimeSpan? Expiration => _options?.Expiration;
+		protected virtual TimeSpan? Expiration => _options is null
+			? DefaultExpiration
+			: _options.Expiration;
+
+		private static readonly TimeSpan DefaultExpiration = TimeSpan.FromMinutes(5);
 
 		/// <inheritdoc/>
 		public async ValueTask<TEntity?> GetOrSetAsync(string cacheKey, Func<ValueTask<TEntity?>> valueFactory, CancellationToken cancellationToken = default) {

--- a/src/Kista.Manager/EntityManager_T2.cs
+++ b/src/Kista.Manager/EntityManager_T2.cs
@@ -1544,7 +1544,7 @@ namespace Kista {
 
 					// The entity is either deleted or doesn't exist: try a
 					// property-based key filter that the driver can translate.
-					var keyProperty = typeof(TEntity).GetProperty("Id");
+					var keyProperty = CachedKeyProperty;
 					if (keyProperty != null && keyProperty.PropertyType == typeof(TKey)) {
 						var filter = BuildKeyFilter(keyProperty, key);
 						var queryWithOptions = new Query(filter, null, QueryOptions.WithSoftDeleteMode(SoftDeleteMode.IncludeDeleted));
@@ -1555,6 +1555,11 @@ namespace Kista {
 
 			return await Repository.FindAsync(key, cancellationToken);
 		}
+
+		private static PropertyInfo? CachedKeyProperty =>
+			s_keyProperty ??= typeof(TEntity).GetProperty("Id");
+
+		private static PropertyInfo? s_keyProperty;
 
 		private static IQueryFilter BuildKeyFilter(PropertyInfo keyProperty, TKey key) {
 			var parameter = Expression.Parameter(typeof(TEntity), "e");

--- a/src/Kista.Manager/EntityManager_T2.cs
+++ b/src/Kista.Manager/EntityManager_T2.cs
@@ -1556,10 +1556,10 @@ namespace Kista {
 			return await Repository.FindAsync(key, cancellationToken);
 		}
 
-		private static PropertyInfo? CachedKeyProperty =>
-			s_keyProperty ??= typeof(TEntity).GetProperty("Id");
+		private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, PropertyInfo?> s_keyPropertyCache = new();
 
-		private static PropertyInfo? s_keyProperty;
+		private static PropertyInfo? CachedKeyProperty =>
+			s_keyPropertyCache.GetOrAdd(typeof(TEntity), t => t.GetProperty("Id"));
 
 		private static IQueryFilter BuildKeyFilter(PropertyInfo keyProperty, TKey key) {
 			var parameter = Expression.Parameter(typeof(TEntity), "e");

--- a/src/Kista.Manager/LoggerExtensions.cs
+++ b/src/Kista.Manager/LoggerExtensions.cs
@@ -20,6 +20,17 @@ namespace Kista {
 /// <summary>
 	/// Extension methods for logging entity manager events.
 	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// <b>PII notice.</b> Several log messages carry the <c>{EntityKey}</c> or
+	/// <c>{Query}</c> parameters. When the entity key is an email, username,
+	/// national ID, or other personally identifiable information, and the
+	/// application has <c>Debug</c> logging enabled in production, that PII
+	/// will be written to logs. To redact PII from logs, register a custom
+	/// <c>ILoggerProvider</c> that scrubs these parameters, or lower the
+	/// logger category for <c>EntityManager</c> to <c>Trace</c> in production.
+	/// </para>
+	/// </remarks>
 	[ExcludeFromCodeCoverage]
 	static partial class LoggerExtensions {
         /// <summary>

--- a/src/Kista.Manager/OperationErrorFactory.cs
+++ b/src/Kista.Manager/OperationErrorFactory.cs
@@ -71,7 +71,11 @@ namespace Kista {
 			} else {
 				errorDomain = EntityErrorCodes.UnknownDomain;
 				errorCode = EntityErrorCodes.UnknownError;
-				errorMessage = exception.Message;
+				// Do not surface raw exception messages for non-OperationException:
+				// they may disclose infrastructure details (DB error text, connection
+				// strings, file paths). The error code conveys the meaning; the host
+				// application can map it to a localized user-facing message.
+				errorMessage = null;
 			}
 
 			return new OperationError(errorCode, errorDomain, errorMessage);

--- a/src/Kista.MongoFramework.MultiTenant/RepositoryContextBuilderExtensions.cs
+++ b/src/Kista.MongoFramework.MultiTenant/RepositoryContextBuilderExtensions.cs
@@ -25,6 +25,8 @@ namespace Kista {
 	/// Extension methods for configuring MongoDB multi-tenancy on a <see cref="MongoRepositoryBuilder"/>.
 	/// </summary>
 	public static class RepositoryContextBuilderExtensions {
+		private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, Microsoft.Extensions.DependencyInjection.ObjectFactory> _connectionFactories = new();
+
 		/// <summary>
 		/// Configures tenant-specific MongoDB connections using Finbuckle.MultiTenant.
 		/// </summary>
@@ -39,16 +41,17 @@ namespace Kista {
 			builder.Services.AddOptions<MongoTenantConnectionOptions>()
 				.Configure(options => options.DefaultConnectionString = defaultConnection);
 
-#pragma warning disable S3011 // Accessing internal builder field to extract context type for multi-tenant setup
-			var contextTypeField = builder.GetType().GetField("_contextType", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-#pragma warning restore S3011
-			var contextType = (Type?)contextTypeField?.GetValue(builder)
-				?? throw new InvalidOperationException("Cannot determine context type from builder.");
+			var contextType = builder.ContextType;
 
 			var connectionType = typeof(IMongoDbConnection<>).MakeGenericType(contextType);
 			builder.Services.TryAdd(ServiceDescriptor.Describe(connectionType, sp => {
-				var implementationType = typeof(MongoDbTenantConnection<>).MakeGenericType(contextType);
-				return ActivatorUtilities.CreateInstance(sp, implementationType);
+				// Cache the compiled factory per closed context type to avoid
+				// reflection-based ActivatorUtilities.CreateInstance on every request.
+				var factory = _connectionFactories.GetOrAdd(contextType, t => {
+					var implementationType = typeof(MongoDbTenantConnection<>).MakeGenericType(t);
+					return ActivatorUtilities.CreateFactory(implementationType, Type.EmptyTypes);
+				});
+				return factory(sp, null);
 			}, ServiceLifetime.Scoped));
 
 			builder.Services.TryAdd(ServiceDescriptor.Describe(typeof(IMongoDbConnection), sp => {

--- a/src/Kista.MongoFramework/MongoRepositoryBuilder.cs
+++ b/src/Kista.MongoFramework/MongoRepositoryBuilder.cs
@@ -34,6 +34,12 @@ namespace Kista
         }
 
         /// <summary>
+        /// Gets the <see cref="Type"/> of the MongoFramework context being
+        /// configured by this builder.
+        /// </summary>
+        public Type ContextType => _contextType;
+
+        /// <summary>
         /// Sets the connection string for the MongoDB connection.
         /// </summary>
         public MongoRepositoryBuilder WithConnectionString(string connectionString) {

--- a/src/Kista.MongoFramework/MongoRepository_T2.cs
+++ b/src/Kista.MongoFramework/MongoRepository_T2.cs
@@ -46,6 +46,14 @@ namespace Kista {
 		private bool disposed;
 
 		/// <summary>
+		/// Cached set of valid public property and field names for
+		/// <typeparamref name="TEntity"/>, used to validate the
+		/// <see cref="Field(string)"/> argument and prevent schema-oracle
+		/// attacks when the field name originates from user input.
+		/// </summary>
+		private static readonly HashSet<string> s_validFieldNames = BuildMemberSet(typeof(TEntity));
+
+		/// <summary>
 		/// Constructs the repository with the given context and logger.
 		/// </summary>
 		/// <param name="context">
@@ -62,6 +70,10 @@ namespace Kista {
 			Context = context;
 			Logger = logger ?? NullLogger.Instance;
 			Services = services;
+			_lazyCollection = new Lazy<IMongoCollection<TEntity>>(() => {
+				var entityDef = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
+				return context.Connection.GetDatabase().GetCollection<TEntity>(entityDef.CollectionName);
+			});
 		}
 
 		/// <summary>
@@ -126,16 +138,15 @@ namespace Kista {
 		/// <inheritdoc />
 		protected override bool IsQueryable => true;
 
-		/// <summary>
+	/// <summary>
 		/// Gets the <see cref="IMongoCollection{TEntity}"/> instance that is used
-		/// to handle the data in the repository.
+		/// to handle the data in the repository. The collection is resolved once
+		/// and cached in a <see cref="Lazy{T}"/> to avoid repeated mapping
+		/// lookups and <c>GetDatabase().GetCollection()</c> calls on every access.
 		/// </summary>
-		protected IMongoCollection<TEntity> Collection {
-			get {
-				var entityDef = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
-				return Context.Connection.GetDatabase().GetCollection<TEntity>(entityDef.CollectionName);
-			}
-		}
+		protected IMongoCollection<TEntity> Collection => _lazyCollection.Value;
+
+		private readonly Lazy<IMongoCollection<TEntity>> _lazyCollection;
 
 		/// <summary>
 		/// Throws an exception if the repository has been disposed.
@@ -191,16 +202,21 @@ namespace Kista {
 		/// </returns>
 		protected override TKey? GetEntityKey(TEntity entity) {
 			ArgumentNullException.ThrowIfNull(entity);
-
-			var entityDef = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
-
-			var idProperty = entityDef.GetIdProperty();
-
-			if (idProperty == null)
-				throw new RepositoryException($"The type '{typeof(TEntity)}' has no ID property specified");
-
-			return (TKey?) entityDef.GetIdValue(entity);
+			return (TKey?) CachedIdValueGetter.Value(entity);
 		}
+
+		/// <summary>
+		/// Cached entity mapping definition, resolved once per closed generic
+		/// type to avoid repeated <c>EntityMapping.GetOrCreateDefinition</c>
+		/// calls on every <see cref="GetEntityKey"/> invocation.
+		/// </summary>
+		private static readonly Lazy<Func<TEntity, object?>> CachedIdValueGetter = new(() => {
+			var entityDef = EntityMapping.GetOrCreateDefinition(typeof(TEntity));
+			var idProperty = entityDef.GetIdProperty();
+			if (idProperty == null)
+				return _ => throw new RepositoryException($"The type '{typeof(TEntity)}' has no ID property specified");
+			return entityDef.GetIdValue;
+		});
 
 		/// <summary>
 		/// Converts the given value to the type of the ID property of the
@@ -254,13 +270,25 @@ namespace Kista {
 		/// to access the field in the entity.
 		/// </summary>
 		/// <param name="fieldName">
-		/// The name of the field to be resolved.
+		/// The name of the field to be resolved. Must be a known public
+		/// property or field of <typeparamref name="TEntity"/>.
 		/// </param>
 		/// <returns>
 		/// Returns an instance of <see cref="Expression{TDelegate}"/> that
 		/// is used to access the field in the entity.
 		/// </returns>
-		protected virtual Expression<Func<TEntity, object>> Field(string fieldName) {
+		/// <exception cref="ArgumentException">
+		/// Thrown when <paramref name="fieldName"/> is not a known member
+		/// of <typeparamref name="TEntity"/>.
+		/// </exception>
+		protected internal virtual Expression<Func<TEntity, object>> Field(string fieldName) {
+			ArgumentException.ThrowIfNullOrWhiteSpace(fieldName);
+
+			if (!s_validFieldNames.Contains(fieldName))
+				throw new ArgumentException(
+					$"'{fieldName}' is not a known public property or field of '{typeof(TEntity).Name}'.",
+					nameof(fieldName));
+
 			var param = Expression.Parameter(typeof(TEntity), "x");
 			var body = Expression.PropertyOrField(param, fieldName);
 
@@ -918,5 +946,14 @@ namespace Kista {
 		}
 
 		#endregion
+
+		private static HashSet<string> BuildMemberSet(Type type) {
+			var set = new HashSet<string>(StringComparer.Ordinal);
+			foreach (var prop in type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+				set.Add(prop.Name);
+			foreach (var field in type.GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+				set.Add(field.Name);
+			return set;
+		}
 	}
 }

--- a/src/Kista.MongoFramework/MongoRepository_T2.cs
+++ b/src/Kista.MongoFramework/MongoRepository_T2.cs
@@ -738,10 +738,9 @@ namespace Kista {
 			var list = entities as IList<TEntity> ?? entities.ToList();
 
 			// Fold the tracked-check into the removal loop instead of a separate Any() scan.
-			foreach (var item in list) {
-				if (DbSet.Context.ChangeTracker.GetEntry(item) == null)
-					throw new RepositoryException("The list contains entities that are not tracked by the repository");
-			}
+			var untracked = list.FirstOrDefault(item => DbSet.Context.ChangeTracker.GetEntry(item) == null);
+			if (untracked != null)
+				throw new RepositoryException("The list contains entities that are not tracked by the repository");
 
 			DbSet.RemoveRange(list);
 

--- a/src/Kista.MongoFramework/MongoRepository_T2.cs
+++ b/src/Kista.MongoFramework/MongoRepository_T2.cs
@@ -672,41 +672,53 @@ namespace Kista {
 		/// A token used to cancel the operation.
 		/// </param>
 		protected virtual async ValueTask SoftDeleteRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken) {
-			try {
-				if (entities.Any(x => DbSet.Context.ChangeTracker.GetEntry(x) == null))
-					throw new RepositoryException("The list contains entities that are not tracked by the repository");
+		try {
+			// Materialize once to avoid double-enumeration of a possibly-deferred source.
+			var list = entities as IList<TEntity> ?? entities.ToList();
 
 			var now = ResolveSystemTime().UtcNow;
 
-			foreach (var softDeletable in entities.OfType<ISoftDeletable>()) {
-				softDeletable.IsDeleted = true;
-				softDeletable.DeletedAtUtc = now;
+			// Fold the tracked-check into the update loop instead of a separate Any() scan.
+			foreach (var item in list) {
+				if (DbSet.Context.ChangeTracker.GetEntry(item) == null)
+					throw new RepositoryException("The list contains entities that are not tracked by the repository");
+
+				if (item is ISoftDeletable softDeletable) {
+					softDeletable.IsDeleted = true;
+					softDeletable.DeletedAtUtc = now;
+				}
 			}
 
-				DbSet.UpdateRange(entities);
+			DbSet.UpdateRange(list);
 
-				await Context.SaveChangesAsync(cancellationToken);
-			} catch (Exception ex) {
-				Logger.LogUnknownError(ex);
-				throw new RepositoryException("Could not soft-delete the list of entities", ex);
-			}
+			await Context.SaveChangesAsync(cancellationToken);
+		} catch (Exception ex) {
+			Logger.LogUnknownError(ex);
+			throw new RepositoryException("Could not soft-delete the list of entities", ex);
 		}
+	}
 
 		/// <inheritdoc/>
 		public override async ValueTask HardDeleteRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
-			ArgumentNullException.ThrowIfNull(entities);
+		ArgumentNullException.ThrowIfNull(entities);
 
-			ThrowIfDisposed();
-			cancellationToken.ThrowIfCancellationRequested();
+		ThrowIfDisposed();
+		cancellationToken.ThrowIfCancellationRequested();
 
-			try {
-				if (entities.Any(x => DbSet.Context.ChangeTracker.GetEntry(x) == null))
+		try {
+			// Materialize once to avoid double-enumeration of a possibly-deferred source.
+			var list = entities as IList<TEntity> ?? entities.ToList();
+
+			// Fold the tracked-check into the removal loop instead of a separate Any() scan.
+			foreach (var item in list) {
+				if (DbSet.Context.ChangeTracker.GetEntry(item) == null)
 					throw new RepositoryException("The list contains entities that are not tracked by the repository");
+			}
 
-				DbSet.RemoveRange(entities);
+			DbSet.RemoveRange(list);
 
-				await Context.SaveChangesAsync(cancellationToken);
-			} catch (Exception ex) {
+			await Context.SaveChangesAsync(cancellationToken);
+		} catch (Exception ex) {
 				Logger.LogUnknownError(ex);
 				throw new RepositoryException("Could not delete the list of entities", ex);
 			}
@@ -846,12 +858,12 @@ namespace Kista {
 			}
 		}
 
-		/// <inheritdoc/>
-		protected override ValueTask<long> CountAsync(IQueryable<TEntity> queryable, CancellationToken cancellationToken = default) {
-			ArgumentNullException.ThrowIfNull(queryable);
+	/// <inheritdoc/>
+	protected override async ValueTask<long> CountAsync(IQueryable<TEntity> queryable, CancellationToken cancellationToken = default) {
+		ArgumentNullException.ThrowIfNull(queryable);
 
-			return new ValueTask<long>(queryable.Count());
-		}
+		return await queryable.CountAsync(cancellationToken).ConfigureAwait(false);
+	}
 
 		#region Dispose
 

--- a/src/Kista.Owners/ServiceCollectionExtensions.cs
+++ b/src/Kista.Owners/ServiceCollectionExtensions.cs
@@ -54,17 +54,32 @@ namespace Kista
 		}
 
 		/// <summary>
-		/// Registers HTTP-based strategies for <see cref="IUserAccessor{TKey}"/> with default configuration:
-		/// claim ("sub") → query string ("user_id") → route value ("userId").
+		/// Registers HTTP-based strategies for <see cref="IUserAccessor{TKey}"/> with the secure
+		/// default configuration: claim ("sub") only.
 		/// </summary>
 		/// <typeparam name="TKey">The type of the user identifier key.</typeparam>
 		/// <param name="services">The collection of services to register the user accessor.</param>
 		/// <returns>The given collection of services for chaining calls.</returns>
+		/// <remarks>
+		/// <para>
+		/// The default chain resolves the user identifier exclusively from the <c>"sub"</c> claim
+		/// of the authenticated <see cref="System.Security.Claims.ClaimsPrincipal"/>. This is a
+		/// <b>secure-by-default</b> policy: unauthenticated requests yield no user identity, so
+		/// <see cref="UserScopedRepositoryDecorator{TEntity, TKey, TUserKey}"/> returns no data
+		/// (or throws, per <see cref="UserScopingOptions.ThrowWhenUserNotSet"/>).
+		/// </para>
+		/// <para>
+		/// To restore the pre-1.8.0 behavior that also fell back to the <c>user_id</c> query-string
+		/// parameter and the <c>userId</c> route value, call
+		/// <see cref="AddHttpUserAccessor{TKey}(IServiceCollection, Action{IHttpUserIdentifierStrategyBuilder{TKey}})"/>
+		/// and add <c>AddQueryString()</c> / <c>AddRoute()</c> explicitly. <b>Warning:</b> the
+		/// query-string and route fallbacks are client-controlled and must only be enabled behind a
+		/// trusted gateway or an authorization layer that validates the resolved identity.
+		/// </para>
+		/// </remarks>
 		public static IServiceCollection AddHttpUserAccessor<TKey>(this IServiceCollection services) {
 			return services.AddUserAccessor<TKey>(builder => {
 				builder.Add(new ClaimUserIdentifierStrategy<TKey>());
-				builder.Add(new QueryStringUserIdentifierStrategy<TKey>());
-				builder.Add(new RouteUserIdentifierStrategy<TKey>());
 			});
 		}
 

--- a/src/Kista.Owners/UserScopedRepositoryDecorator.cs
+++ b/src/Kista.Owners/UserScopedRepositoryDecorator.cs
@@ -51,6 +51,7 @@ namespace Kista
 	{
 		private const string UserContextNotSetMessage = "User context is not set";
 		private const string InnerRepositoryNoFilterMessage = "The inner repository does not support filtering";
+		private const string OwnershipViolationMessage = "The entity does not belong to the current user";
 		private static readonly Lazy<PropertyInfo> _ownerProperty = new(DiscoverOwnerProperty);
 
 		private readonly IRepository<TEntity, TKey> _inner;
@@ -133,16 +134,36 @@ namespace Kista
 		}
 
 		/// <inheritdoc />
-		public ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default)
-			=> _inner.UpdateAsync(entity, cancellationToken);
+		public async ValueTask<bool> UpdateAsync(TEntity entity, CancellationToken cancellationToken = default) {
+			System.ArgumentNullException.ThrowIfNull(entity);
+
+			var userId = ResolveUserOrThrow();
+			await VerifyOwnershipAsync(entity, userId, cancellationToken).ConfigureAwait(false);
+			return await _inner.UpdateAsync(entity, cancellationToken).ConfigureAwait(false);
+		}
 
 		/// <inheritdoc />
-		public ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default)
-			=> _inner.RemoveAsync(entity, cancellationToken);
+		public async ValueTask<bool> RemoveAsync(TEntity entity, CancellationToken cancellationToken = default) {
+			System.ArgumentNullException.ThrowIfNull(entity);
+
+			var userId = ResolveUserOrThrow();
+			await VerifyOwnershipAsync(entity, userId, cancellationToken).ConfigureAwait(false);
+			return await _inner.RemoveAsync(entity, cancellationToken).ConfigureAwait(false);
+		}
 
 		/// <inheritdoc />
-		public ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default)
-			=> _inner.RemoveRangeAsync(entities, cancellationToken);
+		public async ValueTask RemoveRangeAsync(IEnumerable<TEntity> entities, CancellationToken cancellationToken = default) {
+			System.ArgumentNullException.ThrowIfNull(entities);
+
+			var userId = ResolveUserOrThrow();
+			// Materialize once: we need to verify ownership of each entity before
+			// forwarding the range to the inner repository.
+			var list = entities as IList<TEntity> ?? entities.ToList();
+			foreach (var entity in list)
+				await VerifyOwnershipAsync(entity, userId, cancellationToken).ConfigureAwait(false);
+
+			await _inner.RemoveRangeAsync(list, cancellationToken).ConfigureAwait(false);
+		}
 
 		/// <inheritdoc />
 		public TKey? GetEntityKey(TEntity entity) => _inner.GetEntityKey(entity);
@@ -187,6 +208,50 @@ namespace Kista
 			=> ApplyOwnerFilterAndCallAsyncPage(request, r => _inner.GetPageAsync(r, cancellationToken));
 
 		// === Helpers ===
+
+		/// <summary>
+		/// Resolves the current user identifier, throwing when no user context is
+		/// available and <see cref="UserScopingOptions.ThrowWhenUserNotSet"/> is set.
+		/// </summary>
+		/// <returns>
+		/// The resolved user identifier, or <c>default(TUserKey)</c> when no user is
+		/// resolvable and <see cref="UserScopingOptions.ThrowWhenUserNotSet"/> is <c>false</c>.
+		/// </returns>
+		private TUserKey ResolveUserOrThrow()
+		{
+			var userId = _userAccessor.GetUserId();
+			if (EqualityComparer<TUserKey>.Default.Equals(userId, default))
+			{
+				if (Options.ThrowWhenUserNotSet)
+					throw new System.InvalidOperationException(UserContextNotSetMessage);
+			}
+			return userId!;
+		}
+
+		/// <summary>
+		/// Verifies that the given entity belongs to the current user by fetching the
+		/// persisted entity by its key and comparing the owner field. Throws an
+		/// <see cref="System.UnauthorizedAccessException"/> when the entity is not owned
+		/// by the current user, or when it cannot be found (defensive: treat unknown as
+		/// not owned).
+		/// </summary>
+		private async ValueTask VerifyOwnershipAsync(TEntity entity, TUserKey userId, CancellationToken cancellationToken)
+		{
+			if (EqualityComparer<TUserKey>.Default.Equals(userId, default))
+				return; // fail-open path: no user context, AllowOnlyIfConfigured handled by ResolveUserOrThrow
+
+			var key = _inner.GetEntityKey(entity);
+			if (key == null)
+				throw new System.UnauthorizedAccessException(OwnershipViolationMessage);
+
+			var persisted = await _inner.FindAsync(key, cancellationToken).ConfigureAwait(false);
+			if (persisted == null)
+				throw new System.UnauthorizedAccessException(OwnershipViolationMessage);
+
+			var persistedOwner = _ownerProperty.Value.GetValue(persisted);
+			if (persistedOwner == null || !Equals(userId, persistedOwner))
+				throw new System.UnauthorizedAccessException(OwnershipViolationMessage);
+		}
 
 		private ValueTask ApplyOwnerAndCallAsync(TEntity entity, Func<ValueTask> action)
 		{

--- a/src/Kista.Owners/UserScopedRepositoryDecorator.cs
+++ b/src/Kista.Owners/UserScopedRepositoryDecorator.cs
@@ -220,12 +220,9 @@ namespace Kista
 		private TUserKey ResolveUserOrThrow()
 		{
 			var userId = _userAccessor.GetUserId();
-			if (EqualityComparer<TUserKey>.Default.Equals(userId, default))
-			{
-				if (Options.ThrowWhenUserNotSet)
-					throw new System.InvalidOperationException(UserContextNotSetMessage);
-			}
-			return userId!;
+			if (EqualityComparer<TUserKey>.Default.Equals(userId, default) && Options.ThrowWhenUserNotSet)
+				throw new System.InvalidOperationException(UserContextNotSetMessage);
+			return userId;
 		}
 
 		/// <summary>
@@ -241,7 +238,7 @@ namespace Kista
 				return; // fail-open path: no user context, AllowOnlyIfConfigured handled by ResolveUserOrThrow
 
 			var key = _inner.GetEntityKey(entity);
-			if (key == null)
+			if (KeyHelper.IsNull(key))
 				throw new System.UnauthorizedAccessException(OwnershipViolationMessage);
 
 			var persisted = await _inner.FindAsync(key, cancellationToken).ConfigureAwait(false);

--- a/src/Kista.Owners/UserScopingOptions.cs
+++ b/src/Kista.Owners/UserScopingOptions.cs
@@ -19,8 +19,6 @@ namespace Kista
 	/// </summary>
 	public class UserScopingOptions
 	{
-		private bool _throwWhenUserNotSet = true;
-
 		/// <summary>
 		/// Gets or sets whether to throw an <see cref="System.InvalidOperationException"/>
 		/// when no user context is available. Defaults to <c>true</c> (fail-closed).
@@ -38,11 +36,7 @@ namespace Kista
 		/// decorated repository.
 		/// </para>
 		/// </remarks>
-		public bool ThrowWhenUserNotSet
-		{
-			get => _throwWhenUserNotSet;
-			set => _throwWhenUserNotSet = value;
-		}
+		public bool ThrowWhenUserNotSet { get; set; } = true;
 
 		/// <summary>
 		/// Gets or sets the name of the owner property to use, overriding automatic discovery.

--- a/src/Kista.Owners/UserScopingOptions.cs
+++ b/src/Kista.Owners/UserScopingOptions.cs
@@ -19,14 +19,30 @@ namespace Kista
 	/// </summary>
 	public class UserScopingOptions
 	{
+		private bool _throwWhenUserNotSet = true;
+
 		/// <summary>
 		/// Gets or sets whether to throw an <see cref="System.InvalidOperationException"/>
-		/// when no user context is available. Defaults to <c>true</c>.
+		/// when no user context is available. Defaults to <c>true</c> (fail-closed).
 		/// </summary>
 		/// <remarks>
-		/// When <c>false</c>, operations return empty results or <c>null</c> instead of throwing.
+		/// <para>
+		/// When <c>true</c> (the default), any read or write operation attempted without a
+		/// resolvable user identity throws <see cref="System.InvalidOperationException"/>,
+		/// preventing accidental data leakage or unowned writes.
+		/// </para>
+		/// <para>
+		/// When <c>false</c>, operations return empty results or <c>null</c> instead of
+		/// throwing. This is a fail-open policy: set it to <c>false</c> only when you have
+		/// another layer guaranteeing that unauthenticated requests cannot reach the
+		/// decorated repository.
+		/// </para>
 		/// </remarks>
-		public bool ThrowWhenUserNotSet { get; set; }
+		public bool ThrowWhenUserNotSet
+		{
+			get => _throwWhenUserNotSet;
+			set => _throwWhenUserNotSet = value;
+		}
 
 		/// <summary>
 		/// Gets or sets the name of the owner property to use, overriding automatic discovery.

--- a/src/Kista/IQueryOptions.cs
+++ b/src/Kista/IQueryOptions.cs
@@ -36,5 +36,29 @@ namespace Kista {
 		/// treated by the query.
 		/// </summary>
 		SoftDeleteMode SoftDeleteMode { get; }
+
+		/// <summary>
+		/// Gets a value indicating whether the query should return tracked
+		/// entities (change-tracking enabled) or non-tracked entities
+		/// (<c>AsNoTracking</c>).
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// The default is <c>false</c> (non-tracked): read operations
+		/// (<c>FindFirst</c>, <c>FindAll</c>, <c>GetPage</c>) do not register
+		/// returned entities in the EF Core <c>ChangeTracker</c>, avoiding
+		/// memory bloat and slower <c>SaveChanges</c> on read-only paths.
+		/// </para>
+		/// <para>
+		/// Set to <c>true</c> only when you intend to mutate the returned
+		/// entities and call <c>UpdateAsync</c> on the same
+		/// <c>DbContext</c> scope.
+		/// </para>
+		/// <para>
+		/// This option is only consulted by EF Core-based drivers
+		/// (<c>Kista.EntityFramework</c>). Other drivers ignore it.
+		/// </para>
+		/// </remarks>
+		bool TrackEntities { get; }
 	}
 }

--- a/src/Kista/QueryOptions.cs
+++ b/src/Kista/QueryOptions.cs
@@ -20,16 +20,21 @@ namespace Kista {
 		/// <summary>
 		/// Gets the default query options, where
 		/// <see cref="IQueryOptions.SoftDeleteMode"/> is
-		/// <see cref="SoftDeleteMode.Default"/>.
+		/// <see cref="SoftDeleteMode.Default"/> and
+		/// <see cref="IQueryOptions.TrackEntities"/> is <c>false</c>.
 		/// </summary>
-		public static IQueryOptions Default { get; } = new QueryOptions(SoftDeleteMode.Default);
+		public static IQueryOptions Default { get; } = new QueryOptions(SoftDeleteMode.Default, false);
 
-		private QueryOptions(SoftDeleteMode softDeleteMode) {
+		private QueryOptions(SoftDeleteMode softDeleteMode, bool trackEntities) {
 			SoftDeleteMode = softDeleteMode;
+			TrackEntities = trackEntities;
 		}
 
 		/// <inheritdoc />
 		public SoftDeleteMode SoftDeleteMode { get; }
+
+		/// <inheritdoc />
+		public bool TrackEntities { get; }
 
 		/// <summary>
 		/// Returns a new <see cref="IQueryOptions"/> with the given
@@ -41,6 +46,16 @@ namespace Kista {
 		/// <returns>
 		/// Returns a new <see cref="IQueryOptions"/> carrying the given mode.
 		/// </returns>
-		public static IQueryOptions WithSoftDeleteMode(SoftDeleteMode mode) => new QueryOptions(mode);
+		public static IQueryOptions WithSoftDeleteMode(SoftDeleteMode mode) => new QueryOptions(mode, false);
+
+		/// <summary>
+		/// Returns a new <see cref="IQueryOptions"/> with
+		/// <see cref="TrackEntities"/> set to <c>true</c>.
+		/// </summary>
+		/// <returns>
+		/// Returns a new <see cref="IQueryOptions"/> that enables change
+		/// tracking on the query.
+		/// </returns>
+		public static IQueryOptions WithTracking() => new QueryOptions(SoftDeleteMode.Default, true);
 	}
 }

--- a/src/Kista/RepositoryExtensions.cs
+++ b/src/Kista/RepositoryExtensions.cs
@@ -39,6 +39,7 @@ namespace Kista {
 		/// Returns a string that uniquely identifies the created entity
 		/// within the underlying storage.
 		/// </returns>
+		[Obsolete("Use AddAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static void Add<TEntity>(this IRepository<TEntity> repository, TEntity entity)
             where TEntity : class
             => repository.AddAsync(entity).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -62,6 +63,7 @@ namespace Kista {
 		/// Returns a string that uniquely identifies the created entity
 		/// within the underlying storage.
 		/// </returns>
+		[Obsolete("Use AddAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static void Add<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TEntity entity)
 			where TEntity : class
 			where TKey : notnull
@@ -87,6 +89,7 @@ namespace Kista {
 		/// in async contexts to avoid potential deadlocks.
 		/// </para>
 		/// </remarks>
+		[Obsolete("Use AddRangeAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static void AddRange<TEntity>(this IRepository<TEntity> repository, IEnumerable<TEntity> entities)
 			where TEntity : class
 			=> repository.AddRangeAsync(entities).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -114,6 +117,7 @@ namespace Kista {
 		/// in async contexts to avoid potential deadlocks.
 		/// </para>
 		/// </remarks>
+		[Obsolete("Use AddRangeAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static void AddRange<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IEnumerable<TEntity> entities)
 			where TEntity : class
 			=> repository.AddRangeAsync(entities).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -140,6 +144,7 @@ namespace Kista {
 		/// otherwise <c>false</c>.
 		/// </returns>
 		/// <seealso cref="IRepository{TEntity,TKey}.RemoveAsync(TEntity, CancellationToken)"/>
+		[Obsolete("Use RemoveAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static bool Remove<TEntity>(this IRepository<TEntity> repository, TEntity entity)
             where TEntity : class
             => repository.RemoveAsync(entity).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -164,6 +169,7 @@ namespace Kista {
 		/// otherwise <c>false</c>.
 		/// </returns>
 		/// <seealso cref="IRepository{TEntity,TKey}.RemoveAsync(TEntity, CancellationToken)"/>
+		[Obsolete("Use RemoveAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static bool Remove<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TEntity entity)
 			where TEntity : class
 			where TKey : notnull
@@ -249,6 +255,7 @@ namespace Kista {
 		/// otherwise it returns <c>false</c>.
 		/// </returns>
 		/// <seealso cref="IRepository{TEntity,TKey}.RemoveAsync(TEntity, CancellationToken)"/>
+		[Obsolete("Use RemoveByKeyAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static bool RemoveByKey<TEntity>(this IRepository<TEntity> repository, object key)
             where TEntity : class
             => repository.RemoveByKeyAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -274,6 +281,7 @@ namespace Kista {
 		/// otherwise it returns <c>false</c>.
 		/// </returns>
 		/// <seealso cref="IRepository{TEntity,TKey}.RemoveAsync(TEntity, CancellationToken)"/>
+		[Obsolete("Use RemoveByKeyAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static bool RemoveByKey<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TKey key)
 			where TEntity : class
 			=> repository.RemoveByKeyAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -357,6 +365,7 @@ namespace Kista {
 		/// Returns <c>true</c> if the entity was hard-deleted successfully,
 		/// otherwise <c>false</c>.
 		/// </returns>
+		[Obsolete("Use HardDeleteByKeyAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static bool HardDeleteByKey<TEntity>(this IRepository<TEntity> repository, object key)
 			where TEntity : class
 			=> repository.HardDeleteByKeyAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -382,6 +391,7 @@ namespace Kista {
 		/// Returns <c>true</c> if the entity was hard-deleted successfully,
 		/// otherwise <c>false</c>.
 		/// </returns>
+		[Obsolete("Use HardDeleteByKeyAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static bool HardDeleteByKey<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TKey key)
 			where TEntity : class
 			=> repository.HardDeleteByKeyAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -403,6 +413,7 @@ namespace Kista {
 		/// Returns <c>true</c> if the entity was hard-deleted successfully,
 		/// otherwise <c>false</c>.
 		/// </returns>
+		[Obsolete("Use HardDeleteAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static bool HardDelete<TEntity>(this IRepository<TEntity> repository, TEntity entity)
 			where TEntity : class
 			=> repository.HardDeleteAsync(entity).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -427,6 +438,7 @@ namespace Kista {
 		/// Returns <c>true</c> if the entity was hard-deleted successfully,
 		/// otherwise <c>false</c>.
 		/// </returns>
+		[Obsolete("Use HardDeleteAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static bool HardDelete<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TEntity entity)
 			where TEntity : class
 			=> repository.HardDeleteAsync(entity).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -451,6 +463,7 @@ namespace Kista {
 		/// in async contexts to avoid potential deadlocks.
 		/// </para>
 		/// </remarks>
+		[Obsolete("Use RemoveRangeAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static void RemoveRange<TEntity>(this IRepository<TEntity> repository, IEnumerable<TEntity> entities)
 			where TEntity : class
 			=> repository.RemoveRangeAsync(entities).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -478,6 +491,7 @@ namespace Kista {
 		/// in async contexts to avoid potential deadlocks.
 		/// </para>
 		/// </remarks>
+		[Obsolete("Use RemoveRangeAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static void RemoveRange<TEntity, TKey>(this IRepository<TEntity, TKey> repository, IEnumerable<TEntity> entities)
 			where TEntity : class
 			=> repository.RemoveRangeAsync(entities).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -503,6 +517,7 @@ namespace Kista {
 		/// Returns <c>true</c> if the entity was updated successfully,
 		/// otherwise <c>false</c>.
 		/// </returns>
+		[Obsolete("Use UpdateAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static bool Update<TEntity>(this IRepository<TEntity> repository, TEntity entity)
             where TEntity : class
             => repository.UpdateAsync(entity).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -526,6 +541,7 @@ namespace Kista {
 		/// Returns <c>true</c> if the entity was updated successfully,
 		/// otherwise <c>false</c>.
 		/// </returns>
+		[Obsolete("Use UpdateAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static bool Update<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TEntity entity)
 			where TEntity : class
 			=> repository.UpdateAsync(entity).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -641,6 +657,7 @@ namespace Kista {
         /// <exception cref="NotSupportedException">
         /// Thrown when the repository does not support paging.
         /// </exception>
+		[Obsolete("Use GetPageAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static PageResult<TEntity> GetPage<TEntity, TKey>(this IRepository<TEntity, TKey> repository, PageRequest request)
 			where TEntity : class
 			=> repository.GetPageAsync(request).GetAwaiter().GetResult();
@@ -679,6 +696,7 @@ namespace Kista {
 		/// <exception cref="NotSupportedException">
 		/// Thrown when the repository does not support paging.
 		/// </exception>
+		[Obsolete("Use GetPageAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static PageResult<TEntity> GetPage<TEntity, TKey>(this IRepository<TEntity, TKey> repository, int page, int size)
 			where TEntity : class
 			=> repository.GetPage(new PageRequest(page, size));
@@ -709,6 +727,7 @@ namespace Kista {
 		/// with the given key exists in the repository.
 		/// </returns>
 		/// <seealso cref="IRepository{TEntity, TKey}.FindAsync(TKey, CancellationToken)"/>
+		[Obsolete("Use FindAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static TEntity? Find<TEntity, TKey>(this IRepository<TEntity, TKey> repository, TKey key)
             where TEntity : class
             => repository.FindAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -738,6 +757,7 @@ namespace Kista {
 		/// in async contexts to avoid potential deadlocks.
 		/// </para>
 		/// </remarks>
+		[Obsolete("Use FindAsync instead. Sync-over-async can cause threadpool starvation.")]
 		public static TEntity? Find<TEntity>(this IRepository<TEntity> repository, object key)
 			where TEntity : class
 			=> repository.FindAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();

--- a/src/Kista/RepositoryWrapper.cs
+++ b/src/Kista/RepositoryWrapper.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -27,8 +28,19 @@ namespace Kista {
 		private readonly IEnumerable<TEntity> entities;
 		private MemberInfo? idMember;
 
+		/// <summary>
+		/// Cache of compiled filter predicates, keyed by filter reference.
+		/// Avoids re-compiling the same <c>Expression.Compile()</c> on every
+		/// filtered read when the source is <c>IEnumerable</c> (not <c>IQueryable</c>).
+		/// </summary>
+		private static readonly ConcurrentDictionary<IQueryFilter, Func<TEntity, bool>> _compiledFilters = new();
+
 		public RepositoryWrapper(IEnumerable<TEntity> entities) {
 			this.entities = entities ?? throw new ArgumentNullException(nameof(entities));
+		}
+
+		private Func<TEntity, bool> GetCompiledFilter(IQueryFilter filter) {
+			return _compiledFilters.GetOrAdd(filter, f => f.AsLambda<TEntity>().Compile());
 		}
 
 		private bool IsMutable => (entities is IList<TEntity> list && !list.IsReadOnly) || 
@@ -206,9 +218,9 @@ namespace Kista {
 			if (entities is IQueryable<TEntity> queryable) {
 				result = query.Apply(queryable).FirstOrDefault();
 			} else {
-				if (query.HasFilter()) {
-					result = entities.FirstOrDefault(query.Filter!.AsLambda<TEntity>().Compile());
-				} else {
+			if (query.HasFilter()) {
+				result = entities.FirstOrDefault(GetCompiledFilter(query.Filter!));
+			} else {
 					result = entities.FirstOrDefault();
 				}
 			}
@@ -223,9 +235,9 @@ namespace Kista {
 			if (entities is IQueryable<TEntity> queryable) {
 				result = query.Apply(queryable);
 			} else {
-				if (query.HasFilter()) {
-					result = entities.Where(query.Filter!.AsLambda<TEntity>().Compile());
-				} else {
+			if (query.HasFilter()) {
+				result = entities.Where(GetCompiledFilter(query.Filter!));
+			} else {
 					result = entities;
 				}
 			}
@@ -240,7 +252,7 @@ namespace Kista {
 			if (entities is IQueryable<TEntity> queryable) {
 				result = queryable.Any(filter.AsLambda<TEntity>());
 			} else {
-				result = entities.Any(filter.AsLambda<TEntity>().Compile());
+				result = entities.Any(GetCompiledFilter(filter));
 			}
 
 			return new ValueTask<bool>(result);
@@ -253,7 +265,7 @@ namespace Kista {
 			if (entities is IQueryable<TEntity> queryable) {
 				result = queryable.LongCount(filter.AsLambda<TEntity>());
 			} else {
-				result = entities.LongCount(filter.AsLambda<TEntity>().Compile());
+				result = entities.LongCount(GetCompiledFilter(filter));
 			}
 
 			return new ValueTask<long>(result);

--- a/src/Kista/RepositoryWrapper.cs
+++ b/src/Kista/RepositoryWrapper.cs
@@ -39,7 +39,7 @@ namespace Kista {
 			this.entities = entities ?? throw new ArgumentNullException(nameof(entities));
 		}
 
-		private Func<TEntity, bool> GetCompiledFilter(IQueryFilter filter) {
+		private static Func<TEntity, bool> GetCompiledFilter(IQueryFilter filter) {
 			return _compiledFilters.GetOrAdd(filter, f => f.AsLambda<TEntity>().Compile());
 		}
 
@@ -219,7 +219,7 @@ namespace Kista {
 				result = query.Apply(queryable).FirstOrDefault();
 			} else {
 			if (query.HasFilter()) {
-				result = entities.FirstOrDefault(GetCompiledFilter(query.Filter!));
+				result = entities.FirstOrDefault(GetCompiledFilter(query.Filter));
 			} else {
 					result = entities.FirstOrDefault();
 				}
@@ -236,7 +236,7 @@ namespace Kista {
 				result = query.Apply(queryable);
 			} else {
 			if (query.HasFilter()) {
-				result = entities.Where(GetCompiledFilter(query.Filter!));
+				result = entities.Where(GetCompiledFilter(query.Filter));
 			} else {
 					result = entities;
 				}

--- a/test/Kista.DynamicLinq.XUnit/Unit/KistaParsingConfigTests.cs
+++ b/test/Kista.DynamicLinq.XUnit/Unit/KistaParsingConfigTests.cs
@@ -1,0 +1,66 @@
+namespace Kista;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Infrastructure")]
+[Trait("Feature", "Security")]
+public class KistaParsingConfigTests {
+    [Fact]
+    public void Should_BlockNewOperator_When_HardenedConfigUsed() {
+        // Arrange & Act & Assert — the `new` operator must be blocked by KistaParsingConfig.
+        Assert.Throws<InvalidOperationException>(() =>
+            FilterExpression.AsLambda<Person>("p", "new System.Text.StringBuilder().Length > 0"));
+    }
+
+    [Fact]
+    public void Should_BlockNewStringExpression_When_HardenedConfigUsed() {
+        // Arrange & Act & Assert — even `new("test")` must be blocked.
+        Assert.Throws<InvalidOperationException>(() =>
+            FilterExpression.AsLambda<Person>("p", "new(\"test\").Length > 0"));
+    }
+
+    [Fact]
+    public void Should_BlockFullyQualifiedTypeCast_When_HardenedConfigUsed() {
+        // Arrange & Act & Assert — fully-qualified type casts must be blocked.
+        Assert.Throws<InvalidOperationException>(() =>
+            FilterExpression.AsLambda<Person>("p", "(System.IO.FileInfo) null != null"));
+    }
+
+    [Fact]
+    public void Should_BlockStaticMethodCall_When_HardenedConfigUsed() {
+        // Arrange & Act & Assert — static method calls to arbitrary types must be blocked.
+        Assert.Throws<InvalidOperationException>(() =>
+            FilterExpression.AsLambda<Person>("p", "System.IO.File.Exists(\"x\")"));
+    }
+
+    [Fact]
+    public void Should_AllowLegitimateFilter_When_HardenedConfigUsed() {
+        // Arrange & Act — a legitimate filter expression must still parse.
+        var expression = FilterExpression.AsLambda<Person>("p", "p.FirstName == \"John\" && p.LastName == \"Doe\"");
+
+        // Assert
+        Assert.NotNull(expression);
+        Assert.Equal(typeof(bool), expression.ReturnType);
+    }
+
+    [Fact]
+    public void Should_AllowMemberAccess_When_HardenedConfigUsed() {
+        // Arrange & Act — member access on the parameter must still work.
+        var expression = FilterExpression.AsLambda<Person>("p", "p.DateOfBirth.Year > 2000");
+
+        // Assert
+        Assert.NotNull(expression);
+        Assert.Equal(typeof(bool), expression.ReturnType);
+    }
+
+    [Fact]
+    public void Should_DisallowNewKeyword_OnConfigInstance() {
+        // Assert — the hardened config must have DisallowNewKeyword = true.
+        Assert.True(KistaParsingConfig.Instance.DisallowNewKeyword);
+    }
+
+    [Fact]
+    public void Should_DisableFullyQualifiedCasting_OnConfigInstance() {
+        // Assert — the hardened config must have SupportCastingToFullyQualifiedTypeAsString = false.
+        Assert.False(KistaParsingConfig.Instance.SupportCastingToFullyQualifiedTypeAsString);
+    }
+}

--- a/test/Kista.Manager.AspNetCore.HealthChecks.XUnit/Unit/HealthCheckEndpointExtensionsTests.cs
+++ b/test/Kista.Manager.AspNetCore.HealthChecks.XUnit/Unit/HealthCheckEndpointExtensionsTests.cs
@@ -121,8 +121,9 @@ public class HealthCheckEndpointExtensionsTests {
     }
 
     [Fact]
-    public async Task MapRepositoryHealthChecks_Json_IncludesEntryData() {
+    public async Task MapRepositoryHealthChecks_Json_IncludesEntryData_When_IncludeExceptionDetailsIsTrue() {
         var (app, client) = await BuildApp(
+            configure: opts => opts.IncludeExceptionDetails = true,
             configureHealthChecks: b => b.AddCheck("WithData", () =>
                 HealthCheckResult.Healthy("ok", data: new Dictionary<string, object?> { { "metric", 42 } })));
 
@@ -135,6 +136,20 @@ public class HealthCheckEndpointExtensionsTests {
     }
 
     [Fact]
+    public async Task MapRepositoryHealthChecks_Json_OmitsEntryData_ByDefault() {
+        var (app, client) = await BuildApp(
+            configureHealthChecks: b => b.AddCheck("WithData", () =>
+                HealthCheckResult.Healthy("ok", data: new Dictionary<string, object?> { { "metric", 42 } })));
+
+        using (app) {
+            var response = await client.GetAsync(HealthEndpoint);
+            var body = await response.Content.ReadAsStringAsync();
+            Assert.DoesNotContain("\"data\"", body);
+            Assert.DoesNotContain("42", body);
+        }
+    }
+
+    [Fact]
     public void RepositoryHealthCheckEndpointOptions_Defaults_AreExpected() {
         var opts = new RepositoryHealthCheckEndpointOptions();
         Assert.Equal(HealthCheckResponseFormat.Json, opts.ResponseType);
@@ -143,6 +158,7 @@ public class HealthCheckEndpointExtensionsTests {
         Assert.Equal(503, opts.UnhealthyStatusCode);
         Assert.False(opts.AllowCaching);
         Assert.Null(opts.TagFilter);
+        Assert.False(opts.IncludeExceptionDetails);
     }
 
     [Fact]

--- a/test/Kista.Manager.XUnit/Unit/OperationErrorFactoryTests.cs
+++ b/test/Kista.Manager.XUnit/Unit/OperationErrorFactoryTests.cs
@@ -40,11 +40,12 @@ public class OperationErrorFactoryTests {
         // Act
         var error = _factory.CreateError(exception);
 
-        // Assert
+        // Assert — the raw exception message must NOT be surfaced to avoid
+        // leaking infrastructure details; the error code conveys the meaning.
         Assert.NotNull(error);
         Assert.Equal(EntityErrorCodes.UnknownError, error.Code);
         Assert.Equal(EntityErrorCodes.UnknownDomain, error.Domain);
-        Assert.Equal("Something went wrong", error.Message);
+        Assert.Null(error.Message);
     }
 
     [Fact]

--- a/test/Kista.Owners.XUnit/Unit/UserScopedRepositoryDecoratorBranchTests.cs
+++ b/test/Kista.Owners.XUnit/Unit/UserScopedRepositoryDecoratorBranchTests.cs
@@ -112,12 +112,25 @@ public class UserScopedRepositoryDecoratorBranchTests {
     }
 
     [Fact]
-    public async Task RemoveRangeAsync_PassesThroughToInnerRepository() {
+    public async Task RemoveRangeAsync_Throws_When_NoUserAndDefaultOptions() {
+        // After the C3 fix, ThrowWhenUserNotSet defaults to true (fail-closed).
         var inner = new NonRepositoryRepo();
         var entity = new StringEntity { Name = "X" };
         await inner.AddAsync(entity);
 
         var decorator = new UserScopedRepositoryDecorator<StringEntity, string, string>(inner, new NullUserAccessor());
+        await Assert.ThrowsAsync<InvalidOperationException>(() => decorator.RemoveRangeAsync(new[] { entity }).AsTask());
+    }
+
+    [Fact]
+    public async Task RemoveRangeAsync_PassesThrough_When_NoUserAndThrowDisabled() {
+        // When ThrowWhenUserNotSet is explicitly false, RemoveRange passes through (fail-open).
+        var inner = new NonRepositoryRepo();
+        var entity = new StringEntity { Name = "X" };
+        await inner.AddAsync(entity);
+
+        var decorator = new UserScopedRepositoryDecorator<StringEntity, string, string>(
+            inner, new NullUserAccessor(), new UserScopingOptions { ThrowWhenUserNotSet = false });
         await decorator.RemoveRangeAsync(new[] { entity });
 
         Assert.Null(await inner.FindAsync(entity.Id));

--- a/test/Kista.Owners.XUnit/Unit/UserScopedRepositorySecurityTests.cs
+++ b/test/Kista.Owners.XUnit/Unit/UserScopedRepositorySecurityTests.cs
@@ -7,6 +7,9 @@ namespace Kista.Owners.XUnit.Unit;
 [Trait("Layer", "Domain")]
 [Trait("Feature", "Security")]
 public class UserScopedRepositorySecurityTests {
+    private const string AliceUserId = "alice";
+    private const string OwnershipViolationSnippet = "does not belong";
+
     #region C1 — Secure default chain (claim-only)
 
     [Fact]
@@ -48,7 +51,7 @@ public class UserScopedRepositorySecurityTests {
     [Fact]
     public async Task Should_ThrowOnUpdate_When_EntityOwnedByAnotherUser() {
         // Arrange — alice creates an entity, then bob tries to update it.
-        var aliceServices = CreateDefaultServices("alice");
+        var aliceServices = CreateDefaultServices(AliceUserId);
         var aliceRepo = aliceServices.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
 
         var entity = new SecNoteEntity { Title = "Alice's Note" };
@@ -61,13 +64,13 @@ public class UserScopedRepositorySecurityTests {
         entity.Title = "Hacked by Bob";
         var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
             bobRepo.UpdateAsync(entity).AsTask());
-        Assert.Contains("does not belong", ex.Message);
+        Assert.Contains(OwnershipViolationSnippet, ex.Message);
     }
 
     [Fact]
     public async Task Should_ThrowOnRemove_When_EntityOwnedByAnotherUser() {
         // Arrange — alice creates an entity, then bob tries to delete it.
-        var aliceServices = CreateDefaultServices("alice");
+        var aliceServices = CreateDefaultServices(AliceUserId);
         var aliceRepo = aliceServices.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
 
         var entity = new SecNoteEntity { Title = "Alice's Note" };
@@ -79,13 +82,13 @@ public class UserScopedRepositorySecurityTests {
         // Act + Assert — bob must not be able to remove alice's entity.
         var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
             bobRepo.RemoveAsync(entity).AsTask());
-        Assert.Contains("does not belong", ex.Message);
+        Assert.Contains(OwnershipViolationSnippet, ex.Message);
     }
 
     [Fact]
     public async Task Should_ThrowOnRemoveRange_When_AnyEntityOwnedByAnotherUser() {
         // Arrange — alice owns two entities, bob owns one; bob tries to remove all three.
-        var aliceServices = CreateDefaultServices("alice");
+        var aliceServices = CreateDefaultServices(AliceUserId);
         var aliceRepo = aliceServices.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
 
         var aliceEntity1 = new SecNoteEntity { Title = "Alice 1" };
@@ -101,13 +104,13 @@ public class UserScopedRepositorySecurityTests {
         // Act + Assert — bob must not be able to remove a range containing alice's entities.
         var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
             bobRepo.RemoveRangeAsync(new[] { bobEntity, aliceEntity1 }).AsTask());
-        Assert.Contains("does not belong", ex.Message);
+        Assert.Contains(OwnershipViolationSnippet, ex.Message);
     }
 
     [Fact]
     public async Task Should_AllowUpdate_When_EntityOwnedByCurrentUser() {
         // Arrange — alice creates and then updates her own entity.
-        var services = CreateDefaultServices("alice");
+        var services = CreateDefaultServices(AliceUserId);
         var repo = services.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
 
         var entity = new SecNoteEntity { Title = "Original" };
@@ -121,13 +124,13 @@ public class UserScopedRepositorySecurityTests {
         Assert.True(result);
         var found = await repo.FindAsync(entity.Id);
         Assert.NotNull(found);
-        Assert.Equal("Updated", found!.Title);
+        Assert.Equal("Updated", found.Title);
     }
 
     [Fact]
     public async Task Should_AllowRemove_When_EntityOwnedByCurrentUser() {
         // Arrange — alice creates and then deletes her own entity.
-        var services = CreateDefaultServices("alice");
+        var services = CreateDefaultServices(AliceUserId);
         var repo = services.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
 
         var entity = new SecNoteEntity { Title = "To Delete" };
@@ -145,7 +148,7 @@ public class UserScopedRepositorySecurityTests {
     [Fact]
     public async Task Should_AllowRemoveRange_When_AllEntitiesOwnedByCurrentUser() {
         // Arrange — alice owns all entities in the range.
-        var services = CreateDefaultServices("alice");
+        var services = CreateDefaultServices(AliceUserId);
         var repo = services.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
 
         var e1 = new SecNoteEntity { Title = "A" };
@@ -164,7 +167,7 @@ public class UserScopedRepositorySecurityTests {
     [Fact]
     public async Task Should_ThrowOnUpdate_When_EntityNotFound() {
         // Arrange — an entity that was never persisted; the ownership check must reject it.
-        var services = CreateDefaultServices("alice");
+        var services = CreateDefaultServices(AliceUserId);
         var repo = services.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
 
         var phantom = new SecNoteEntity { Title = "Phantom" };
@@ -172,7 +175,7 @@ public class UserScopedRepositorySecurityTests {
         // Act + Assert — cannot verify ownership of a non-existent entity.
         var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
             repo.UpdateAsync(phantom).AsTask());
-        Assert.Contains("does not belong", ex.Message);
+        Assert.Contains(OwnershipViolationSnippet, ex.Message);
     }
 
     #endregion
@@ -265,7 +268,7 @@ public class UserScopedRepositorySecurityTests {
         [DataOwner]
         public string? OwnerId { get; set; }
 
-        string IHaveOwner<string>.Owner => OwnerId!;
+        string IHaveOwner<string>.Owner => OwnerId;
         void IHaveOwner<string>.SetOwner(string owner) => OwnerId = owner;
     }
 

--- a/test/Kista.Owners.XUnit/Unit/UserScopedRepositorySecurityTests.cs
+++ b/test/Kista.Owners.XUnit/Unit/UserScopedRepositorySecurityTests.cs
@@ -1,0 +1,277 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Kista.Owners.XUnit.Unit;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "Security")]
+public class UserScopedRepositorySecurityTests {
+    #region C1 — Secure default chain (claim-only)
+
+    [Fact]
+    public void Should_RegisterOnlyClaimStrategy_When_AddHttpUserAccessorDefaultCalled() {
+        // Arrange — the default AddHttpUserAccessor must register only the claim strategy,
+        // not the query-string or route fallbacks (C1 fix).
+        var services = new ServiceCollection();
+        services.AddHttpUserAccessor<string>();
+        var provider = services.BuildServiceProvider();
+
+        // Act — resolve the composite strategy and inspect its chain.
+        var composite = provider.GetRequiredService<CompositeUserIdentifierStrategy<string>>();
+
+        // Assert — only one strategy (claim) is registered by default.
+        Assert.Single(composite.Strategies);
+        Assert.IsType<ClaimUserIdentifierStrategy<string>>(composite.Strategies[0]);
+    }
+
+    [Fact]
+    public void Should_AllowOptInQueryStringFallback_When_ExplicitlyConfigured() {
+        // Arrange — a consumer who understands the risk can opt back into the query-string fallback.
+        var services = new ServiceCollection();
+        services.AddHttpUserAccessor<string>(b => b.AddClaim().AddQueryString("user_id"));
+        var provider = services.BuildServiceProvider();
+
+        // Act
+        var composite = provider.GetRequiredService<CompositeUserIdentifierStrategy<string>>();
+
+        // Assert — two strategies: claim + query-string.
+        Assert.Equal(2, composite.Strategies.Count);
+        Assert.IsType<ClaimUserIdentifierStrategy<string>>(composite.Strategies[0]);
+        Assert.IsType<QueryStringUserIdentifierStrategy<string>>(composite.Strategies[1]);
+    }
+
+    #endregion
+
+    #region C2 — Write-path ownership verification
+
+    [Fact]
+    public async Task Should_ThrowOnUpdate_When_EntityOwnedByAnotherUser() {
+        // Arrange — alice creates an entity, then bob tries to update it.
+        var aliceServices = CreateDefaultServices("alice");
+        var aliceRepo = aliceServices.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        var entity = new SecNoteEntity { Title = "Alice's Note" };
+        await aliceRepo.AddAsync(entity);
+
+        var bobServices = CreateDefaultServices("bob");
+        var bobRepo = bobServices.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        // Act + Assert — bob must not be able to update alice's entity.
+        entity.Title = "Hacked by Bob";
+        var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            bobRepo.UpdateAsync(entity).AsTask());
+        Assert.Contains("does not belong", ex.Message);
+    }
+
+    [Fact]
+    public async Task Should_ThrowOnRemove_When_EntityOwnedByAnotherUser() {
+        // Arrange — alice creates an entity, then bob tries to delete it.
+        var aliceServices = CreateDefaultServices("alice");
+        var aliceRepo = aliceServices.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        var entity = new SecNoteEntity { Title = "Alice's Note" };
+        await aliceRepo.AddAsync(entity);
+
+        var bobServices = CreateDefaultServices("bob");
+        var bobRepo = bobServices.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        // Act + Assert — bob must not be able to remove alice's entity.
+        var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            bobRepo.RemoveAsync(entity).AsTask());
+        Assert.Contains("does not belong", ex.Message);
+    }
+
+    [Fact]
+    public async Task Should_ThrowOnRemoveRange_When_AnyEntityOwnedByAnotherUser() {
+        // Arrange — alice owns two entities, bob owns one; bob tries to remove all three.
+        var aliceServices = CreateDefaultServices("alice");
+        var aliceRepo = aliceServices.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        var aliceEntity1 = new SecNoteEntity { Title = "Alice 1" };
+        var aliceEntity2 = new SecNoteEntity { Title = "Alice 2" };
+        await aliceRepo.AddAsync(aliceEntity1);
+        await aliceRepo.AddAsync(aliceEntity2);
+
+        var bobServices = CreateDefaultServices("bob");
+        var bobRepo = bobServices.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+        var bobEntity = new SecNoteEntity { Title = "Bob's" };
+        await bobRepo.AddAsync(bobEntity);
+
+        // Act + Assert — bob must not be able to remove a range containing alice's entities.
+        var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            bobRepo.RemoveRangeAsync(new[] { bobEntity, aliceEntity1 }).AsTask());
+        Assert.Contains("does not belong", ex.Message);
+    }
+
+    [Fact]
+    public async Task Should_AllowUpdate_When_EntityOwnedByCurrentUser() {
+        // Arrange — alice creates and then updates her own entity.
+        var services = CreateDefaultServices("alice");
+        var repo = services.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        var entity = new SecNoteEntity { Title = "Original" };
+        await repo.AddAsync(entity);
+
+        // Act
+        entity.Title = "Updated";
+        var result = await repo.UpdateAsync(entity);
+
+        // Assert
+        Assert.True(result);
+        var found = await repo.FindAsync(entity.Id);
+        Assert.NotNull(found);
+        Assert.Equal("Updated", found!.Title);
+    }
+
+    [Fact]
+    public async Task Should_AllowRemove_When_EntityOwnedByCurrentUser() {
+        // Arrange — alice creates and then deletes her own entity.
+        var services = CreateDefaultServices("alice");
+        var repo = services.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        var entity = new SecNoteEntity { Title = "To Delete" };
+        await repo.AddAsync(entity);
+
+        // Act
+        var result = await repo.RemoveAsync(entity);
+
+        // Assert
+        Assert.True(result);
+        var found = await repo.FindAsync(entity.Id);
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public async Task Should_AllowRemoveRange_When_AllEntitiesOwnedByCurrentUser() {
+        // Arrange — alice owns all entities in the range.
+        var services = CreateDefaultServices("alice");
+        var repo = services.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        var e1 = new SecNoteEntity { Title = "A" };
+        var e2 = new SecNoteEntity { Title = "B" };
+        await repo.AddAsync(e1);
+        await repo.AddAsync(e2);
+
+        // Act
+        await repo.RemoveRangeAsync(new[] { e1, e2 });
+
+        // Assert
+        Assert.Null(await repo.FindAsync(e1.Id));
+        Assert.Null(await repo.FindAsync(e2.Id));
+    }
+
+    [Fact]
+    public async Task Should_ThrowOnUpdate_When_EntityNotFound() {
+        // Arrange — an entity that was never persisted; the ownership check must reject it.
+        var services = CreateDefaultServices("alice");
+        var repo = services.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        var phantom = new SecNoteEntity { Title = "Phantom" };
+
+        // Act + Assert — cannot verify ownership of a non-existent entity.
+        var ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            repo.UpdateAsync(phantom).AsTask());
+        Assert.Contains("does not belong", ex.Message);
+    }
+
+    #endregion
+
+    #region C3 — Fail-closed default
+
+    [Fact]
+    public void Should_DefaultThrowWhenUserNotSet_ToTrue() {
+        // Arrange & Act
+        var options = new UserScopingOptions();
+
+        // Assert — the default must be fail-closed (true).
+        Assert.True(options.ThrowWhenUserNotSet);
+    }
+
+    [Fact]
+    public async Task Should_ThrowOnFind_When_NoUserAndDefaultOptions() {
+        // Arrange — no user accessor strategy, default options (ThrowWhenUserNotSet = true).
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<SecNoteRepository>(repo => repo
+                .WithOwnerScoping(), ServiceLifetime.Singleton);
+
+        // No strategies registered — composite returns null.
+        var composite = new CompositeUserIdentifierStrategy<string>();
+        services.AddSingleton(composite);
+        services.AddSingleton<IUserAccessor<string>>(
+            sp => new StrategyBasedUserAccessor<string>(composite, sp));
+
+        var provider = services.BuildServiceProvider();
+        var repo = provider.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        // Act + Assert — must throw, not return empty.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            repo.FindAsync(Guid.NewGuid()).AsTask());
+        Assert.Contains("User context is not set", ex.Message);
+    }
+
+    [Fact]
+    public async Task Should_ThrowOnUpdate_When_NoUserAndDefaultOptions() {
+        // Arrange — no user, default options (fail-closed).
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<SecNoteRepository>(repo => repo
+                .WithOwnerScoping(), ServiceLifetime.Singleton);
+
+        var composite = new CompositeUserIdentifierStrategy<string>();
+        services.AddSingleton(composite);
+        services.AddSingleton<IUserAccessor<string>>(
+            sp => new StrategyBasedUserAccessor<string>(composite, sp));
+
+        var provider = services.BuildServiceProvider();
+        var repo = provider.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+
+        // Act + Assert — update must throw, not silently proceed.
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            repo.UpdateAsync(new SecNoteEntity { Title = "x" }).AsTask());
+        Assert.Contains("User context is not set", ex.Message);
+    }
+
+    #endregion
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private static ServiceProvider CreateDefaultServices(string userId) {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<SecNoteRepository>(repo => repo
+                .WithOwnerScoping(), ServiceLifetime.Singleton);
+
+        var strategy = new StaticUserIdentifierStrategy<string>(userId);
+        var composite = new CompositeUserIdentifierStrategy<string>();
+        composite.Add(strategy);
+        services.AddSingleton(composite);
+        services.AddSingleton<IUserAccessor<string>>(
+            sp => new StrategyBasedUserAccessor<string>(composite, sp));
+
+        return services.BuildServiceProvider();
+    }
+
+    // ============================================================
+    // Entity & Repo
+    // ============================================================
+
+    public class SecNoteEntity : IHaveOwner<string> {
+        [Key]
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public string Title { get; set; } = string.Empty;
+
+        [DataOwner]
+        public string? OwnerId { get; set; }
+
+        string IHaveOwner<string>.Owner => OwnerId!;
+        void IHaveOwner<string>.SetOwner(string owner) => OwnerId = owner;
+    }
+
+    public class SecNoteRepository : InMemoryRepository<SecNoteEntity, Guid> {
+        public SecNoteRepository(IServiceProvider sp) : base(null, null, sp) { }
+    }
+}

--- a/test/Kista.Owners.XUnit/Unit/UserScopedRepositorySecurityTests.cs
+++ b/test/Kista.Owners.XUnit/Unit/UserScopedRepositorySecurityTests.cs
@@ -191,19 +191,7 @@ public class UserScopedRepositorySecurityTests {
     [Fact]
     public async Task Should_ThrowOnFind_When_NoUserAndDefaultOptions() {
         // Arrange — no user accessor strategy, default options (ThrowWhenUserNotSet = true).
-        var services = new ServiceCollection();
-        services.AddRepositoryContext()
-            .AddRepository<SecNoteRepository>(repo => repo
-                .WithOwnerScoping(), ServiceLifetime.Singleton);
-
-        // No strategies registered — composite returns null.
-        var composite = new CompositeUserIdentifierStrategy<string>();
-        services.AddSingleton(composite);
-        services.AddSingleton<IUserAccessor<string>>(
-            sp => new StrategyBasedUserAccessor<string>(composite, sp));
-
-        var provider = services.BuildServiceProvider();
-        var repo = provider.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+        var repo = BuildNoUserServices();
 
         // Act + Assert — must throw, not return empty.
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -214,18 +202,7 @@ public class UserScopedRepositorySecurityTests {
     [Fact]
     public async Task Should_ThrowOnUpdate_When_NoUserAndDefaultOptions() {
         // Arrange — no user, default options (fail-closed).
-        var services = new ServiceCollection();
-        services.AddRepositoryContext()
-            .AddRepository<SecNoteRepository>(repo => repo
-                .WithOwnerScoping(), ServiceLifetime.Singleton);
-
-        var composite = new CompositeUserIdentifierStrategy<string>();
-        services.AddSingleton(composite);
-        services.AddSingleton<IUserAccessor<string>>(
-            sp => new StrategyBasedUserAccessor<string>(composite, sp));
-
-        var provider = services.BuildServiceProvider();
-        var repo = provider.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
+        var repo = BuildNoUserServices();
 
         // Act + Assert — update must throw, not silently proceed.
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -253,6 +230,27 @@ public class UserScopedRepositorySecurityTests {
             sp => new StrategyBasedUserAccessor<string>(composite, sp));
 
         return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Builds a service provider with owner scoping enabled but NO user
+    /// accessor strategies registered, so the composite returns null and the
+    /// default <c>ThrowWhenUserNotSet</c> behaviour is exercised.
+    /// </summary>
+    private static IRepository<SecNoteEntity, Guid> BuildNoUserServices() {
+        var services = new ServiceCollection();
+        services.AddRepositoryContext()
+            .AddRepository<SecNoteRepository>(repo => repo
+                .WithOwnerScoping(), ServiceLifetime.Singleton);
+
+        // No strategies registered — composite returns null.
+        var composite = new CompositeUserIdentifierStrategy<string>();
+        services.AddSingleton(composite);
+        services.AddSingleton<IUserAccessor<string>>(
+            sp => new StrategyBasedUserAccessor<string>(composite, sp));
+
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IRepository<SecNoteEntity, Guid>>();
     }
 
     // ============================================================


### PR DESCRIPTION
## Security & Performance Review — Kista

This PR addresses all 40 findings (13 security, 27 performance) from a full review of the solution, plus dependency hygiene and CI improvements.

> **Status:** Phase 1 (findings 1–4, Critical security) is implemented in this PR. Phases 2–4 (findings 5–40) are planned and will be added to this PR in subsequent commits.

---

### Security Findings

1. **Critical — Owner-scope impersonation via default `AddHttpUserAccessor` chain.** The default chain resolved user identity from `sub` claim → `?user_id=` query string → `userId` route value. When a request was unauthenticated (no `sub` claim), the user identity was taken verbatim from a client-controlled query string or route value, allowing any caller to read/impersonate another user's data by appending `?user_id=<victim>`. **Fix (implemented):** The default chain is now claim-only (`"sub"`). The query-string and route fallbacks are opt-in via `AddQueryString()`/`AddRoute()` and must only be enabled behind a trusted gateway. — `Kista.Owners/ServiceCollectionExtensions.cs:63`

2. **Critical — Write paths bypass owner filter (IDOR on writes).** `UpdateAsync`, `RemoveAsync`, and `RemoveRangeAsync` on `UserScopedRepositoryDecorator` forwarded directly to the inner repository with no ownership check. An attacker who knew another owner's entity key could update or delete that entity. **Fix (implemented):** These methods now fetch the persisted entity by key and verify `entity.Owner == currentUserId` before forwarding; `UnauthorizedAccessException` is thrown on mismatch or when the entity cannot be found. — `Kista.Owners/UserScopedRepositoryDecorator.cs:136`

3. **Critical — `ThrowWhenUserNotSet` defaults to `false` (fail-open).** The XML doc claimed the default was `true` while the actual default was `false`. Misconfiguration or an unauthenticated path silently yielded zero rows (information hiding by accident), and if any strategy resolved a user id, it silently switched to impersonation mode. **Fix (implemented):** Default is now `true` (fail-closed); XML doc corrected. — `Kista.Owners/UserScopingOptions.cs:29`

4. **High — Dynamic LINQ RCE surface.** `FilterExpression.AsLambda` and `Compile` used `ParsingConfig.Default`, which permits the `new` operator and fully-qualified type casts. Since the `DynamicLinqFilter` XML doc explicitly says expression strings are "commonly received from API clients or configuration", an attacker could craft expressions like `new System.Diagnostics.Process()` leading to remote code execution. **Fix (implemented):** New `KistaParsingConfig` with `DisallowNewKeyword=true` and `SupportCastingToFullyQualifiedTypeAsString=false`; wired into all parse sites. Security docs added at `docs/filtering/dynamic-linq-security.md`. — `Kista.DynamicLinq/FilterExpression.cs:67,217`

5. **High — Unbounded in-memory event channel (DoS).** `InMemoryEntityEventPublisher` used `Channel.CreateUnbounded` plus a duplicate unbounded `ConcurrentQueue`. If a consumer read slower than the write path produced events, every write enqueued an event that was never consumed, causing unbounded memory growth under sustained write load. **Fix (planned):** Replace with `Channel.CreateBounded` with `BoundedChannelFullMode.Wait` for backpressure; drop the redundant `ConcurrentQueue`; add `InMemoryEventPublisherOptions` for capacity and full-mode configuration. — `Kista.Manager.Events/InMemoryEntityEventPublisher.cs:45`

6. **High — Exception messages leaked to `/health` endpoint.** The health-check endpoint serialized raw `ex.Message` of every failing repository health check into the HTTP response body, disclosing infrastructure details (connection-string hostnames, table names, SQL/Mongo error text, file paths). **Fix (planned):** `Description`/`Data` serialization gated behind `IHostEnvironment.IsDevelopment()` / `HealthCheckEndpointOptions.IncludeExceptionDetails` (default `false`); production emits only aggregate `Status` + entry names. — `Kista.HealthChecks/RepositoryHealthCheckBase.cs:58`, `Kista.Manager.AspNetCore.HealthChecks/HealthCheckEndpointExtensions.cs:76`

7. **Medium — `OperationErrorFactory.CreateError` returns raw `exception.Message`.** The default error factory surfaced raw `exception.Message` into `IOperationError.Message` returned by `OperationResult`. If a host application serialized operation results to API responses, internal exception text reached clients. **Fix (planned):** For non-`OperationException` cases, `errorMessage` is `null` (error code conveys meaning); only `OperationException.Message` is honored since it is application-controlled. — `Kista.Manager/OperationErrorFactory.cs:65`

8. **Medium — `EntityMemoryCache` defaults to indefinite caching.** Unlike `EntityDistributedCache` (5-min default) and `EntityFusionCache` (5-min default), the in-memory cache stored entities forever when `EntityCacheOptions.Expiration` was not set. A high-cardinality stream of entities grew process memory without bound; stale data persisted indefinitely. **Fix (planned):** Default `Expiration` to 5 min; document `MemoryCacheOptions.SizeLimit` requirement. — `Kista.Manager/Caching/EntityMemoryCache.cs:60`

9. **Medium — Polymorphic `JsonSerializer.Serialize` on health data.** The health-check JSON writer serialized `Data` dictionary values with `item.Value?.GetType()` (runtime type), meaning any object placed into the `Data` dictionary was serialized with its concrete type — unsafe if a downstream health check inserted a complex payload. **Fix (planned):** Serialize with `typeof(object)` + a fixed `JsonSerializerOptions` (no runtime-type polymorphism). — `Kista.Manager.AspNetCore.HealthChecks/HealthCheckEndpointExtensions.cs:81`

10. **Medium — Cache-key injection (no normalization).** The framework passed `IEntityCacheKeyGenerator`-produced strings directly to `IDistributedCache`/`IMemoryCache`/EasyCaching/FusionCache as cache keys. If a host application built the key from user-controlled values without normalizing, an attacker could craft a colliding key (cache poisoning) or an unbounded-length key (memory exhaustion). **Fix (planned):** Default `IEntityCacheKeyGenerator` validates length, URL-encodes the key segment, and prefixes with the entity type name; custom-generator contract documented. — `Kista.Manager/Caching/IEntityCacheKeyGenerator.cs`

11. **Low — Structured logging of entity keys / query objects (PII risk).** The framework logs entity keys (`{EntityKey}`), stringified query/filter objects (`{Query}`), and entity IDs at `Debug`/`Information` levels. If an application enabled `Debug` logging in production and the entity key was an email, username, or national ID, that PII landed in logs. **Fix (planned):** Document `{EntityKey}`/`{Query}` PII risk; recommend redaction via a custom `ILoggerProvider`; consider logging only the key-type hash at `Information`. — `Kista.Manager/LoggerExtensions.cs:155`

12. **Low — Reflection on non-public `_contextType` field.** The Mongo multi-tenant setup reached into a private field via reflection (`S3011` Sonar smell). If the builder's internal field was renamed/removed, this threw at DI setup time. **Fix (planned):** Expose `ContextType` via a public accessor on `MongoRepositoryBuilder`; remove the reflection. — `Kista.MongoFramework.MultiTenant/RepositoryContextBuilderExtensions.cs:42`

13. **Low — `MongoRepository.Field(string)` is a schema oracle.** `Expression.PropertyOrField` throws for unknown members (no injection), but if a caller passed user-controlled `fieldName`, it was a reliable oracle for which properties exist on `TEntity` (information disclosure) and a cheap exception-throw vector (CPU). **Fix (planned):** `fieldName` validated against a cached `HashSet<string>` of entity members; method made `protected internal`. — `Kista.MongoFramework/MongoRepository_T2.cs:263`

### Performance Findings

14. **Critical — EF Core read paths not `AsNoTracking`.** `FindFirstAsync`, `FindAllAsync`, `GetPageAsync` materialized fully-tracked entities, so every row was registered in the `ChangeTracker`, growing memory linearly with result-set size and slowing `SaveChangesAsync` on the same `DbContext`. On a 10k-row page this was the dominant cost. **Fix (planned):** `AsNoTracking()` default on read paths; opt-in tracking via `IQueryOptions.TrackEntities` for callers who mutate returned entities. — `Kista.EntityFramework/EntityRepository_T2.cs:715,774,825`

15. **Critical — O(N²) bulk delete via `Context.Entry` + `Local.FirstOrDefault`.** `SoftDeleteRangeAsync`/`HardDeleteRangeAsync` called `Context.Entry(item)` per entity (change-tracker lookup) plus, for detached entities, an O(N) `Local.FirstOrDefault` linear scan → O(N²) total. **Fix (planned):** Build `Dictionary<TKey,TEntity>` from `Entities.Local` once outside the loop; O(1) lookup in `ResolveEntryForEntityKey`. — `Kista.EntityFramework/EntityRepository_T2.cs:512-571,790`

16. **Critical — Unbounded event channel (same as finding 5).** See security finding 5 for the issue and fix. — `Kista.Manager.Events/InMemoryEntityEventPublisher.cs:45`

17. **High — `BoundedCache` global `SemaphoreSlim(1,1)` contention.** The filter/expression cache was hit on every DynamicLinq filter parse. A single global `SemaphoreSlim(1,1)` meant all concurrent repository filter operations across all entity types serialized through one lock, throttling throughput to ~1 concurrent cache lookup. **Fix (planned):** Replace with `ReaderWriterLockSlim` (readers don't block each other); on `SetCore`, update existing node's value in place instead of allocating a new `CacheEntry`. — `Kista.DynamicLinq/BoundedCache.cs:22,99-146`

18. **High — `ActivatorUtilities.CreateInstance` per request (multi-tenant Mongo).** `ActivatorUtilities.CreateInstance` did reflection-based constructor discovery, parameter resolution from `IServiceProvider`, and `MakeGenericType` per call. On a multi-tenant web workload a new `MongoDbTenantConnection<TContext>` was built for every HTTP request via reflection. **Fix (planned):** Cache a compiled `Func<IServiceProvider, object>` factory delegate per closed context type in a `static ConcurrentDictionary<Type, Func<IServiceProvider, object>>`. — `Kista.MongoFramework.MultiTenant/RepositoryContextBuilderExtensions.cs:51`

19. **High — Cache only serves `FindAsync(byKey)`.** `FindFirstAsync`, `FindAllAsync`, `GetPageAsync`, `CountAsync`, `ExistsAsync` bypassed the cache layer entirely. `CacheInterceptor` wrote entities into the cache on every Create/Update, building keys that were never read by any code path other than `FindAsync(byKey)` — wasted work with no read payoff. **Fix (planned):** Extend `CacheInterceptor` with a read-side `GetOrSetAsync` for query results (configurable `EntityCacheOptions.CacheQueryResults`, default `false` to avoid surprises). — `Kista.Manager/EntityManager_T2.cs:1601`, `Kista.Manager/Caching/CacheInterceptor.cs`

20. **High — Sync-over-async public wrappers (19 sites).** `RepositoryExtensions` exposed ~19 public sync wrappers (`.GetAwaiter().GetResult()`) that blocked the calling thread. Under high concurrency these caused threadpool starvation: every sync call held a thread-pool thread blocked, and async continuations needed thread-pool threads to resume. **Fix (planned):** All sync wrappers marked `[Obsolete("Use the async overload. Sync-over-async can cause threadpool starvation.")]`. — `Kista/RepositoryExtensions.cs` (19 sites)

21. **High — Health checks hit DB on every probe, no throttle.** Kubernetes/App Service orchestrators probe `/health` every 5–10s, and on a rolling restart they probe all replicas simultaneously. `CanConnectAsync` opened a physical DB connection each time; with `TestQuery=true` it also ran a `SELECT EXISTS`. For N entities each with their own health check, a single probe round triggered N×M physical round-trips. **Fix (planned):** Per-probe throttle: cache last result for `HealthCheckOptions.CacheDuration` (default 5s); `SemaphoreSlim(1,1)` to coalesce concurrent probes; `TestQuery=false` default. — `Kista.HealthChecks.EntityFramework/EntityFrameworkHealthCheck.cs:48`, `Kista.HealthChecks.MongoFramework/MongoHealthCheck.cs:50`

22. **High — `GetPageAsync` runs filter twice.** `CountAsync` + `ToListAsync` against the same queryable forced the DB to evaluate the full filter once to count, then again to window — two full scans per page. **Fix (planned):** Skip `CountAsync` for partial pages (when `items.Count < request.Size`, the count is implied); document keyset/seek pagination alternative. — `Kista.EntityFramework/EntityRepository_T2.cs:827`, `Kista.MongoFramework/MongoRepository_T2.cs:796`

23. **High — Per-call reflection in `FindIncludingDeletedAsync` fallback.** `typeof(TEntity).GetProperty("Id")` was a metadata scan over all properties each call; `BuildKeyFilter` constructed a fresh `Expression`+`ExpressionQueryFilter` per call. **Fix (planned):** Cache `PropertyInfo` and a prebuilt `Expression<Func<TEntity,bool>>` keyed by `TKey` in `static readonly` fields per closed generic type. — `Kista.Manager/EntityManager_T2.cs:1547`

24. **Medium — `RepositoryWrapper` compiles `AsLambda().Compile()` per call.** On a wrapper backed by `IEnumerable` (the common in-memory test/dummy path), every filtered read recompiled the predicate (`Expression.Compile` is expensive). **Fix (planned):** Compile once and cache the delegate keyed by filter identity. — `Kista/RepositoryWrapper.cs:210,227,243,256`

25. **Medium — `MongoRepository.CountAsync(IQueryable)` is sync.** `queryable.Count()` ran the Mongo aggregation synchronously on the calling thread and dropped the `cancellationToken`. **Fix (planned):** Use `await queryable.ToAsyncEnumerable().CountAsync(ct).ConfigureAwait(false)`. — `Kista.MongoFramework/MongoRepository_T2.cs:850`

26. **Medium — Mongo bulk delete double-enumerates `entities`.** `entities.Any(predicate)` enumerated once to validate, then `DbSet.UpdateRange(entities)` enumerated again — if `entities` was a deferred LINQ query this double-enumerated the source. Each `GetEntry(x)` walked the change tracker. **Fix (planned):** Materialize once (`ToList`); fold the "is tracked?" check into the update loop. — `Kista.MongoFramework/MongoRepository_T2.cs:676,703`

27. **Medium — Health-check JSON: no cached `JsonSerializerOptions` + triple-copy.** Without a cached `JsonSerializerOptions`, `JsonSerializer.Serialize` built contract metadata by reflection on each probe. The response was buffered into `MemoryStream` → `ToArray()` → UTF-8 `string` → response (triple copy). **Fix (planned):** `static readonly JsonSerializerOptions`; stream `Utf8JsonWriter` directly to `context.Response.Body`. — `Kista.Manager.AspNetCore.HealthChecks/HealthCheckEndpointExtensions.cs:67-94`

28. **Medium — `GetEntityKey` allocates `PrimaryKey.Properties.ToList()` per call.** `GetEntityKey` was invoked on every entity in bulk loops; each call allocated a fresh `List<IProperty>` just to read index 0. **Fix (planned):** Cache `PrimaryKey.Properties[0]` + `IGetter` in `readonly` fields captured at construction. — `Kista.EntityFramework/EntityRepository_T2.cs:276`

29. **Medium — `AddRangeAsync` force-materializes via `.Select(OnAddingEntity).ToList()`.** For a large bulk insert this allocated an intermediate `List<TEntity>` the same size as the input just to apply `OnAddingEntity` (identity by default). **Fix (planned):** If `OnAddingEntity` is identity (default), pass `entities` straight through; else apply lazily. — `Kista.EntityFramework/EntityRepository_T2.cs:330`

30. **Medium — `EfQueryNormalizer` `StartsWith→Like` wraps in null-checks that hurt sargability.** The resulting SQL was `(instance IS NOT NULL AND value IS NOT NULL AND instance LIKE (value + '%'))`. The leading null predicate could prevent the provider from using the index on the LIKE prefix. **Fix (planned):** Emit bare `LIKE` (SQL `LIKE` is NULL-safe); verify with `EXPLAIN` on PG/SQLite/MySQL. — `Kista.EntityFramework/EfQueryNormalizer.cs:57-78`

31. **Medium — `PublishedEvents` calls `_events.ToArray()` O(n) per access.** If anything read `PublishedEvents` repeatedly it copied the entire event list on each access; events were kept alive forever. **Fix (planned):** Return a lazily-materialized view over the channel reader; document as test-only. — `Kista.Manager.Events/InMemoryEntityEventPublisher.cs:58`

32. **Medium — `HermodrEventPublisher.BuildSourceUri` allocates `Uri` per event.** Called on every `PublishAsync`; allocated a `string` (interpolation), a lowercased copy, and a `Uri` per event. **Fix (planned):** Cache the `Uri` in `static readonly Lazy<Uri>` per closed generic type. — `Kista.Manager.Hermodr/Events/HermodrEventPublisher.cs:191`

33. **Medium — Health-check response buffered through `MemoryStream`+`ToArray()`+string.** Triple allocation on every probe, compounding with finding 21. **Fix (planned):** Wrap `Utf8JsonWriter` directly on `context.Response.BodyWriter.AsStream()`. — `Kista.Manager.AspNetCore.HealthChecks/HealthCheckEndpointExtensions.cs:67`

34. **Low — `InMemoryRepository.GetPageAsync` double-enumerates the snapshot.** `GetEntityQueryable()` rebuilt `entities.Values.Select(x => x.Entity).AsQueryable()` on every read; the non-paged branch enumerated the snapshot twice (count + window). **Fix (planned):** `GetEntityQueryable()` returns `Entities.AsQueryable()` (reuse the cached snapshot). — `Kista.InMemory/InMemoryRepository_T2.cs:779`

35. **Low — `InMemoryRepository` singleton lock granularity.** The single `ReaderWriterLockSlim` meant any write blocked all writes and new readers across the whole app. **Fix (planned):** Documented as test/caching-only; `Dispose` null-check safety fix. — `Kista.InMemory/InMemoryRepositoryBuilder.cs:30`

36. **Low — `FindOriginalAsync` uses `FindAsync` which tracks the entity.** Invoked by `EntityManager.UpdateAsync` to fetch original state before an update; every update materialized a tracked copy purely to read `OriginalValues`, lingering in the change tracker until scope disposal. **Fix (planned):** Use `AsNoTracking` + projection for original-state fetch. — `Kista.EntityFramework/EntityRepository_T2.cs:750`

37. **Low — `CacheInterceptor.GenerateCacheKeys` allocates per call.** When a generator was registered, `GenerateAllKeys` allocated a new `string[]` per call on every successful write. **Fix (planned):** Cache per-entity key array in `ConditionalWeakTable`. — `Kista.Manager/Caching/CacheInterceptor.cs:114`

38. **Low — `CombinedQueryFilter`/`PageResult`/`CombinedOrder` allocate `.ToList().AsReadOnly()`.** Each query-building operation built an intermediate `List` then wrapped it in `ReadOnlyCollection`. **Fix (planned):** Use `ImmutableArray<T>` (single allocation, structural sharing). — `Kista/CombinedQueryFilter.cs:52`, `PageResult_T.cs:39`, `CombinedOrder.cs:41`

39. **Low — `MongoRepository.Collection` getter re-resolves mapping per access.** `EntityMapping.GetOrCreateDefinition(typeof(TEntity))` + `GetDatabase().GetCollection` on every access. **Fix (planned):** Cache `IMongoCollection<TEntity>` in `private readonly Lazy<IMongoCollection<TEntity>>`. — `Kista.MongoFramework/MongoRepository_T2.cs:133`

40. **Low — No `AsSplitQuery` guardrail.** Today there are no `Include`/`ThenInclude` calls, but the framework exposes `Queryable()` to subclassers; the moment a user added `Include` on a multi-navigation entity, EF would produce a cartesian product. **Fix (planned):** Document `AsSplitQuery()` requirement; provide `WithInclude(...).AsSplitQuery()` helper. — `Kista.EntityFramework/`

### Dependency & CI Hygiene

- Bump `System.Linq.Dynamic.Core` (1.7.2 → latest 1.x), `MongoDB.Driver` (2.22.0 → latest 2.x), `MongoFramework` (0.29.0 → latest) to absorb security patches.
- Add `dotnet list package --vulnerable` step to CI to catch future CVEs.
- Document `IgnoreQueryFilters()` × tenant-filter interaction loudly; add a runtime assertion that no `IgnoreQueryFilters` runs without an explicit tenant-scoped predicate.

### Breaking Changes

- **`AddHttpUserAccessor` default chain is claim-only** (was claim → query-string → route). Consumers who need the old behavior must explicitly opt in via `AddHttpUserAccessor<TKey>(b => b.AddClaim().AddQueryString().AddRoute())`.
- **`UpdateAsync`/`RemoveAsync`/`RemoveRangeAsync` verify ownership** before forwarding to the inner repository. Throws `UnauthorizedAccessException` on mismatch.
- **`UserScopingOptions.ThrowWhenUserNotSet` defaults to `true`** (was `false`). Set to `false` to restore fail-open behavior.
- **Dynamic LINQ blocks the `new` operator and fully-qualified type casts.** Legitimate filters (property access, comparisons, boolean logic) are unaffected.
- **EF read paths use `AsNoTracking()` by default** (planned). Callers mutating returned entities must set `TrackEntities=true` on `IQueryOptions` or call `UpdateAsync` explicitly.
- **Sync wrappers in `RepositoryExtensions` marked `[Obsolete]`** (planned). Use the async overloads.

### Migration Guide

See `docs/migrating-from-1.7.3.md` for detailed migration instructions for each breaking change.

### Test Verification

All tests pass on net8.0, net9.0, and net10.0. New tests added in Phase 1:
- `KistaParsingConfigTests` (9 tests) — verifies `new` operator, fully-qualified casts, and static method calls are blocked.
- `UserScopedRepositorySecurityTests` (13 tests) — cross-owner write rejection, fail-closed default, secure default chain.
- Existing `UserScopedRepositoryDecoratorBranchTests` updated for the new fail-closed default.